### PR TITLE
refactor(home): Revise home screen categories and filtering logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/domain/model/TrendingPeriod.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/domain/model/TrendingPeriod.kt
@@ -1,0 +1,5 @@
+package zed.rainxch.githubstore.feature.home.domain.model
+
+enum class TrendingPeriod(val days: Int) {
+    WEEK(7)
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/domain/repository/HomeRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/domain/repository/HomeRepository.kt
@@ -2,9 +2,10 @@ package zed.rainxch.githubstore.feature.home.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 import zed.rainxch.githubstore.feature.home.domain.model.PaginatedRepos
+import zed.rainxch.githubstore.feature.home.domain.model.TrendingPeriod
 
 interface HomeRepository {
     fun getTrendingRepositories(page: Int): Flow<PaginatedRepos>
-    fun getLatestUpdated(page: Int): Flow<PaginatedRepos>
     fun getNew(page: Int): Flow<PaginatedRepos>
+    fun getRecentlyUpdated(page: Int): Flow<PaginatedRepos>
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/HomeState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/HomeState.kt
@@ -9,5 +9,5 @@ data class HomeState(
     val isLoadingMore: Boolean = false,
     val errorMessage: String? = null,
     val hasMorePages: Boolean = true,
-    val currentCategory: HomeCategory = HomeCategory.POPULAR
+    val currentCategory: HomeCategory = HomeCategory.TRENDING
 )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/HomeViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import zed.rainxch.githubstore.feature.home.domain.model.TrendingPeriod
 import zed.rainxch.githubstore.feature.home.domain.repository.HomeRepository
 import zed.rainxch.githubstore.feature.home.presentation.model.HomeCategory
 
@@ -66,9 +67,9 @@ class HomeViewModel(
 
             try {
                 val flow = when (targetCategory) {
-                    HomeCategory.POPULAR -> homeRepository.getTrendingRepositories(nextPageIndex)
-                    HomeCategory.LATEST_UPDATED -> homeRepository.getLatestUpdated(nextPageIndex)
+                    HomeCategory.TRENDING -> homeRepository.getTrendingRepositories(nextPageIndex)
                     HomeCategory.NEW -> homeRepository.getNew(nextPageIndex)
+                    HomeCategory.RECENTLY_UPDATED -> homeRepository.getRecentlyUpdated(nextPageIndex)
                 }
 
                 flow.collect { paginatedRepos ->

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/components/HomeFilterChips.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/components/HomeFilterChips.kt
@@ -22,11 +22,7 @@ fun RowScope.HomeFilterChips(
     FilterChip(
         label = {
             Text(
-                text = when (category) {
-                    HomeCategory.POPULAR -> "Popular"
-                    HomeCategory.LATEST_UPDATED -> "Latest"
-                    HomeCategory.NEW -> "New"
-                },
+                text = category.displayText,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/model/HomeCategory.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/model/HomeCategory.kt
@@ -1,7 +1,7 @@
 package zed.rainxch.githubstore.feature.home.presentation.model
 
-enum class HomeCategory {
-    POPULAR,
-    LATEST_UPDATED,
-    NEW
+enum class HomeCategory(val displayText: String) {
+    TRENDING("Trending"),
+    NEW("New"),
+    RECENTLY_UPDATED("Recently updated"),
 }


### PR DESCRIPTION
This commit refactors the categories on the home screen to provide more relevant and timely repository lists. The filtering logic has been updated to use more precise date ranges for each category.

Key changes:
- Renamed `POPULAR` to `TRENDING` and narrowed the trending period to the last 7 days.
- Replaced `LATEST_UPDATED` with `RECENTLY_UPDATED`, which now filters for repositories updated in the last 3 days with at least 50 stars.
- Modified the `NEW` category to only include repositories created in the last 30 days.
- Updated `HomeCategory` enum to include a `displayText` property for cleaner UI code.
- Adjusted the `HomeRepository` and `HomeViewModel` to reflect these new category definitions and their corresponding repository fetching logic.