### PR TITLE
Apply ime padding to the loading area to move it above the keyboard

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchRoot.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchRoot.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -286,7 +287,7 @@ fun SearchScreen(
             Box(Modifier.fillMaxSize()) {
                 if (state.isLoading && state.repositories.isEmpty()) {
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxSize().imePadding(),
                         contentAlignment = Alignment.Center
                     ) {
                         CircularProgressIndicator()


### PR DESCRIPTION
When i worked with app for first time and tried to serach some repositories, after typing in the search field, i thought nothing happend, but actually there was a loading, but under the keyboard.

So i think this is a issue and should be fixed, this PR refers to that.

<img width="1522" height="1612" alt="image" src="https://github.com/user-attachments/assets/349f474b-6445-4aad-b1be-d3f7c59adcc0" />
