### PR TITLE
feat: Add dynamic color theme support

### DIFF
--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.android.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.android.kt
@@ -1,0 +1,24 @@
+package zed.rainxch.githubstore.core.presentation.theme
+
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+actual fun isDynamicColorAvailable(): Boolean {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+}
+
+@Composable
+actual fun getDynamicColorScheme(darkTheme: Boolean): ColorScheme? {
+    if (!isDynamicColorAvailable()) return null
+
+    val context = LocalContext.current
+    return if (darkTheme) {
+        dynamicDarkColorScheme(context)
+    } else {
+        dynamicLightColorScheme(context)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
@@ -140,6 +142,7 @@ fun AppNavigation(
                 targetOffsetX = { it },
                 animationSpec = spring(Spring.DampingRatioLowBouncy)
             )
-        }
+        },
+        modifier = Modifier.background(MaterialTheme.colorScheme.background)
     )
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/model/AppTheme.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/model/AppTheme.kt
@@ -15,10 +15,16 @@ import zed.rainxch.githubstore.core.presentation.theme.slateGrayLight
 
 enum class AppTheme(
     val displayName: String,
-    val lightScheme: ColorScheme,
-    val darkScheme: ColorScheme,
-    val primaryColor: Color
+    val lightScheme: ColorScheme?,
+    val darkScheme: ColorScheme?,
+    val primaryColor: Color?
 ) {
+    DYNAMIC(
+        displayName = "Dynamic",
+        lightScheme = null,
+        darkScheme = null,
+        primaryColor = null
+    ),
     OCEAN(
         displayName = "Ocean",
         lightScheme = oceanBlueLight,

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.kt
@@ -2,6 +2,7 @@ package zed.rainxch.githubstore.core.presentation.theme
 
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.darkColorScheme
@@ -404,10 +405,15 @@ fun GithubStoreTheme(
     appTheme: AppTheme = AppTheme.OCEAN,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) {
-        appTheme.darkScheme
-    } else {
-        appTheme.lightScheme
+    val colorScheme = when {
+        appTheme == AppTheme.DYNAMIC -> {
+            getDynamicColorScheme(darkTheme) ?: run {
+                if (darkTheme) AppTheme.OCEAN.darkScheme!! else AppTheme.OCEAN.lightScheme!!
+            }
+        }
+
+        darkTheme -> appTheme.darkScheme!!
+        else -> appTheme.lightScheme!!
     }
 
     MaterialTheme(
@@ -416,3 +422,8 @@ fun GithubStoreTheme(
         content = content
     )
 }
+
+expect fun isDynamicColorAvailable(): Boolean
+
+@Composable
+expect fun getDynamicColorScheme(darkTheme: Boolean): ColorScheme?

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
@@ -1,6 +1,7 @@
 package zed.rainxch.githubstore.feature.settings.presentation.components.sections
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import zed.rainxch.githubstore.core.presentation.model.AppTheme
+import zed.rainxch.githubstore.core.presentation.theme.isDynamicColorAvailable
 import zed.rainxch.githubstore.feature.settings.presentation.SettingsAction
 
 fun LazyListScope.appearance(
@@ -69,7 +71,13 @@ fun LazyListScope.appearance(
                     horizontalArrangement = Arrangement.spacedBy(20.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items(AppTheme.entries) { theme ->
+                    val availableThemes = if (isDynamicColorAvailable()) {
+                        AppTheme.entries
+                    } else {
+                        AppTheme.entries.filter { it != AppTheme.DYNAMIC }
+                    }
+
+                    items(availableThemes) { theme ->
                         Column(
                             modifier = Modifier
                                 .clickable(onClick = {
@@ -82,10 +90,21 @@ fun LazyListScope.appearance(
                                 Modifier
                                     .size(50.dp)
                                     .clip(CircleShape)
-                                    .background(theme.primaryColor),
+                                    .background(
+                                        theme.primaryColor ?: MaterialTheme.colorScheme.primary
+                                    )
+                                    .then(
+                                        if (theme == AppTheme.DYNAMIC) {
+                                            Modifier.border(
+                                                2.dp,
+                                                MaterialTheme.colorScheme.outline,
+                                                CircleShape
+                                            )
+                                        } else Modifier
+                                    ),
                                 contentAlignment = Alignment.Center
                             ) {
-                                if(selectedThemeColor == theme) {
+                                if (selectedThemeColor == theme) {
                                     Icon(
                                         imageVector = Icons.Default.Done,
                                         contentDescription = "Selected color : ${theme.displayName}",

--- a/composeApp/src/jvmMain/java/zed/rainxch/githubstore/core/presentation/theme/Theme.jvm.kt
+++ b/composeApp/src/jvmMain/java/zed/rainxch/githubstore/core/presentation/theme/Theme.jvm.kt
@@ -1,0 +1,13 @@
+package zed.rainxch.githubstore.core.presentation.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+actual fun isDynamicColorAvailable(): Boolean {
+    return false
+}
+
+@Composable
+actual fun getDynamicColorScheme(darkTheme: Boolean): ColorScheme? {
+    return null
+}


### PR DESCRIPTION
Introduced support for Material You dynamic theming on Android (SDK 31+) and added a "Dynamic" theme option in the settings.

This is implemented using `expect`/`actual` functions (`isDynamicColorAvailable` and `getDynamicColorScheme`) to provide platform-specific logic. On Android, the theme is derived from the system wallpaper, while other platforms default to the "Ocean" theme.

The theme selection UI has been updated to:
- Conditionally display the "Dynamic" theme option only if it's available on the platform.
- Visually distinguish the "Dynamic" theme button with an outline border.