### PR TITLE
feat(i18n): Add Korean translation and localize theme options

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings-es.xml
@@ -189,4 +189,9 @@
 
     <string name="system_font">Fuente del sistema</string>
     <string name="system_font_description">Usa la fuente de tu dispositivo para mejor legibilidad</string>
+
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Oscuro</string>
+    <string name="theme_system">Sistema</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -189,4 +189,9 @@
 
     <string name="system_font">Police système</string>
     <string name="system_font_description">Utilisez la police de votre appareil pour une meilleure lisibilité</string>
+
+    <string name="theme_light">Clair</string>
+    <string name="theme_dark">Sombre</string>
+    <string name="theme_system">Système</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ja/values-ja.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/values-ja.xml
@@ -189,4 +189,9 @@
 
     <string name="system_font">システムフォント</string>
     <string name="system_font_description">デバイスのフォントを使用して読みやすさを向上</string>
+
+    <string name="theme_light">ライト</string>
+    <string name="theme_dark">ダーク</string>
+    <string name="theme_system">システム</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-kr/strings-kr.xml
+++ b/composeApp/src/commonMain/composeResources/values-kr/strings-kr.xml
@@ -1,0 +1,248 @@
+<resources>
+
+    <!-- Apps feature - App -->
+    <string name="app_name">GitHub Store</string>
+
+    <!-- Apps feature - Navigation / Top bar -->
+    <string name="installed_apps">설치된 앱</string>
+    <string name="navigate_back">뒤로 이동</string>
+    <string name="check_for_updates">업데이트 확인</string>
+
+    <!-- Apps feature - Errors / messages -->
+    <string name="cannot_launch">%1$s을(를) 실행할 수 없습니다</string>
+    <string name="failed_to_open">%1$s을(를) 열지 못했습니다</string>
+    <string name="failed_to_update">%1$s 업데이트 실패: %2$s</string>
+    <string name="update_all_failed">모두 업데이트 실패: %1$s</string>
+    <string name="all_apps_updated_successfully">모든 앱이 성공적으로 업데이트되었습니다</string>
+    <string name="no_updates_available">사용 가능한 업데이트가 없습니다</string>
+
+    <!-- Apps feature - Search -->
+    <string name="search_your_apps">앱 검색</string>
+    <string name="no_apps_found">앱을 찾을 수 없습니다</string>
+
+    <!-- Apps feature - Actions -->
+    <string name="update_all">모두 업데이트</string>
+    <string name="update">업데이트</string>
+    <string name="open">열기</string>
+    <string name="cancel">취소</string>
+
+    <!-- Apps feature - Update states -->
+    <string name="checking">확인 중…</string>
+    <string name="updated_successfully">성공적으로 업데이트됨</string>
+    <string name="error_with_message">오류: %1$s</string>
+
+    <!-- Apps feature - Update all progress -->
+    <string name="updating_x_of_y">%2$d개 중 %1$d개 업데이트 중</string>
+    <string name="currently_updating">현재 업데이트 중: %1$s</string>
+
+    <!-- Auth general -->
+    <string name="waiting_for_authorization">인증 대기 중…</string>
+    <string name="signed_in">로그인 완료!</string>
+    <string name="redirecting_message">이제 앱을 사용할 수 있습니다. 이동 중…</string>
+    <string name="try_again">다시 시도</string>
+
+    <!-- Errors -->
+    <string name="auth_error_with_message">오류: %1$s</string>
+
+    <!-- Device flow -->
+    <string name="enter_code_on_github">GitHub에 다음 코드를 입력하세요:</string>
+    <string name="copy_code">코드 복사</string>
+    <string name="open_github">GitHub 열기</string>
+
+    <!-- Logged out -->
+    <string name="unlock_full_experience">전체\n기능 잠금 해제</string>
+
+    <string name="more_requests">더 많은 요청</string>
+    <string name="more_requests_description">
+        로그인하여 API 요청 한도를 늘리고 중단 없이 사용하세요.
+    </string>
+
+    <string name="sign_in_with_github">GitHub로 로그인</string>
+
+    <string name="error_cancelled">취소됨</string>
+    <string name="error_unknown">알 수 없는 오류</string>
+
+    <string name="language_label">언어:</string>
+
+    <string name="discover_repositories">저장소 탐색</string>
+    <string name="search_repositories_hint">저장소, 설명 검색…</string>
+
+    <!-- Filters -->
+    <string name="filter_by_language">언어로 필터링</string>
+
+    <!-- Results -->
+    <string name="results_found">%1$d개의 결과를 찾았습니다</string>
+
+    <!-- Sorting -->
+    <string name="sort_by">정렬 기준</string>
+    <string name="close">닫기</string>
+
+    <string name="sort_most_stars">별 많은 순</string>
+    <string name="sort_most_forks">포크 많은 순</string>
+    <string name="sort_best_match">최적의 결과</string>
+
+    <!-- Programming languages -->
+    <string name="language_all">모든 언어</string>
+    <string name="language_kotlin">Kotlin</string>
+    <string name="language_java">Java</string>
+    <string name="language_javascript">JavaScript</string>
+    <string name="language_typescript">TypeScript</string>
+    <string name="language_python">Python</string>
+    <string name="language_swift">Swift</string>
+    <string name="language_rust">Rust</string>
+    <string name="language_go">Go</string>
+    <string name="language_csharp">C#</string>
+    <string name="language_cpp">C++</string>
+    <string name="language_c">C</string>
+    <string name="language_dart">Dart</string>
+    <string name="language_ruby">Ruby</string>
+    <string name="language_php">PHP</string>
+
+    <string name="search_failed">검색 실패</string>
+    <string name="no_repositories_found">저장소를 찾을 수 없습니다</string>
+
+    <!-- Settings -->
+    <string name="settings_title">설정</string>
+
+    <!-- Sections -->
+    <string name="section_appearance">외관</string>
+    <string name="section_about">정보</string>
+
+    <!-- Appearance -->
+    <string name="theme_color">테마 색상</string>
+    <string name="amoled_black_theme">AMOLED 블랙 테마</string>
+    <string name="amoled_black_description">다크 모드용 순수 블랙 배경</string>
+    <string name="selected_color">선택된 색상: %1$s</string>
+
+    <!-- About -->
+    <string name="version">버전</string>
+    <string name="help_support">도움말 및 지원</string>
+
+    <!-- Account -->
+    <string name="logout">로그아웃</string>
+
+    <!-- Snackbar -->
+    <string name="logout_success">성공적으로 로그아웃되었습니다. 이동 중...</string>
+
+    <!-- Dialog -->
+    <string name="warning">경고!</string>
+    <string name="logout_confirmation">정말 로그아웃하시겠습니까?</string>
+
+    <!-- Theme names -->
+    <string name="theme_dynamic">동적</string>
+    <string name="theme_ocean">오션</string>
+    <string name="theme_purple">퍼플</string>
+    <string name="theme_forest">포레스트</string>
+    <string name="theme_slate">슬레이트</string>
+    <string name="theme_amber">앰버</string>
+
+    <!-- Navigation & actions -->
+    <string name="open_repository">저장소 열기</string>
+    <string name="open_in_browser">브라우저에서 열기</string>
+    <string name="cancel_download">다운로드 취소</string>
+    <string name="show_install_options">설치 옵션 보기</string>
+
+    <!-- Errors & states -->
+    <string name="error_loading_details">상세 정보를 불러오는 중 오류 발생</string>
+    <string name="retry">다시 시도</string>
+    <string name="no_description">설명이 없습니다.</string>
+    <string name="no_release_notes">릴리스 노트가 없습니다.</string>
+
+    <!-- Headers -->
+    <string name="about_this_app">이 앱 정보</string>
+    <string name="install_logs">설치 로그</string>
+    <string name="author">작성자</string>
+    <string name="whats_new">새로운 기능</string>
+
+    <!-- Install status -->
+    <string name="installed">설치됨</string>
+    <string name="update_available">업데이트 가능</string>
+    <string name="not_available">사용 불가</string>
+    <string name="install_latest">최신 버전 설치</string>
+    <string name="reinstall">재설치</string>
+    <string name="update_app">앱 업데이트</string>
+
+    <!-- Download stages -->
+    <string name="downloading">다운로드 중</string>
+    <string name="updating">업데이트 중</string>
+    <string name="verifying">검증 중</string>
+    <string name="installing">설치 중</string>
+
+    <!-- Install helpers -->
+    <string name="open_in_obtainium">Obtainium에서 열기</string>
+    <string name="obtainium_description">업데이트 자동 관리</string>
+    <string name="inspect_with_appmanager">AppManager로 검사</string>
+    <string name="appmanager_description">권한, 트래커 및 보안 확인</string>
+
+    <!-- Author -->
+    <string name="profile">프로필</string>
+
+    <!-- Stats -->
+    <string name="forks">포크</string>
+    <string name="stars">별</string>
+    <string name="issues">이슈</string>
+
+    <!-- Misc -->
+    <string name="by_author">%1$s 작성</string>
+    <string name="installed_version">• 설치됨: %1$s</string>
+    <string name="architecture_compatible">아키텍처 호환</string>
+    <string name="update_to_version">%1$s(으)로 업데이트</string>
+
+    <!-- General -->
+    <string name="error_load_details">상세 정보를 불러오지 못했습니다</string>
+    <string name="installer_saved_downloads">설치 파일이 다운로드 폴더에 저장되었습니다</string>
+
+    <!-- Download / install states -->
+    <string name="log_download_started">다운로드 시작됨</string>
+    <string name="log_downloaded">다운로드 완료</string>
+    <string name="log_update_started">업데이트 시작됨</string>
+    <string name="log_installed">설치됨</string>
+    <string name="log_updated">업데이트됨</string>
+    <string name="log_cancelled">취소됨</string>
+    <string name="log_install_started">설치 시작됨</string>
+    <string name="log_error">오류</string>
+    <string name="log_error_with_message">오류: %1$s</string>
+
+    <!-- External tools -->
+    <string name="log_prepare_appmanager">AppManager 준비 중</string>
+    <string name="log_opened_appmanager">AppManager에서 열림</string>
+
+    <!-- Errors -->
+    <string name="error_generic">오류: %1$s</string>
+    <string name="error_asset_not_supported">.%1$s 파일 형식은 지원되지 않습니다</string>
+    <string name="error_file_not_found">다운로드된 파일을 찾을 수 없습니다</string>
+
+    <string name="home_category_trending">인기</string>
+    <string name="home_category_new">신규</string>
+    <string name="home_category_recently_updated">최근 업데이트</string>
+
+    <string name="home_finding_repositories">저장소를 찾는 중...</string>
+    <string name="home_loading_more">더 불러오는 중...</string>
+    <string name="home_no_more_repositories">더 이상 저장소가 없습니다</string>
+    <string name="home_retry">다시 시도</string>
+    <string name="home_failed_to_load_repositories">저장소를 불러오지 못했습니다</string>
+    <string name="home_view_details">상세 보기</string>
+
+    <string name="updated_just_now">방금 업데이트됨</string>
+    <string name="updated_hours_ago">%1$d시간 전 업데이트됨</string>
+    <string name="updated_yesterday">어제 업데이트됨</string>
+    <string name="updated_days_ago">%1$d일 전 업데이트됨</string>
+    <string name="updated_on_date">%1$s에 업데이트됨</string>
+
+    <string name="rate_limit_exceeded">요청 한도 초과</string>
+    <string name="rate_limit_used_all">%1$d개의 API 요청을 모두 사용했습니다.</string>
+    <string name="rate_limit_used_all_free">%1$d개의 무료 API 요청을 모두 사용했습니다.</string>
+    <string name="rate_limit_resets_in_minutes">%1$d분 후 초기화</string>
+    <string name="rate_limit_tip_sign_in">💡 로그인하면 시간당 60회 대신 5,000회 요청을 사용할 수 있습니다!</string>
+    <string name="rate_limit_sign_in">로그인</string>
+    <string name="rate_limit_ok">확인</string>
+    <string name="rate_limit_close">닫기</string>
+
+    <string name="system_font">시스템 글꼴</string>
+    <string name="system_font_description">가독성을 위해 기기 글꼴과 일치</string>
+
+    <string name="theme_light">라이트</string>
+    <string name="theme_dark">다크</string>
+    <string name="theme_system">시스템</string>
+
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -207,4 +207,9 @@
 
     <string name="system_font">Системный шрифт</string>
     <string name="system_font_description">Используйте шрифт вашего устройства для лучшей читаемости</string>
