### PR TITLE
feat: Add localized README support

### DIFF
--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/di/PlatformModules.android.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/di/PlatformModules.android.kt
@@ -6,6 +6,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import zed.rainxch.githubstore.core.data.AndroidApkInfoExtractor
+import zed.rainxch.githubstore.core.data.AndroidLocalizationManager
 import zed.rainxch.githubstore.core.data.AndroidPackageMonitor
 import zed.rainxch.githubstore.core.data.services.PackageMonitor
 import zed.rainxch.githubstore.core.data.local.data_store.createDataStore
@@ -25,6 +26,7 @@ import zed.rainxch.githubstore.feature.details.data.AndroidInstaller
 import zed.rainxch.githubstore.core.data.services.Downloader
 import zed.rainxch.githubstore.core.data.services.FileLocationsProvider
 import zed.rainxch.githubstore.core.data.services.Installer
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
 
 actual val platformModule: Module = module {
     single<Downloader> {
@@ -69,6 +71,10 @@ actual val platformModule: Module = module {
 
     single<PackageMonitor> {
         AndroidPackageMonitor(androidContext())
+    }
+
+    single<LocalizationManager> {
+        AndroidLocalizationManager()
     }
 
     single<AppLauncher> {

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/core/data/AndroidLocalizationManager.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/core/data/AndroidLocalizationManager.kt
@@ -1,0 +1,21 @@
+package zed.rainxch.githubstore.core.data
+
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
+import java.util.Locale
+
+class AndroidLocalizationManager : LocalizationManager {
+    override fun getCurrentLanguageCode(): String {
+        val locale = Locale.getDefault()
+        val language = locale.language
+        val country = locale.country
+        return if (country.isNotEmpty()) {
+            "$language-$country"
+        } else {
+            language
+        }
+    }
+
+    override fun getPrimaryLanguageCode(): String {
+        return Locale.getDefault().language
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/SharedModules.kt
@@ -183,7 +183,8 @@ val detailsModule: Module = module {
     single<DetailsRepository> {
         DetailsRepositoryImpl(
             github = get(),
-            appStateManager = get()
+            appStateManager = get(),
+            localizationManager = get()
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/services/LocalizationManager.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/services/LocalizationManager.kt
@@ -1,0 +1,14 @@
+package zed.rainxch.githubstore.core.data.services
+
+interface LocalizationManager {
+    /**
+     * Returns the current device language code in ISO 639-1 format (e.g., "en", "zh", "ja")
+     * Can include region code if available (e.g., "zh-CN", "pt-BR")
+     */
+    fun getCurrentLanguageCode(): String
+    
+    /**
+     * Returns the primary language code without region (e.g., "zh" from "zh-CN")
+     */
+    fun getPrimaryLanguageCode(): String
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/model/ReadmeAttempt.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/model/ReadmeAttempt.kt
@@ -1,0 +1,7 @@
+package zed.rainxch.githubstore.feature.details.data.model
+
+data class ReadmeAttempt(
+    val path: String,
+    val filename: String,
+    val priority: Int
+)

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/repository/DetailsRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/repository/DetailsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpHeaders
 import zed.rainxch.githubstore.app.app_state.AppStateManager
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
 import zed.rainxch.githubstore.core.domain.model.GithubRelease
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
 import zed.rainxch.githubstore.core.domain.model.GithubUser
@@ -16,6 +17,7 @@ import zed.rainxch.githubstore.feature.details.data.dto.RepoByIdNetwork
 import zed.rainxch.githubstore.feature.details.data.dto.RepoInfoNetwork
 import zed.rainxch.githubstore.feature.details.data.dto.UserProfileNetwork
 import zed.rainxch.githubstore.feature.details.data.mappers.toDomain
+import zed.rainxch.githubstore.feature.details.data.utils.ReadmeLocalizationHelper
 import zed.rainxch.githubstore.feature.details.data.utils.preprocessMarkdown
 import zed.rainxch.githubstore.feature.details.domain.model.RepoStats
 import zed.rainxch.githubstore.feature.details.domain.repository.DetailsRepository
@@ -24,8 +26,11 @@ import zed.rainxch.githubstore.network.safeApiCall
 
 class DetailsRepositoryImpl(
     private val github: HttpClient,
-    private val appStateManager: AppStateManager
+    private val appStateManager: AppStateManager,
+    private val localizationManager: LocalizationManager
 ) : DetailsRepository {
+
+    private val readmeHelper = ReadmeLocalizationHelper(localizationManager)
 
     override suspend fun getRepositoryById(id: Long): GithubRepoSummary {
         val repoResult = github.safeApiCall<RepoByIdNetwork>(
@@ -113,43 +118,134 @@ class DetailsRepositoryImpl(
         return processedLatestRelease.toDomain()
     }
 
-    override suspend fun getReadme(owner: String, repo: String, defaultBranch: String): String? {
-        return try {
-            val rawMarkdownResult = github.safeApiCall<String>(
-                rateLimitHandler = appStateManager.rateLimitHandler,
-                autoRetryOnRateLimit = false
-            ) {
-                get("https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/README.md")
+    override suspend fun getReadme(
+        owner: String,
+        repo: String,
+        defaultBranch: String
+    ): Triple<String, String?, String>? {
+        val attempts = readmeHelper.generateReadmeAttempts()
+        val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/"
+
+        val primaryLang = localizationManager.getPrimaryLanguageCode()
+        Logger.d {
+            "Attempting to fetch README for language preference: ${localizationManager.getCurrentLanguageCode()}"
+        }
+
+        var lastError: Throwable? = null
+        val foundReadmes = mutableMapOf<String, Pair<String, String?>>()
+
+        for (attempt in attempts) {
+            try {
+                Logger.d { "Trying ${attempt.path} (priority: ${attempt.priority})..." }
+
+                val rawMarkdownResult = github.safeApiCall<String>(
+                    rateLimitHandler = appStateManager.rateLimitHandler,
+                    autoRetryOnRateLimit = false
+                ) {
+                    get("$baseUrl${attempt.path}")
+                }
+
+                rawMarkdownResult.onFailure { error ->
+                    if (error is RateLimitException) {
+                        appStateManager.updateRateLimit(error.rateLimitInfo)
+                    }
+                }
+
+                val rawMarkdown = rawMarkdownResult.getOrNull()
+
+                if (rawMarkdown != null) {
+                    Logger.d { "Successfully fetched ${attempt.path}" }
+
+                    val processed = preprocessMarkdown(
+                        markdown = rawMarkdown,
+                        baseUrl = baseUrl
+                    )
+
+                    val detectedLang = readmeHelper.detectReadmeLanguage(processed)
+                    Logger.d { "Detected language: ${detectedLang ?: "unknown"} for ${attempt.path}" }
+
+                    foundReadmes[attempt.path] = Pair(processed, detectedLang)
+
+
+                    if (attempt.filename != "README.md" && detectedLang == primaryLang) {
+                        Logger.d { "Found localized README matching user language: ${attempt.path}" }
+                        return Triple(processed, detectedLang, attempt.path)
+                    }
+
+                    if (attempt.filename.contains(".${primaryLang}.", ignoreCase = true) ||
+                        attempt.filename.contains("-${primaryLang.uppercase()}.", ignoreCase = true)) {
+                        Logger.d { "Found explicit language file for user: ${attempt.path}" }
+                        return Triple(processed, detectedLang ?: primaryLang, attempt.path)
+                    }
+
+                    if (attempt.filename == "README.md") {
+                        if (detectedLang == primaryLang) {
+                            Logger.d { "Default README matches user language: ${attempt.path}" }
+                            return Triple(processed, detectedLang, attempt.path)
+                        }
+
+                        if (primaryLang == "en" && detectedLang != null && detectedLang != "en") {
+                            Logger.d { "Default README is $detectedLang, continuing search for English version" }
+                            continue
+                        }
+
+                        if (primaryLang != "en" && detectedLang == "en") {
+                            Logger.d { "Default README is English, continuing search for $primaryLang version" }
+                            continue
+                        }
+
+                        if (attempt.path == "README.md" && attempts.any { it.path.startsWith("docs/") }) {
+                            Logger.d { "Found root README.md, but checking docs/ folder first" }
+                            continue
+                        }
+                    }
+
+                    if (primaryLang == "en" &&
+                        (attempt.filename.contains(".en.", ignoreCase = true) ||
+                                attempt.filename.contains("-EN.", ignoreCase = true))) {
+                        Logger.d { "Found English README for English user: ${attempt.path}" }
+                        return Triple(processed, "en", attempt.path)
+                    }
+                }
+            } catch (e: Throwable) {
+                lastError = e
+                Logger.d { "Failed to fetch ${attempt.path}: ${e.message}" }
+            }
+        }
+
+        if (foundReadmes.isNotEmpty()) {
+            foundReadmes.entries.firstOrNull { it.value.second == primaryLang }?.let {
+                Logger.d { "Fallback: Using README matching user language: ${it.key}" }
+                return Triple(it.value.first, it.value.second, it.key)
             }
 
-            rawMarkdownResult.onFailure { error ->
-                if (error is RateLimitException) {
-                    appStateManager.updateRateLimit(error.rateLimitInfo)
+            if (primaryLang == "en") {
+                foundReadmes.entries.firstOrNull { it.value.second == "en" }?.let {
+                    Logger.d { "Fallback: Using English README: ${it.key}" }
+                    return Triple(it.value.first, it.value.second, it.key)
                 }
             }
 
-            val rawMarkdown = rawMarkdownResult.getOrNull()
-                ?: throw Exception("Failed to fetch $defaultBranch README")
-
-            val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/"
-
-            val processed = preprocessMarkdown(
-                markdown = rawMarkdown,
-                baseUrl = baseUrl
-            )
-
-            // Log a sample to verify
-            Logger.d {
-                "First 500 chars of processed markdown: ${processed.take(500)}"
+            foundReadmes.entries.firstOrNull { it.key == "README.md" }?.let {
+                Logger.d { "Fallback: Using root README.md (language: ${it.value.second}): ${it.key}" }
+                return Triple(it.value.first, it.value.second, it.key)
             }
 
-            processed
-        } catch (e: Throwable) {
-            Logger.e {
-                "Failed to fetch README $e"
+            foundReadmes.entries.firstOrNull { it.key.startsWith(".github/") }?.let {
+                Logger.d { "Fallback: Using .github README: ${it.key}" }
+                return Triple(it.value.first, it.value.second, it.key)
             }
-            null
+
+            foundReadmes.entries.first().let {
+                Logger.d { "Fallback: Using first found README: ${it.key}" }
+                return Triple(it.value.first, it.value.second, it.key)
+            }
         }
+
+        Logger.e {
+            "Failed to fetch any README variant. Last error: ${lastError?.message}"
+        }
+        return null
     }
 
     override suspend fun getRepoStats(owner: String, repo: String): RepoStats {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/utils/ReadmeLocalizationHelper.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/data/utils/ReadmeLocalizationHelper.kt
@@ -1,0 +1,159 @@
+package zed.rainxch.githubstore.feature.details.data.utils
+
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
+import zed.rainxch.githubstore.feature.details.data.model.ReadmeAttempt
+
+class ReadmeLocalizationHelper(
+    private val localizationManager: LocalizationManager
+) {
+
+    private val searchPaths = listOf(
+        ".github",
+        "",
+        "docs",
+        "doc"
+    )
+
+    fun generateReadmeAttempts(): List<ReadmeAttempt> {
+        val attempts = mutableListOf<ReadmeAttempt>()
+        val currentLang = localizationManager.getCurrentLanguageCode().lowercase()
+        val primaryLang = localizationManager.getPrimaryLanguageCode().lowercase()
+
+        var globalPriority = 0
+
+        for ((pathIndex, searchPath) in searchPaths.withIndex()) {
+            val pathPrefix = if (searchPath.isEmpty()) "" else "$searchPath/"
+
+            var localPriority = 0
+
+            if (currentLang.contains("-")) {
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.${currentLang}.md",
+                    filename = "README.${currentLang}.md",
+                    priority = globalPriority + localPriority++
+                ))
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.${currentLang.replace("-", "_")}.md",
+                    filename = "README.${currentLang.replace("-", "_")}.md",
+                    priority = globalPriority + localPriority++
+                ))
+            }
+
+            attempts.add(ReadmeAttempt(
+                path = "${pathPrefix}README.${primaryLang}.md",
+                filename = "README.${primaryLang}.md",
+                priority = globalPriority + localPriority++
+            ))
+
+            if (currentLang.contains("-")) {
+                val parts = currentLang.split("-")
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.${parts[0].uppercase()}.md",
+                    filename = "README.${parts[0].uppercase()}.md",
+                    priority = globalPriority + localPriority++
+                ))
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README-${parts[0].uppercase()}.md",
+                    filename = "README-${parts[0].uppercase()}.md",
+                    priority = globalPriority + localPriority++
+                ))
+            } else {
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.${primaryLang.uppercase()}.md",
+                    filename = "README.${primaryLang.uppercase()}.md",
+                    priority = globalPriority + localPriority++
+                ))
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README-${primaryLang.uppercase()}.md",
+                    filename = "README-${primaryLang.uppercase()}.md",
+                    priority = globalPriority + localPriority++
+                ))
+            }
+
+            attempts.add(ReadmeAttempt(
+                path = "${pathPrefix}README_${primaryLang}.md",
+                filename = "README_${primaryLang}.md",
+                priority = globalPriority + localPriority++
+            ))
+            attempts.add(ReadmeAttempt(
+                path = "${pathPrefix}readme.${primaryLang}.md",
+                filename = "readme.${primaryLang}.md",
+                priority = globalPriority + localPriority++
+            ))
+
+            attempts.add(ReadmeAttempt(
+                path = "${pathPrefix}README.md",
+                filename = "README.md",
+                priority = globalPriority + localPriority++
+            ))
+
+            if (primaryLang != "en") {
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.en.md",
+                    filename = "README.en.md",
+                    priority = globalPriority + localPriority++
+                ))
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README.EN.md",
+                    filename = "README.EN.md",
+                    priority = globalPriority + localPriority++
+                ))
+                attempts.add(ReadmeAttempt(
+                    path = "${pathPrefix}README-EN.md",
+                    filename = "README-EN.md",
+                    priority = globalPriority + localPriority++
+                ))
+            }
+
+            globalPriority += 100 * (pathIndex + 1)
+        }
+
+        return attempts.sortedBy { it.priority }
+    }
+
+    fun detectReadmeLanguage(content: String): String? {
+        val sample = content.take(1000)
+        val sampleLower = sample.lowercase()
+
+        val chineseChars = sample.count { it in '\u4e00'..'\u9fff' }
+        val japaneseHiragana = sample.count { it in '\u3040'..'\u309f' }
+        val japaneseKatakana = sample.count { it in '\u30a0'..'\u30ff' }
+        val koreanChars = sample.count { it in '\uac00'..'\ud7af' }
+        val arabicChars = sample.count { it in '\u0600'..'\u06ff' }
+        val cyrillicChars = sample.count { it in 'а'..'я' || it in 'А'..'Я' || it == 'ё' || it == 'Ё' }
+
+        val totalChars = sample.length
+        val threshold = 0.15
+
+        return when {
+            chineseChars > totalChars * threshold -> "zh"
+
+            (japaneseHiragana + japaneseKatakana) > totalChars * threshold -> "ja"
+
+            koreanChars > totalChars * threshold -> "ko"
+
+            arabicChars > totalChars * threshold -> "ar"
+
+            cyrillicChars > totalChars * threshold -> "ru"
+
+            else -> {
+                val englishIndicators = listOf(
+                    "\\bthe\\b", "\\band\\b", "\\bfor\\b", "\\bwith\\b",
+                    "\\bthis\\b", "\\bthat\\b", "\\bfrom\\b", "\\bare\\b",
+                    "\\bwas\\b", "\\bhave\\b", "\\bhas\\b", "\\bwill\\b",
+                    "\\byou\\b", "\\bcan\\b", "\\buse\\b", "\\binstall\\b"
+                )
+
+                val matchCount = englishIndicators.count { pattern ->
+                    Regex(pattern, RegexOption.IGNORE_CASE).containsMatchIn(sampleLower)
+                }
+
+                if (matchCount >= 4) {
+                    "en"
+                } else {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/domain/repository/DetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/domain/repository/DetailsRepository.kt
@@ -5,12 +5,24 @@ import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
 import zed.rainxch.githubstore.core.domain.model.GithubUserProfile
 import zed.rainxch.githubstore.feature.details.domain.model.RepoStats
 
+typealias ReadmeContent = String
+typealias ReadmePath = String
+typealias LanguageCode = String
+
 interface DetailsRepository {
     suspend fun getRepositoryById(id: Long): GithubRepoSummary
 
-    suspend fun getLatestPublishedRelease(owner: String, repo: String, defaultBranch: String): GithubRelease?
+    suspend fun getLatestPublishedRelease(
+        owner: String,
+        repo: String,
+        defaultBranch: String
+    ): GithubRelease?
 
-    suspend fun getReadme(owner: String, repo: String, defaultBranch: String): String?
+    suspend fun getReadme(
+        owner: String,
+        repo: String,
+        defaultBranch: String
+    ): Triple<ReadmeContent, LanguageCode?, ReadmePath>?
 
     suspend fun getRepoStats(owner: String, repo: String): RepoStats
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsRoot.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsRoot.kt
@@ -203,8 +203,11 @@ fun DetailsScreen(
                     stats(repoStats = stats)
                 }
 
-                state.readmeMarkdown?.let { readmeMarkdown ->
-                    about(readmeMarkdown)
+                state.readmeMarkdown?.let {
+                    about(
+                        readmeMarkdown = state.readmeMarkdown,
+                        readmeLanguage = state.readmeLanguage
+                    )
                 }
 
                 state.latestRelease?.let { latestRelease ->

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/DetailsState.kt
@@ -28,6 +28,7 @@ data class DetailsState(
 
     val stats: RepoStats? = null,
     val readmeMarkdown: String? = null,
+    val readmeLanguage: String? = null,
 
     val installLogs: List<InstallLogItem> = emptyList(),
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/sections/About.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/details/presentation/components/sections/About.kt
@@ -1,5 +1,7 @@
 package zed.rainxch.githubstore.feature.details.presentation.components.sections
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -10,11 +12,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
 import com.mikepenz.markdown.compose.Markdown
 import io.github.fletchmckee.liquid.liquefiable
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
@@ -23,7 +25,10 @@ import zed.rainxch.githubstore.feature.details.presentation.utils.MarkdownImageT
 import zed.rainxch.githubstore.feature.details.presentation.utils.rememberMarkdownColors
 import zed.rainxch.githubstore.feature.details.presentation.utils.rememberMarkdownTypography
 
-fun LazyListScope.about(readmeMarkdown: String) {
+fun LazyListScope.about(
+    readmeMarkdown: String,
+    readmeLanguage: String?,
+) {
     item {
         val liquidState = LocalTopbarLiquidState.current
 
@@ -31,15 +36,31 @@ fun LazyListScope.about(readmeMarkdown: String) {
 
         Spacer(Modifier.height(16.dp))
 
-        Text(
-            text = "About this app",
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onBackground,
-            fontWeight = FontWeight.Bold,
+        Row(
             modifier = Modifier
-                .padding(bottom = 8.dp)
-                .liquefiable(liquidState)
-        )
+                .fillMaxWidth()
+                .padding(bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "About this app",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.liquefiable(liquidState)
+            )
+
+            readmeLanguage?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.liquefiable(liquidState)
+                )
+            }
+        }
     }
 
     item {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/app/di/PlatformModules.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/app/di/PlatformModules.jvm.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import zed.rainxch.githubstore.core.data.DesktopApkInfoExtractor
+import zed.rainxch.githubstore.core.data.DesktopLocalizationManager
 import zed.rainxch.githubstore.core.data.DesktopPackageMonitor
 import zed.rainxch.githubstore.core.data.services.PackageMonitor
 import zed.rainxch.githubstore.core.data.local.data_store.createDataStore
@@ -22,6 +23,7 @@ import zed.rainxch.githubstore.feature.auth.data.TokenStore
 import zed.rainxch.githubstore.core.data.services.Downloader
 import zed.rainxch.githubstore.core.data.services.FileLocationsProvider
 import zed.rainxch.githubstore.core.data.services.Installer
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
 import zed.rainxch.githubstore.feature.details.data.DesktopDownloader
 import zed.rainxch.githubstore.feature.details.data.DesktopFileLocationsProvider
 import zed.rainxch.githubstore.feature.details.data.DesktopInstaller
@@ -71,6 +73,10 @@ actual val platformModule: Module = module {
 
     single<PackageMonitor> {
         DesktopPackageMonitor()
+    }
+
+    single<LocalizationManager> {
+        DesktopLocalizationManager()
     }
 
     single<AppLauncher> {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/DesktopLocalizationManager.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/DesktopLocalizationManager.kt
@@ -1,0 +1,20 @@
+package zed.rainxch.githubstore.core.data
+
+import zed.rainxch.githubstore.core.data.services.LocalizationManager
+
+class DesktopLocalizationManager : LocalizationManager {
+    override fun getCurrentLanguageCode(): String {
+        val locale = java.util.Locale.getDefault()
+        val language = locale.language
+        val country = locale.country
+        return if (country.isNotEmpty()) {
+            "$language-$country"
+        } else {
+            language
+        }
+    }
+    
+    override fun getPrimaryLanguageCode(): String {
+        return java.util.Locale.getDefault().language
+    }
+}


### PR DESCRIPTION
This change introduces the ability to fetch and display localized README files based on the user's device language. The system now attempts to find a README that matches the user's language preference before falling back to a default or English version.

Key changes:
- Introduced a `LocalizationManager` service to get the device's current language code, with platform-specific implementations for Android and JVM.
- Created a `ReadmeLocalizationHelper` to generate a prioritized list of possible README file paths (e.g., `README.zh-CN.md`, `README-zh.md`, `README.md`) and to detect the language of a given markdown file.
- The `DetailsRepository` now uses this helper to search for the most appropriate README file across various common locations (`.github/`, `docs/`, root). It returns the README content, its detected language, and its path.
- The `DetailsViewModel` and `DetailsState` have been updated to handle the new README data structure, including the detected language.
- The "About" section in the UI now displays the detected language of the README file next to the section title.