### PR TITLE
refactor: Move logout logic to Settings feature

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import zed.rainxch.githubstore.app.AppStateManager
+import zed.rainxch.githubstore.app.app_state.AppStateManager
 import zed.rainxch.githubstore.core.data.data_source.TokenDataSource
 import zed.rainxch.githubstore.core.domain.repository.ThemesRepository
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/AppState.kt
@@ -1,4 +1,4 @@
-package zed.rainxch.githubstore.app
+package zed.rainxch.githubstore.app.app_state
 
 import zed.rainxch.githubstore.network.RateLimitInfo
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/AppStateManager.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/AppStateManager.kt
@@ -1,4 +1,4 @@
-package zed.rainxch.githubstore.app
+package zed.rainxch.githubstore.app.app_state
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/components/RateLimitDialog.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/app_state/components/RateLimitDialog.kt
@@ -1,4 +1,4 @@
-package zed.rainxch.githubstore.app
+package zed.rainxch.githubstore.app.app_state.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
@@ -7,7 +7,7 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import zed.rainxch.githubstore.MainViewModel
-import zed.rainxch.githubstore.app.AppStateManager
+import zed.rainxch.githubstore.app.app_state.AppStateManager
 import zed.rainxch.githubstore.core.data.data_source.DefaultTokenDataSource
 import zed.rainxch.githubstore.core.data.data_source.TokenDataSource
 import zed.rainxch.githubstore.core.data.repository.ThemesRepositoryImpl
@@ -29,6 +29,8 @@ import zed.rainxch.githubstore.feature.home.presentation.HomeViewModel
 import zed.rainxch.githubstore.feature.search.data.repository.SearchRepositoryImpl
 import zed.rainxch.githubstore.feature.search.domain.repository.SearchRepository
 import zed.rainxch.githubstore.feature.search.presentation.SearchViewModel
+import zed.rainxch.githubstore.feature.settings.data.repository.SettingsRepositoryImpl
+import zed.rainxch.githubstore.feature.settings.domain.repository.SettingsRepository
 import zed.rainxch.githubstore.feature.settings.presentation.SettingsViewModel
 import zed.rainxch.githubstore.network.RateLimitHandler
 
