### PR TITLE
refactor: Localize rate limit error message

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/network/RateLimitInfo.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/network/RateLimitInfo.kt
@@ -39,7 +39,7 @@ data class RateLimitInfo(
 
 class RateLimitException(
     val rateLimitInfo: RateLimitInfo,
-    message: String = "GitHub API rate limit exceeded"
+    message: String
 ) : Exception(message)
 
 class RateLimitHandler {


### PR DESCRIPTION
This commit refactors the `RateLimitException` to use a localized string resource for the error message.

Previously, the error message was a hardcoded string. Now, it fetches the translated message from `Res.string.rate_limit_exceeded`, allowing the rate limit error to be displayed in the user's language. The `RateLimitException` constructor and `safeApiCall` function have been updated to support this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when GitHub API rate limits are exceeded with localized error strings for better clarity across different languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->