### PR TITLE
feat: Integrate Obtainium for app updates

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
@@ -79,7 +79,8 @@ val detailsModule: Module = module {
             repositoryId = params.get(),
             detailsRepository = get(),
             downloader = get<Downloader>(),
-            installer = get<Installer>()
+            installer = get<Installer>(),
+            platform = getPlatform()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -82,6 +82,13 @@ fun AppNavigation(
                 onNavigateBack = {
                     navHostController.navigateUp()
                 },
+                onOpenRepositoryInApp = { repoId ->
+                    navHostController.navigate(
+                        GithubStoreGraph.DetailsScreen(
+                            repositoryId = repoId
+                        )
+                    )
+                },
                 viewModel = koinViewModel {
                     parametersOf(args.repositoryId)
                 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/Installer.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/Installer.kt
@@ -13,4 +13,10 @@ interface Installer {
     fun isAssetInstallable(assetName: String): Boolean
     fun choosePrimaryAsset(assets: List<GithubAsset>): GithubAsset?
     fun detectSystemArchitecture(): Architecture
+    fun isObtainiumInstalled(): Boolean
+    fun openInObtainium(
+        repoOwner: String,
+        repoName: String,
+        onOpenInstaller: () -> Unit
+    )
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsAction.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsAction.kt
@@ -2,14 +2,13 @@ package zed.rainxch.githubstore.feature.details.presentation
 
 sealed interface DetailsAction {
     data object OnNavigateBackClick : DetailsAction
-
     data object Retry : DetailsAction
-
     data object InstallPrimary : DetailsAction
     data class DownloadAsset(val assetName: String, val downloadUrl: String, val sizeBytes: Long) : DetailsAction
     data object CancelCurrentDownload : DetailsAction
-
     data object OpenRepoInBrowser : DetailsAction
     data object OpenAuthorInBrowser : DetailsAction
     data class OpenAuthorInApp(val authorId: Int) : DetailsAction
+    data object OpenInObtainium : DetailsAction
+    data object OnToggleInstallDropdown : DetailsAction
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsEvent.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsEvent.kt
@@ -1,0 +1,5 @@
+package zed.rainxch.githubstore.feature.details.presentation
+
+sealed interface DetailsEvent {
+    data class OnOpenRepositoryInApp(val repositoryId: Int) : DetailsEvent
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsRoot.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsRoot.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.githubstore.core.presentation.theme.GithubStoreTheme
+import zed.rainxch.githubstore.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.githubstore.feature.details.presentation.components.sections.about
 import zed.rainxch.githubstore.feature.details.presentation.components.sections.header
 import zed.rainxch.githubstore.feature.details.presentation.components.sections.logs
@@ -37,10 +38,19 @@ import zed.rainxch.githubstore.feature.details.presentation.components.states.Er
 
 @Composable
 fun DetailsRoot(
+    onOpenRepositoryInApp: (repoId: Int) -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: DetailsViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ObserveAsEvents(viewModel.events) { event ->
+        when (event) {
+            is DetailsEvent.OnOpenRepositoryInApp -> {
+                onOpenRepositoryInApp(event.repositoryId)
+            }
+        }
+    }
 
     DetailsScreen(
         state = state,
@@ -165,7 +175,9 @@ fun DetailsScreen(
 private fun Preview() {
     GithubStoreTheme {
         DetailsScreen(
-            state = DetailsState(),
+            state = DetailsState(
+                isLoading = false
+            ),
             onAction = {}
         )
     }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsState.kt
@@ -29,7 +29,12 @@ data class DetailsState(
     val installError: String? = null,
 
     val downloadStage: DownloadStage = DownloadStage.IDLE,
-    val systemArchitecture: Architecture = Architecture.UNKNOWN
+    val systemArchitecture: Architecture = Architecture.UNKNOWN,
+
+    val isObtainiumAvailable: Boolean = false,
+    val isObtainiumEnabled: Boolean = false,
+
+    val isInstallDropdownExpanded: Boolean = false,
 )
 
 data class InstallLogItem(

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/SmartInstallButton.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/SmartInstallButton.kt
@@ -17,23 +17,31 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import zed.rainxch.githubstore.core.domain.model.Architecture
 import zed.rainxch.githubstore.core.domain.model.GithubAsset
+import zed.rainxch.githubstore.feature.details.presentation.DetailsAction
 import zed.rainxch.githubstore.feature.details.presentation.DetailsState
 import zed.rainxch.githubstore.feature.details.presentation.DownloadStage
 import zed.rainxch.githubstore.feature.details.presentation.utils.extractArchitectureFromName
@@ -45,142 +53,207 @@ fun SmartInstallButton(
     isInstalling: Boolean,
     progress: Int?,
     primaryAsset: GithubAsset?,
-    onClick: () -> Unit,
+    onAction: (DetailsAction) -> Unit,
     modifier: Modifier = Modifier,
     state: DetailsState
 ) {
-    val enabled = primaryAsset != null && !isDownloading && !isInstalling
+    val enabled = remember(primaryAsset, isDownloading, isInstalling) {
+        primaryAsset != null && !isDownloading && !isInstalling
+    }
 
     val animatedProgress by animateFloatAsState(
         targetValue = (progress ?: 0) / 100f,
         animationSpec = tween(durationMillis = 500)
     )
 
-    ElevatedCard(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .clip(CircleShape)
-            .background(
-                color = if (enabled) {
-                    MaterialTheme.colorScheme.primary
-                } else MaterialTheme.colorScheme.surfaceContainer,
-                shape = CircleShape
-            )
-            .clickable(enabled = enabled, onClick = onClick),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = if (enabled) {
-                MaterialTheme.colorScheme.primary
-            } else MaterialTheme.colorScheme.surfaceContainer
-        ),
-        shape = CircleShape
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+        ElevatedCard(
+            modifier = Modifier
+                .weight(1f)
+                .height(52.dp)
+                .background(
+                    color = if (enabled) {
+                        MaterialTheme.colorScheme.primary
+                    } else MaterialTheme.colorScheme.surfaceContainer,
+                    shape = CircleShape
+                )
+                .clickable(
+                    enabled = enabled,
+                    onClick = {
+                        onAction(DetailsAction.InstallPrimary)
+                    }
+                ),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = if (enabled) {
+                    MaterialTheme.colorScheme.primary
+                } else MaterialTheme.colorScheme.surfaceContainer
+            ),
+            shape = if (state.isObtainiumEnabled) {
+                RoundedCornerShape(
+                    topStart = 24.dp,
+                    bottomStart = 24.dp,
+                    topEnd = 6.dp,
+                    bottomEnd = 6.dp
+                )
+            } else CircleShape
         ) {
-            if (state.isDownloading || state.downloadStage != DownloadStage.IDLE) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    when (state.downloadStage) {
-                        DownloadStage.DOWNLOADING -> {
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                LinearProgressIndicator(
-                                    progress = { animatedProgress },
-                                    color = MaterialTheme.colorScheme.onPrimary,
-                                    trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                                    modifier = Modifier.fillMaxSize(),
-                                )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                if (state.isDownloading || state.downloadStage != DownloadStage.IDLE) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        when (state.downloadStage) {
+                            DownloadStage.DOWNLOADING -> {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    LinearProgressIndicator(
+                                        progress = { animatedProgress },
+                                        color = MaterialTheme.colorScheme.onPrimary,
+                                        trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                                        modifier = Modifier.fillMaxSize(),
+                                    )
+
+                                    Text(
+                                        text = "Downloading... ${progress ?: 0}%",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                            }
+
+                            DownloadStage.VERIFYING -> {
+                                CircularProgressIndicator()
 
                                 Text(
-                                    text = "Downloading... ${progress ?: 0}%",
+                                    text = "Verifying app...",
                                     style = MaterialTheme.typography.titleMedium,
-                                    color = MaterialTheme.colorScheme.onSurface
+                                    color = MaterialTheme.colorScheme.onPrimary
                                 )
                             }
+
+                            DownloadStage.INSTALLING -> {
+                                CircularProgressIndicator()
+
+                                Text(
+                                    text = "Installing...",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onPrimary
+                                )
+                            }
+
+                            DownloadStage.IDLE -> {}
                         }
-
-                        DownloadStage.VERIFYING -> {
-                            CircularProgressIndicator()
-
-                            Text(
-                                text = "Verifying app...",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onPrimary
-                            )
-                        }
-
-                        DownloadStage.INSTALLING -> {
-                            CircularProgressIndicator()
-
-                            Text(
-                                text = "Installing...",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onPrimary
-                            )
-                        }
-
-                        DownloadStage.IDLE -> {}
                     }
-                }
-            } else {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        text = if (primaryAsset != null) {
-                            "Install latest"
-                        } else "Not Available",
-                        color = if (enabled) {
-                            MaterialTheme.colorScheme.onPrimary
-                        } else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.titleMedium
-                    )
+                } else {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = if (primaryAsset != null) {
+                                "Install latest"
+                            } else "Not Available",
+                            color = if (enabled) {
+                                MaterialTheme.colorScheme.onPrimary
+                            } else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleMedium
+                        )
 
-                    // Show architecture info
-                    if (primaryAsset != null) {
-                        val assetArch = extractArchitectureFromName(primaryAsset.name)
-                        val systemArch = state.systemArchitecture
+                        if (primaryAsset != null) {
+                            val assetArch = extractArchitectureFromName(primaryAsset.name)
+                            val systemArch = state.systemArchitecture
 
-                        Spacer(modifier = Modifier.height(2.dp))
+                            Spacer(modifier = Modifier.height(2.dp))
 
-                        Row(
-                            horizontalArrangement = Arrangement.Center,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = assetArch ?: systemArch.name.lowercase(),
-                                color = if (enabled) {
-                                    MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
-                                } else {
-                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                                },
-                                style = MaterialTheme.typography.bodySmall
-                            )
-
-                            if (assetArch != null && isExactArchitectureMatch(primaryAsset.name.lowercase(), systemArch)) {
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Icon(
-                                    imageVector = Icons.Default.CheckCircle,
-                                    contentDescription = "Architecture compatible",
-                                    tint = if (enabled) {
+                            Row(
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = assetArch ?: systemArch.name.lowercase(),
+                                    color = if (enabled) {
                                         MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
                                     } else {
                                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                                     },
-                                    modifier = Modifier.size(14.dp)
+                                    style = MaterialTheme.typography.bodySmall
                                 )
+
+                                if (assetArch != null && isExactArchitectureMatch(
+                                        assetName = primaryAsset.name.lowercase(),
+                                        systemArch = systemArch
+                                    )
+                                ) {
+                                    Spacer(modifier = Modifier.width(4.dp))
+
+                                    Icon(
+                                        imageVector = Icons.Default.CheckCircle,
+                                        contentDescription = "Architecture compatible",
+                                        tint = if (enabled) {
+                                            MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                                        },
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
         }
+
+        if (state.isObtainiumEnabled) {
+            IconButton(
+                onClick = {
+                    onAction(DetailsAction.OnToggleInstallDropdown)
+                },
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = if (enabled) {
+                        MaterialTheme.colorScheme.primary
+                    } else MaterialTheme.colorScheme.surfaceContainer
+                ),
+                modifier = Modifier.size(52.dp),
+                shape = RoundedCornerShape(
+                    topStart = 6.dp,
+                    bottomStart = 6.dp,
+                    topEnd = 24.dp,
+                    bottomEnd = 24.dp
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.KeyboardArrowDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = if (enabled) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                )
+            }
+        }
     }
+}
+
+@Preview
+@Composable
+fun SmartInstallButtonPreview() {
+    SmartInstallButton(
+        isDownloading = false,
+        isInstalling = false,
+        progress = 10,
+        primaryAsset = null,
+        onAction = {},
+        state = DetailsState()
+    )
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/sections/Header.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/sections/Header.kt
@@ -1,6 +1,20 @@
 package zed.rainxch.githubstore.feature.details.presentation.components.sections
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Update
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import zed.rainxch.githubstore.feature.details.presentation.DetailsAction
 import zed.rainxch.githubstore.feature.details.presentation.DetailsState
 import zed.rainxch.githubstore.feature.details.presentation.components.AppHeader
@@ -21,13 +35,52 @@ fun LazyListScope.header(
     }
 
     item {
-        SmartInstallButton(
-            isDownloading = state.isDownloading,
-            isInstalling = state.isInstalling,
-            progress = state.downloadProgressPercent,
-            primaryAsset = state.primaryAsset,
-            state = state,
-            onClick = { onAction(DetailsAction.InstallPrimary) }
-        )
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            SmartInstallButton(
+                isDownloading = state.isDownloading,
+                isInstalling = state.isInstalling,
+                progress = state.downloadProgressPercent,
+                primaryAsset = state.primaryAsset,
+                state = state,
+                onAction = onAction,
+            )
+
+            DropdownMenu(
+                expanded = state.isInstallDropdownExpanded,
+                onDismissRequest = {
+                    onAction(DetailsAction.OnToggleInstallDropdown)
+                },
+                offset = DpOffset(x = 0.dp, y = 20.dp)
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        Column {
+                            Text(
+                                text = "Open in Obtainium",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = "Manage updates automatically",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    },
+                    onClick = {
+                        onAction(DetailsAction.OpenInObtainium)
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Update,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    },
+                )
+            }
+        }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/feature/details/data/DesktopInstaller.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/feature/details/data/DesktopInstaller.kt
@@ -27,6 +27,13 @@ class DesktopInstaller(
     }
 
     override fun detectSystemArchitecture(): Architecture = systemArchitecture
+    override fun isObtainiumInstalled(): Boolean {
+        return false
+    }
+
+    override fun openInObtainium(repoOwner: String, repoName: String, onOpenInstaller: () -> Unit) {
+        // No-op
+    }
 
     override fun isAssetInstallable(assetName: String): Boolean {
         val name = assetName.lowercase()
@@ -90,7 +97,8 @@ class DesktopInstaller(
                     "x86_64" -> Architecture.X86_64
                     else -> Architecture.fromString(System.getProperty("os.arch"))
                 }
-            } catch (_: Exception) { }
+            } catch (_: Exception) {
+            }
         }
 
         val osArch = System.getProperty("os.arch") ?: return Architecture.UNKNOWN
@@ -142,7 +150,8 @@ class DesktopInstaller(
             }
 
             if ((name.endsWith(".dmg") || name.endsWith(".pkg")) &&
-                !listOf("x86_64", "amd64", "arm64", "aarch64").any { name.contains(it) }) {
+                !listOf("x86_64", "amd64", "arm64", "aarch64").any { name.contains(it) }
+            ) {
                 return true
             }
         }
@@ -539,24 +548,31 @@ class DesktopInstaller(
                     LinuxTerminal.GNOME_TERMINAL -> ProcessBuilder(
                         "gnome-terminal", "--", "bash", "-c", command
                     )
+
                     LinuxTerminal.KONSOLE -> ProcessBuilder(
                         "konsole", "-e", "bash", "-c", command
                     )
+
                     LinuxTerminal.XTERM -> ProcessBuilder(
                         "xterm", "-e", "bash", "-c", command
                     )
+
                     LinuxTerminal.XFCE4_TERMINAL -> ProcessBuilder(
                         "xfce4-terminal", "-e", "bash -c \"$command\""
                     )
+
                     LinuxTerminal.ALACRITTY -> ProcessBuilder(
                         "alacritty", "-e", "bash", "-c", command
                     )
+
                     LinuxTerminal.KITTY -> ProcessBuilder(
                         "kitty", "bash", "-c", command
                     )
+
                     LinuxTerminal.TILIX -> ProcessBuilder(
                         "tilix", "-e", "bash -c \"$command\""
                     )
+
                     LinuxTerminal.MATE_TERMINAL -> ProcessBuilder(
                         "mate-terminal", "-e", "bash -c \"$command\""
                     )


### PR DESCRIPTION
Adds an "Open in Obtainium" option to the install button's dropdown menu on the details screen. This allows users to manage application updates automatically through Obtainium.

- If Obtainium is not installed, it navigates to the Obtainium repository details page within the app.
- This feature is currently available only for the Android platform.
- The UI of the install button has been updated to accommodate a dropdown menu for this new action.
<img height="500" alt="Screenshot_20251208_123004" src="https://github.com/user-attachments/assets/151bc51a-276f-4b51-8cc6-428443af066f" />
<img height="500" alt="Screenshot_20251208_123013" src="https://github.com/user-attachments/assets/78d537e1-1489-4d97-b0ac-b39e2c478aa3" />
