### PR TITLE
feat(search): Add programming language filter

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/domain/model/ProgrammingLanguage.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/domain/model/ProgrammingLanguage.kt
@@ -1,0 +1,28 @@
+package zed.rainxch.githubstore.feature.search.domain.model;
+
+enum class ProgrammingLanguage(val displayName: String, val queryValue: String?) {
+    All("All Languages", null),
+    Kotlin("Kotlin", "kotlin"),
+    Java("Java", "java"),
+    JavaScript("JavaScript", "javascript"),
+    TypeScript("TypeScript", "typescript"),
+    Python("Python", "python"),
+    Swift("Swift", "swift"),
+    Rust("Rust", "rust"),
+    Go("Go", "go"),
+    CSharp("C#", "c#"),
+    CPlusPlus("C++", "c++"),
+    C("C", "c"),
+    Dart("Dart", "dart"),
+    Ruby("Ruby", "ruby"),
+    PHP("PHP", "php");
+
+    companion object {
+        fun fromLanguageString(lang: String?): ProgrammingLanguage {
+            if (lang == null) return All
+            return entries.find {
+                it.queryValue?.equals(lang, ignoreCase = true) == true
+            } ?: All
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/domain/repository/SearchRepository.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/domain/repository/SearchRepository.kt
@@ -2,12 +2,14 @@ package zed.rainxch.githubstore.feature.search.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 import zed.rainxch.githubstore.feature.home.domain.model.PaginatedRepos
+import zed.rainxch.githubstore.feature.search.domain.model.ProgrammingLanguage
 import zed.rainxch.githubstore.feature.search.domain.model.SearchPlatformType
 
 interface SearchRepository {
     fun searchRepositories(
         query: String,
         searchPlatformType: SearchPlatformType,
+        language: ProgrammingLanguage,
         page: Int
     ): Flow<PaginatedRepos>
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchAction.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchAction.kt
@@ -1,16 +1,19 @@
 package zed.rainxch.githubstore.feature.search.presentation
 
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
+import zed.rainxch.githubstore.feature.search.domain.model.ProgrammingLanguage
 import zed.rainxch.githubstore.feature.search.domain.model.SearchPlatformType
 import zed.rainxch.githubstore.feature.search.domain.model.SortBy
 
 sealed interface SearchAction {
-    data class OnPlatformTypeSelected(val searchPlatformType: SearchPlatformType) : SearchAction
-    data class OnRepositoryClick(val repository: GithubRepoSummary) : SearchAction
     data class OnSearchChange(val query: String) : SearchAction
+    data class OnPlatformTypeSelected(val searchPlatformType: SearchPlatformType) : SearchAction
+    data class OnLanguageSelected(val language: ProgrammingLanguage) : SearchAction
+    data class OnSortBySelected(val sortBy: SortBy) : SearchAction
+    data class OnRepositoryClick(val repository: GithubRepoSummary) : SearchAction
     data object OnSearchImeClick : SearchAction
     data object OnNavigateBackClick : SearchAction
-    data class OnSortBySelected(val sortBy: SortBy) : SearchAction
     data object LoadMore : SearchAction
     data object Retry : SearchAction
+    data object OnToggleLanguageSheetVisibility : SearchAction
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchState.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/SearchState.kt
@@ -1,19 +1,22 @@
 package zed.rainxch.githubstore.feature.search.presentation
 
 import zed.rainxch.githubstore.core.domain.model.GithubRepoSummary
+import zed.rainxch.githubstore.feature.search.domain.model.ProgrammingLanguage
 import zed.rainxch.githubstore.feature.search.domain.model.SearchPlatformType
 import zed.rainxch.githubstore.feature.search.domain.model.SortBy
 
 data class SearchState(
-    val search: String = "",
-    val selectedSortBy: SortBy = SortBy.BestMatch,
-    val selectedSearchPlatformType: SearchPlatformType = SearchPlatformType.All,
+    val query: String = "",
     val repositories: List<SearchRepo> = emptyList(),
-    val totalCount: Int? = null,
+    val selectedSearchPlatformType: SearchPlatformType = SearchPlatformType.All,
+    val selectedSortBy: SortBy = SortBy.BestMatch,
+    val selectedLanguage: ProgrammingLanguage = ProgrammingLanguage.All,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
+    val errorMessage: String? = null,
     val hasMorePages: Boolean = true,
-    val errorMessage: String? = null
+    val totalCount: Int? = null,
+    val isLanguageSheetVisible: Boolean = false
 )
 
 data class SearchRepo(

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/components/LanguageFilterBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/search/presentation/components/LanguageFilterBottomSheet.kt
@@ -1,0 +1,84 @@
+package zed.rainxch.githubstore.feature.search.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import zed.rainxch.githubstore.feature.search.domain.model.ProgrammingLanguage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LanguageFilterBottomSheet(
+    selectedLanguage: ProgrammingLanguage,
+    onLanguageSelected: (ProgrammingLanguage) -> Unit,
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState()
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = "Filter by Language",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                items(ProgrammingLanguage.entries.toList()) { language ->
+                    FilterChip(
+                        selected = selectedLanguage == language,
+                        onClick = {
+                            onLanguageSelected(language)
+                            onDismissRequest()
+                        },
+                        label = {
+                            Text(
+                                text = language.displayName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = if (selectedLanguage == language) {
+                                    FontWeight.SemiBold
+                                } else {
+                                    FontWeight.Normal
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                textAlign = TextAlign.Center
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change introduces the ability for users to filter search results by programming language.

Key changes:
- Added a `ProgrammingLanguage` enum to define a list of supported languages for filtering.
- Implemented a "Language" filter chip on the search screen, which opens a bottom sheet for language selection.
- The `SearchRepository` now appends the selected language to the search query (e.g., `language:kotlin`).
- The UI includes a button to clear the language filter and return to searching all languages.
- State management in `SearchViewModel` is updated to handle language selection and trigger a new search.
- The top app bar and its search field have been refactored into a separate `SearchTopbar` composable.