### PR TITLE
feat: Bump JVM target to 21

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -41,7 +41,7 @@ val generateJvmBuildConfig = tasks.register("generateJvmBuildConfig") {
 kotlin {
     androidTarget {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_20)
+            jvmTarget.set(JvmTarget.JVM_21)
         }
     }
 
@@ -161,8 +161,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_20
-        targetCompatibility = JavaVersion.VERSION_20
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         buildConfig = true


### PR DESCRIPTION
Updated the `jvmTarget` for the Android target from 20 to 21. Aligned the `sourceCompatibility` and `targetCompatibility` in `compileOptions` to Java 21.