### PR TITLE
fix(ui): Prevent text truncation in home filter chips

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/components/HomeFilterChips.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/home/presentation/components/HomeFilterChips.kt
@@ -33,7 +33,6 @@ fun RowScope.HomeFilterChips(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f)
             )
         },
         shape = CircleShape,


### PR DESCRIPTION
Ensures the text within the home screen's filter chips does not get truncated by applying `fillMaxWidth` and a weight of `1f` to the `Text` composable. This allows the text to occupy the available space within the chip before ellipsizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the home screen filter chips’ layout and responsiveness: chips now share space evenly, and their labels stretch to use available width for more consistent sizing and better alignment across screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->