@@ -76,7 +78,6 @@ val authModule: Module = module {
     factory { StartDeviceFlowUseCase(get()) }
     factory { AwaitDeviceTokenUseCase(get()) }
     factory { ObserveAccessTokenUseCase(get()) }
-    factory { LogoutUseCase(get()) }
     factory { IsAuthenticatedUseCase(get()) }
 
     single<CoroutineScope> {
@@ -87,7 +88,6 @@ val authModule: Module = module {
         AuthenticationViewModel(
             startDeviceFlow = get(),
             awaitDeviceToken = get(),
-            logoutUc = get(),
             observeAccessToken = get(),
             browserHelper = get(),
             clipboardHelper = get(),
@@ -148,10 +148,17 @@ val detailsModule: Module = module {
 }
 
 val settingsModule: Module = module {
+    single<SettingsRepository> {
+        SettingsRepositoryImpl(
+            tokenDataSource = get()
+        )
+    }
+
     viewModel {
         SettingsViewModel(
             browserHelper = get(),
-            themesRepository = get()
+            themesRepository = get(),
+            settingsRepository = get()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -3,13 +3,10 @@ package zed.rainxch.githubstore.app.navigation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -18,10 +15,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import zed.rainxch.githubstore.MainAction
 import zed.rainxch.githubstore.MainState
-import zed.rainxch.githubstore.MainViewModel
-import zed.rainxch.githubstore.app.AppState
-import zed.rainxch.githubstore.app.RateLimitDialog
-import zed.rainxch.githubstore.core.presentation.theme.GithubStoreTheme
+import zed.rainxch.githubstore.app.app_state.components.RateLimitDialog
 import zed.rainxch.githubstore.feature.auth.presentation.AuthenticationRoot
 import zed.rainxch.githubstore.feature.details.presentation.DetailsRoot
 import zed.rainxch.githubstore.feature.home.presentation.HomeRoot

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/data/repository/AuthRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/data/repository/AuthRepositoryImpl.kt
@@ -179,10 +179,6 @@ class AuthRepositoryImpl(
         return block()
     }
 
-    override suspend fun logout() {
-        tokenDataSource.clear()
-    }
-
     companion object {
         const val DEFAULT_SCOPE = "repo"
     }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/domain/UseCases.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/domain/UseCases.kt
@@ -10,15 +10,12 @@ class StartDeviceFlowUseCase(private val repo: AuthRepository) {
 }
 
 class AwaitDeviceTokenUseCase(private val repo: AuthRepository) {
-    suspend operator fun invoke(start: DeviceStart): DeviceTokenSuccess = repo.awaitDeviceToken(start)
+    suspend operator fun invoke(start: DeviceStart): DeviceTokenSuccess =
+        repo.awaitDeviceToken(start)
 }
 
 class ObserveAccessTokenUseCase(private val repo: AuthRepository) {
     operator fun invoke(): Flow<String?> = repo.accessTokenFlow
-}
-
-class LogoutUseCase(private val repo: AuthRepository) {
-    suspend operator fun invoke() = repo.logout()
 }
 
 class IsAuthenticatedUseCase(private val repo: AuthRepository) {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/domain/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/domain/repository/AuthRepository.kt
@@ -12,6 +12,5 @@ interface AuthRepository {
 
     suspend fun awaitDeviceToken(start: DeviceStart): DeviceTokenSuccess
 
-    suspend fun logout()
     suspend fun isAuthenticated(): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/presentation/AuthenticationAction.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/presentation/AuthenticationAction.kt
@@ -6,7 +6,6 @@ sealed interface AuthenticationAction {
     data object StartLogin : AuthenticationAction
     data class CopyCode(val start: DeviceStart) : AuthenticationAction
     data class OpenGitHub(val start: DeviceStart) : AuthenticationAction
-    data object Logout : AuthenticationAction
     data object MarkLoggedOut : AuthenticationAction
     data object MarkLoggedIn : AuthenticationAction
     data class OnInfo(val message: String) : AuthenticationAction

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/presentation/AuthenticationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/auth/presentation/AuthenticationViewModel.kt
@@ -18,20 +18,18 @@ import zed.rainxch.githubstore.core.domain.model.DeviceStart
 import zed.rainxch.githubstore.core.presentation.utils.BrowserHelper
 import zed.rainxch.githubstore.core.presentation.utils.ClipboardHelper
 import zed.rainxch.githubstore.feature.auth.domain.AwaitDeviceTokenUseCase
-import zed.rainxch.githubstore.feature.auth.domain.LogoutUseCase
 import zed.rainxch.githubstore.feature.auth.domain.ObserveAccessTokenUseCase
 import zed.rainxch.githubstore.feature.auth.domain.StartDeviceFlowUseCase
 
 class AuthenticationViewModel(
     private val startDeviceFlow: StartDeviceFlowUseCase,
     private val awaitDeviceToken: AwaitDeviceTokenUseCase,
-    private val logoutUc: LogoutUseCase,
     observeAccessToken: ObserveAccessTokenUseCase,
     private val browserHelper: BrowserHelper,
     private val clipboardHelper: ClipboardHelper,
     private val scope: CoroutineScope,
 
-) : ViewModel() {
+    ) : ViewModel() {
 
     private var hasLoadedInitialData = false
 
@@ -73,7 +71,6 @@ class AuthenticationViewModel(
             is AuthenticationAction.StartLogin -> startLogin()
             is AuthenticationAction.CopyCode -> copyCode(action.start)
             is AuthenticationAction.OpenGitHub -> openGitHub(action.start)
-            is AuthenticationAction.Logout -> logout()
             AuthenticationAction.MarkLoggedIn -> _state.update { it.copy(loginState = AuthLoginState.LoggedIn) }
             AuthenticationAction.MarkLoggedOut -> _state.update { it.copy(loginState = AuthLoginState.LoggedOut) }
             is AuthenticationAction.OnInfo -> {
@@ -139,13 +136,6 @@ class AuthenticationViewModel(
             label = "GitHub Code",
             text = start.userCode
         )
-    }
-
-    private fun logout() {
-        scope.launch {
-            logoutUc()
-            _state.update { it.copy(loginState = AuthLoginState.LoggedOut) }
-        }
     }
 
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/repository/DetailsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/repository/DetailsRepositoryImpl.kt
@@ -1,12 +1,11 @@
 package zed.rainxch.githubstore.feature.details.data.repository
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpHeaders
-import zed.rainxch.githubstore.app.AppStateManager
+import zed.rainxch.githubstore.app.app_state.AppStateManager
 import zed.rainxch.githubstore.core.domain.model.GithubRelease
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
 import zed.rainxch.githubstore.core.domain.model.GithubUser

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/data/repository/HomeRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/data/repository/HomeRepositoryImpl.kt
@@ -2,7 +2,6 @@ package zed.rainxch.githubstore.feature.home.data.repository
 
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -22,7 +21,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import zed.rainxch.githubstore.app.AppStateManager
+import zed.rainxch.githubstore.app.app_state.AppStateManager
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
 import zed.rainxch.githubstore.core.data.mappers.toSummary
 import zed.rainxch.githubstore.core.data.model.GithubRepoNetworkModel

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/data/repository/SearchRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/data/repository/SearchRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package zed.rainxch.githubstore.feature.search.data.repository
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -21,7 +20,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
-import zed.rainxch.githubstore.app.AppStateManager
+import zed.rainxch.githubstore.app.app_state.AppStateManager
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
 import zed.rainxch.githubstore.core.data.mappers.toSummary
 import zed.rainxch.githubstore.core.data.model.GithubRepoNetworkModel

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/data/repository/SettingsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package zed.rainxch.githubstore.feature.settings.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import zed.rainxch.githubstore.core.data.data_source.TokenDataSource
+import zed.rainxch.githubstore.feature.settings.domain.repository.SettingsRepository
+
+class SettingsRepositoryImpl(
+    private val tokenDataSource: TokenDataSource,
+) : SettingsRepository {
+    override val isUserLoggedIn: Flow<Boolean>
+        get() = tokenDataSource
+            .tokenFlow
+            .map {
+                it != null
+            }
+            .flowOn(Dispatchers.IO)
+
+    override suspend fun logout() {
+        tokenDataSource.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/domain/repository/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/domain/repository/SettingsRepository.kt
@@ -1,0 +1,8 @@
+package zed.rainxch.githubstore.feature.settings.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    val isUserLoggedIn: Flow<Boolean>
+    suspend fun logout()
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsAction.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsAction.kt
@@ -6,4 +6,7 @@ sealed interface SettingsAction {
     data object OnNavigateBackClick : SettingsAction
     data class OnThemeColorSelected(val themeColor: AppTheme) : SettingsAction
     data object OnHelpClick : SettingsAction
+    data object OnLogoutClick : SettingsAction
+    data object OnLogoutDismiss : SettingsAction
+    data object OnLogoutConfirmClick : SettingsAction
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsEvent.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsEvent.kt
@@ -1,0 +1,6 @@
+package zed.rainxch.githubstore.feature.settings.presentation
+
+sealed interface SettingsEvent {
+    data object OnLogoutSuccessful : SettingsEvent
+    data class OnLogoutError(val message: String) : SettingsEvent
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsRoot.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsRoot.kt
@@ -14,16 +14,25 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.githubstore.core.presentation.theme.GithubStoreTheme
+import zed.rainxch.githubstore.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.githubstore.feature.settings.presentation.components.LogoutDialog
 import zed.rainxch.githubstore.feature.settings.presentation.components.sections.about
+import zed.rainxch.githubstore.feature.settings.presentation.components.sections.logout
 import zed.rainxch.githubstore.feature.settings.presentation.components.sections.appearance
 
 @Composable
@@ -32,6 +41,28 @@ fun SettingsRoot(
     viewModel: SettingsViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    ObserveAsEvents(viewModel.events) { event ->
+        when (event) {
+            SettingsEvent.OnLogoutSuccessful -> {
+                coroutineScope.launch {
+                    snackbarState.showSnackbar("Logged out successfully, redirecting...")
+
+                    delay(1000)
+
+                    onNavigateBack()
+                }
+            }
+
+            is SettingsEvent.OnLogoutError -> {
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(event.message)
+                }
+            }
+        }
+    }
 
     SettingsScreen(
         state = state,
@@ -45,8 +76,20 @@ fun SettingsRoot(
                     viewModel.onAction(action)
                 }
             }
-        }
+        },
+        snackbarState = snackbarState
     )
+
+    if (state.isLogoutDialogVisible) {
+        LogoutDialog(
+            onDismissRequest = {
+                viewModel.onAction(SettingsAction.OnLogoutDismiss)
+            },
+            onLogout = {
+                viewModel.onAction(SettingsAction.OnLogoutConfirmClick)
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -54,8 +97,12 @@ fun SettingsRoot(
 fun SettingsScreen(
     state: SettingsState,
     onAction: (SettingsAction) -> Unit,
+    snackbarState: SnackbarHostState
 ) {
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarState)
+        },
         topBar = {
             CenterAlignedTopAppBar(
                 navigationIcon = {
@@ -102,6 +149,16 @@ fun SettingsScreen(
             about(
                 onAction = onAction
             )
+
+            if (state.isUserLoggedIn) {
+                item {
+                    Spacer(Modifier.height(16.dp))
+                }
+
+                logout(
+                    onAction = onAction
+                )
+            }
         }
     }
 }
@@ -112,7 +169,8 @@ private fun Preview() {
     GithubStoreTheme {
         SettingsScreen(
             state = SettingsState(),
-            onAction = {}
+            onAction = {},
+            snackbarState = SnackbarHostState()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsState.kt
@@ -3,5 +3,7 @@ package zed.rainxch.githubstore.feature.settings.presentation
 import zed.rainxch.githubstore.core.presentation.model.AppTheme
 
 data class SettingsState(
-    val selectedThemeColor: AppTheme = AppTheme.OCEAN
+    val selectedThemeColor: AppTheme = AppTheme.OCEAN,
+    val isLogoutDialogVisible: Boolean = false,
+    val isUserLoggedIn: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/LogoutDialog.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/LogoutDialog.kt
@@ -1,0 +1,85 @@
+package zed.rainxch.githubstore.feature.settings.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogoutDialog(
+    onDismissRequest: () -> Unit,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BasicAlertDialog(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(16.dp)
+    ) {
+        Column (
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(
+                text = "Warning!",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Text(
+                text = "Are you sure you want to logout!",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(
+                    onClick = {
+                        onDismissRequest()
+                    }
+                ) {
+                    Text(
+                        text = "Close",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+
+                Button(
+                    onClick = onLogout,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
+                    Text(
+                        text = "Logout",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Account.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Account.kt
@@ -1,0 +1,108 @@
+package zed.rainxch.githubstore.feature.settings.presentation.components.sections
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import zed.rainxch.githubstore.feature.settings.presentation.SettingsAction
+
+fun LazyListScope.logout(
+    onAction: (SettingsAction) -> Unit,
+) {
+    item {
+        Spacer(Modifier.height(8.dp))
+
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer
+            ),
+            shape = RoundedCornerShape(16.dp),
+            onClick = {
+                onAction(SettingsAction.OnLogoutClick)
+            }
+        ) {
+            AccountItem(
+                icon = Icons.AutoMirrored.Filled.Logout,
+                title = "Logout",
+                actions = {
+                    IconButton(
+                        onClick = {
+                            onAction(SettingsAction.OnLogoutClick)
+                        },
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun AccountItem(
+    icon: ImageVector,
+    title: String,
+    actions: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(
+            onClick = { },
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer
+            )
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        Text(
+            text = title,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f)
+        )
+
+        actions.invoke()
+    }
+}


### PR DESCRIPTION
This commit refactors the logout functionality, moving it from the authentication feature to a new, dedicated `SettingsRepository`.

**Key Changes:**

*   **New `SettingsRepository`:** Created `SettingsRepository` and `SettingsRepositoryImpl` to handle settings-related data operations, including logout and observing the user's login state.
*   **Logout in Settings:** Implemented the logout flow within the `SettingsScreen`, which now displays a logout button and confirmation dialog for logged-in users.
*   **Centralized Logic:** The `logout()` function was removed from `AuthRepository` and `AuthenticationViewModel` and is now handled by `SettingsRepository` by clearing the `TokenDataSource`.
*   **UI/UX:**
    *   Added a logout button to the settings screen, which is only visible when a user is logged in.
    *   Introduced a `LogoutDialog` to confirm the action.
    *   The UI now provides feedback via a snackbar on successful logout before navigating away.
*   **Code Organization:** Relocated `AppState`, `AppStateManager`, and `RateLimitDialog` into a new `app_state` sub-package for better structure.