+
+    <string name="theme_light">Светлая</string>
+    <string name="theme_dark">Тёмная</string>
+    <string name="theme_system">Системная</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -190,4 +190,9 @@
 
     <string name="system_font">系统字体</string>
     <string name="system_font_description">使用设备字体以提高可读性</string>
+
+    <string name="theme_light">浅色</string>
+    <string name="theme_dark">深色</string>
+    <string name="theme_system">跟随系统</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -242,4 +242,9 @@
 
     <string name="system_font">System font</string>
     <string name="system_font_description">Match your device's font for better readability</string>
+
+    <string name="theme_light">Light</string>
+    <string name="theme_dark">Dark</string>
+    <string name="theme_system">System</string>
+
 </resources>

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/feature/settings/presentation/components/sections/Appearance.kt
@@ -66,6 +66,9 @@ import githubstore.composeapp.generated.resources.selected_color
 import githubstore.composeapp.generated.resources.system_font
 import githubstore.composeapp.generated.resources.system_font_description
 import githubstore.composeapp.generated.resources.theme_color
+import githubstore.composeapp.generated.resources.theme_dark
+import githubstore.composeapp.generated.resources.theme_light
+import githubstore.composeapp.generated.resources.theme_system
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.githubstore.core.presentation.model.AppTheme
 import zed.rainxch.githubstore.core.presentation.theme.isDynamicColorAvailable
