### PR TITLE
ci(workflow): Update macOS runners for desktop build

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -74,9 +74,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Updates the `build-desktop-platforms` workflow to use newer macOS images.

- The runner for `x64` architecture is changed from `macos-13` to `macos-15-intel`.
- The runner for `arm64` architecture is changed from `macos-14` to `macos-latest`.