### PR TITLE
feat: Add AMOLED black theme option

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/App.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/App.kt
@@ -2,7 +2,6 @@ package zed.rainxch.githubstore
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
@@ -37,7 +36,8 @@ fun App(
     }
 
     GithubStoreTheme(
-        appTheme = state.currentColorTheme
+        appTheme = state.currentColorTheme,
+        isAmoledTheme = state.isAmoledTheme
     ) {
         LaunchedEffect(state.isCheckingAuth) {
             if (!state.isCheckingAuth) {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainState.kt
@@ -8,5 +8,6 @@ data class MainState(
     val isLoggedIn: Boolean = false,
     val rateLimitInfo: RateLimitInfo? = null,
     val showRateLimitDialog: Boolean = false,
-    val currentColorTheme: AppTheme = AppTheme.OCEAN
+    val currentColorTheme: AppTheme = AppTheme.OCEAN,
+    val isAmoledTheme: Boolean = false
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/MainViewModel.kt
@@ -53,6 +53,15 @@ class MainViewModel(
                     }
                 }
         }
+        viewModelScope.launch {
+            themesRepository
+                .getAmoledTheme()
+                .collect { isAmoled ->
+                    _state.update {
+                        it.copy(isAmoledTheme = isAmoled)
+                    }
+                }
+        }
 
         viewModelScope.launch {
             appStateManager.appState.collect { appState ->
@@ -66,7 +75,7 @@ class MainViewModel(
         }
     }
 
-    fun onAction(action : MainAction) {
+    fun onAction(action: MainAction) {
         when (action) {
             MainAction.DismissRateLimitDialog -> {
                 appStateManager.dismissRateLimitDialog()

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/repository/ThemesRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/repository/ThemesRepositoryImpl.kt
@@ -2,6 +2,7 @@ package zed.rainxch.githubstore.core.data.repository
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -13,7 +14,7 @@ class ThemesRepositoryImpl(
     private val preferences: DataStore<Preferences>
 ) : ThemesRepository {
     private val THEME_KEY = stringPreferencesKey("app_theme")
-
+    private val AMOLED_KEY = booleanPreferencesKey("amoled_theme")
 
     override fun getThemeColor(): Flow<AppTheme> {
         return preferences.data.map { prefs ->
@@ -28,4 +29,15 @@ class ThemesRepositoryImpl(
         }
     }
 
+    override fun getAmoledTheme(): Flow<Boolean> {
+        return preferences.data.map { prefs ->
+            prefs[AMOLED_KEY] ?: false
+        }
+    }
+
+    override suspend fun setAmoledTheme(enabled: Boolean) {
+        preferences.edit { prefs ->
+            prefs[AMOLED_KEY] = enabled
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/domain/repository/ThemesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/domain/repository/ThemesRepository.kt
@@ -6,4 +6,6 @@ import zed.rainxch.githubstore.core.presentation.model.AppTheme
 interface ThemesRepository {
     fun getThemeColor(): Flow<AppTheme>
     suspend fun setThemeColor(theme: AppTheme)
+    fun getAmoledTheme(): Flow<Boolean>
+    suspend fun setAmoledTheme(enabled: Boolean)
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Color.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.githubstore.core.presentation.theme
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 
 val primaryLight = Color(0xFF2A638A)
@@ -73,3 +74,19 @@ val surfaceContainerLowDark = Color(0xFF181C20)
 val surfaceContainerDark = Color(0xFF1C2024)
 val surfaceContainerHighDark = Color(0xFF272A2E)
 val surfaceContainerHighestDark = Color(0xFF313539)
+
+
+fun ColorScheme.toAmoled(): ColorScheme {
+    return this.copy(
+        background = Color.Black,
+        surface = Color.Black,
+        surfaceContainer = Color(0xFF0A0A0A),
+        surfaceContainerLow = Color(0xFF050505),
+        surfaceContainerLowest = Color.Black,
+        surfaceContainerHigh = Color(0xFF121212),
+        surfaceContainerHighest = Color(0xFF1A1A1A),
+        surfaceDim = Color(0xFF0D0D0D),
+        surfaceBright = Color(0xFF1F1F1F),
+        surfaceVariant = Color(0xFF121212)
+    )
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/presentation/theme/Theme.kt
@@ -407,17 +407,23 @@ val amberOrangeDark = darkColorScheme(
 fun GithubStoreTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     appTheme: AppTheme = AppTheme.OCEAN,
+    isAmoledTheme: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    val baseColorScheme = when {
         appTheme == AppTheme.DYNAMIC -> {
             getDynamicColorScheme(darkTheme) ?: run {
-                if (darkTheme) AppTheme.OCEAN.darkScheme!! else AppTheme.OCEAN.lightScheme!!
+                if (darkTheme) AppTheme.OCEAN.darkScheme else AppTheme.OCEAN.lightScheme
             }
         }
-
         darkTheme -> appTheme.darkScheme!!
         else -> appTheme.lightScheme!!
+    }
+
+    val colorScheme = if (darkTheme && isAmoledTheme) {
+        baseColorScheme?.toAmoled()
+    } else {
+        baseColorScheme
     }
 
     MaterialExpressiveTheme(

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsAction.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsAction.kt
@@ -5,8 +5,9 @@ import zed.rainxch.githubstore.core.presentation.model.AppTheme
 sealed interface SettingsAction {
     data object OnNavigateBackClick : SettingsAction
     data class OnThemeColorSelected(val themeColor: AppTheme) : SettingsAction
-    data object OnHelpClick : SettingsAction
+    data class OnAmoledThemeToggled(val enabled: Boolean) : SettingsAction
     data object OnLogoutClick : SettingsAction
-    data object OnLogoutDismiss : SettingsAction
     data object OnLogoutConfirmClick : SettingsAction
+    data object OnLogoutDismiss : SettingsAction
+    data object OnHelpClick : SettingsAction
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsRoot.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsRoot.kt
@@ -140,6 +140,10 @@ fun SettingsScreen(
                 selectedThemeColor = state.selectedThemeColor,
                 onThemeColorSelected = { theme ->
                     onAction(SettingsAction.OnThemeColorSelected(theme))
+                },
+                isAmoledThemeEnabled = state.isAmoledThemeEnabled,
+                onAmoledThemeToggled = { enabled ->
+                    onAction(SettingsAction.OnAmoledThemeToggled(enabled))
                 }
             )
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsState.kt
@@ -5,5 +5,6 @@ import zed.rainxch.githubstore.core.presentation.model.AppTheme
 data class SettingsState(
     val selectedThemeColor: AppTheme = AppTheme.OCEAN,
     val isLogoutDialogVisible: Boolean = false,
-    val isUserLoggedIn: Boolean = false
+    val isUserLoggedIn: Boolean = false,
+    val isAmoledThemeEnabled: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/SettingsViewModel.kt
@@ -54,9 +54,15 @@ class SettingsViewModel(
         viewModelScope.launch {
             themesRepository.getThemeColor().collect { theme ->
                 _state.update {
-                    it.copy(
-                        selectedThemeColor = theme
-                    )
+                    it.copy(selectedThemeColor = theme)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            themesRepository.getAmoledTheme().collect { isAmoled ->
+                _state.update {
+                    it.copy(isAmoledThemeEnabled = isAmoled)
                 }
             }
         }
@@ -73,6 +79,12 @@ class SettingsViewModel(
             is SettingsAction.OnThemeColorSelected -> {
                 viewModelScope.launch {
                     themesRepository.setThemeColor(action.themeColor)
+                }
+            }
+
+            is SettingsAction.OnAmoledThemeToggled -> {
+                viewModelScope.launch {
+                    themesRepository.setAmoledTheme(action.enabled)
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,6 +25,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.toShape
 import androidx.compose.ui.Alignment
@@ -31,15 +33,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import zed.rainxch.githubstore.core.presentation.model.AppTheme
 import zed.rainxch.githubstore.core.presentation.theme.isDynamicColorAvailable
-import zed.rainxch.githubstore.feature.settings.presentation.SettingsAction
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 fun LazyListScope.appearance(
     selectedThemeColor: AppTheme,
+    isAmoledThemeEnabled: Boolean,
     onThemeColorSelected: (AppTheme) -> Unit,
+    onAmoledThemeToggled: (Boolean) -> Unit,
 ) {
     item {
         Text(
@@ -131,6 +133,50 @@ fun LazyListScope.appearance(
                         }
                     }
                 }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            ),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAmoledThemeToggled(!isAmoledThemeEnabled)
+                    }
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = "AMOLED Black Theme",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Text(
+                        text = "Pure black background for dark mode",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Switch(
+                    checked = isAmoledThemeEnabled,
+                    onCheckedChange = onAmoledThemeToggled
+                )
             }
         }
     }


### PR DESCRIPTION
This change introduces an AMOLED black theme option for dark mode, providing a pure black background to save battery on OLED screens and for aesthetic preference.

Key changes:
- Added a toggle switch in the "Appearance" section of the settings screen to enable or disable the AMOLED theme.
- The theme preference is persisted using `DataStore`.
- Updated the `ThemesRepository` with `getAmoledTheme()` and `setAmoledTheme()` methods.
- The main `GithubStoreTheme` now conditionally applies an AMOLED color scheme (`toAmoled()`) if dark mode and the new setting are both enabled.
- The `SettingsViewModel` and relevant UI states have been updated to manage and reflect the new theme setting.