@@ -153,7 +156,7 @@ private fun ThemeSelectionCard(
         ) {
             ThemeModeOption(
                 icon = Icons.Default.LightMode,
-                label = "Light",
+                label = stringResource(Res.string.theme_light),
                 isSelected = isDarkTheme != null && !isDarkTheme,
                 onClick = { onDarkThemeChange(false) },
                 modifier = Modifier.weight(1f)
@@ -161,7 +164,7 @@ private fun ThemeSelectionCard(
 
             ThemeModeOption(
                 icon = Icons.Default.DarkMode,
-                label = "Dark",
+                label = stringResource(Res.string.theme_dark),
                 isSelected = isDarkTheme == true,
                 onClick = { onDarkThemeChange(true) },
                 modifier = Modifier.weight(1f)
@@ -169,7 +172,7 @@ private fun ThemeSelectionCard(
 
             ThemeModeOption(
                 icon = Icons.Default.Colorize,
-                label = "System",
+                label = stringResource(Res.string.theme_system),
                 isSelected = isDarkTheme == null,
                 onClick = { onDarkThemeChange(null) },
                 modifier = Modifier.weight(1f)


### PR DESCRIPTION
This commit introduces a complete Korean translation for the application by adding the `strings-kr.xml` file.

Additionally, it localizes the theme mode options ("Light", "Dark", "System") in the settings screen. The corresponding string resources have been added to all existing language files (English, Chinese, French, Japanese, Russian, Spanish) and the new Korean file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added multilingual support for theme selection options across Spanish, French, Japanese, Korean, Russian, and Simplified Chinese locales.
  * Theme preference labels (Light, Dark, System) now display in the user's preferred language within the appearance settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->