### PR TITLE
feat: Centralize and expose app version through BuildConfig

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -11,30 +11,38 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
+val appVersionName = "1.2.1"
+val appVersionCode = 4
+
 // Load local.properties for secrets like GITHUB_CLIENT_ID
 val localProps = Properties().apply {
     val file = rootProject.file("local.properties")
     if (file.exists()) file.inputStream().use { this.load(it) }
 }
-val localGithubClientId = (localProps.getProperty("GITHUB_CLIENT_ID") ?: "Ov23linTY28VFpFjFiI9").trim()
+val localGithubClientId =
+    (localProps.getProperty("GITHUB_CLIENT_ID") ?: "Ov23linTY28VFpFjFiI9").trim()
 
 // Generate BuildConfig for JVM (Configuration Cache Compatible)
 val generateJvmBuildConfig = tasks.register("generateJvmBuildConfig") {
     val outputDir = layout.buildDirectory.dir("generated/buildconfig/jvm")
     val clientId = localGithubClientId
+    val versionName = appVersionName
 
     outputs.dir(outputDir)
 
     doLast {
         val file = outputDir.get().asFile.resolve("zed/rainxch/githubstore/BuildConfig.kt")
         file.parentFile.mkdirs()
-        file.writeText("""
+        file.writeText(
+            """
             package zed.rainxch.githubstore
             
             object BuildConfig {
                 const val GITHUB_CLIENT_ID = "$clientId"
+                const val VERSION_NAME = "$versionName"
             }
-        """.trimIndent())
+        """.trimIndent()
+        )
     }
 }
 
@@ -144,10 +152,11 @@ android {
         applicationId = "zed.rainxch.githubstore"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 4
-        versionName = "1.2.1"
+        versionCode = appVersionCode
+        versionName = appVersionName
         // Expose GitHub client id to Android BuildConfig (do NOT commit secrets; read from local.properties)
         buildConfigField("String", "GITHUB_CLIENT_ID", "\"${localGithubClientId}\"")
+        buildConfigField("String", "VERSION_NAME", "\"${appVersionName}\"")
     }
     packaging {
         resources {
@@ -182,7 +191,7 @@ compose.desktop {
         mainClass = "zed.rainxch.githubstore.MainKt"
         nativeDistributions {
             packageName = "github-store"
-            packageVersion = "1.2.1"
+            packageVersion = appVersionName
             vendor = "rainxchzed"
             includeAllModules = true
             targetFormats(
@@ -205,8 +214,8 @@ compose.desktop {
             }
             linux {
                 iconFile.set(project.file("logo/app_icon.png"))
-                appRelease = "4"
-                debPackageVersion = "1.2.1"
+                appRelease = appVersionCode.toString()
+                debPackageVersion = appVersionName
                 menuGroup = "Development"
                 appCategory = "Development"
             }

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.android.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.android.kt
@@ -1,0 +1,7 @@
+package zed.rainxch.githubstore.feature.settings.presentation.utils
+
+import zed.rainxch.githubstore.BuildConfig
+
+actual fun getVersionName(): String {
+    return BuildConfig.VERSION_NAME
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/About.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/About.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import zed.rainxch.githubstore.feature.settings.presentation.SettingsAction
+import zed.rainxch.githubstore.feature.settings.presentation.utils.getVersionName
 
 fun LazyListScope.about(
     onAction: (SettingsAction) -> Unit,
@@ -55,7 +56,7 @@ fun LazyListScope.about(
                 title = "Version",
                 actions = {
                     Text(
-                        text = "v1.0.1",
+                        text = getVersionName(),
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.outline,
                     )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.kt
@@ -1,0 +1,3 @@
+package zed.rainxch.githubstore.feature.settings.presentation.utils
+
+expect fun getVersionName(): String

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/utils/getVersionName.jvm.kt
@@ -1,0 +1,13 @@
+package zed.rainxch.githubstore.feature.settings.presentation.utils
+
+import zed.rainxch.githubstore.BuildConfig
+
+actual fun getVersionName(): String {
+    val fromSys = System.getProperty("VERSION_NAME")?.trim().orEmpty()
+    if (fromSys.isNotEmpty()) return fromSys
+
+    val fromEnv = System.getenv("VERSION_NAME")?.trim().orEmpty()
+    if (fromEnv.isNotEmpty()) return fromEnv
+
+    return BuildConfig.VERSION_NAME
+}


### PR DESCRIPTION
Centralized the app version name and code in `build.gradle.kts` to ensure consistency across all builds (Android, Desktop, Linux).

This change introduces a `getVersionName()` `expect`/`actual` function to retrieve the version name from a common `BuildConfig` file on Android and JVM, allowing the UI to display the version dynamically.

The following has been updated to use the new centralized version variables:
- Android `versionCode` and `versionName`.
- Desktop `packageVersion`.
- Linux `appRelease` and `debPackageVersion`.