### PR TITLE
feat(download): Add file validation and cleanup

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/services/Downloader.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/data/services/Downloader.kt
@@ -1,6 +1,7 @@
 package zed.rainxch.githubstore.core.data.services
 
 import kotlinx.coroutines.flow.Flow
+import zed.rainxch.githubstore.core.domain.model.DownloadedFile
 import zed.rainxch.githubstore.feature.details.domain.model.DownloadProgress
 
 interface Downloader {
@@ -12,4 +13,10 @@ interface Downloader {
     suspend fun getDownloadedFilePath(fileName: String): String?
 
     suspend fun cancelDownload(fileName: String): Boolean
+    suspend fun listDownloadedFiles(): List<DownloadedFile>
+    suspend fun getLatestDownload(): DownloadedFile?
+    suspend fun getLatestDownloadForAssets(assetNames: List<String>): DownloadedFile?
+
+    // Add this new method
+    suspend fun getFileSize(filePath: String): Long?
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/domain/model/DownloadedFile.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/core/domain/model/DownloadedFile.kt
@@ -1,0 +1,8 @@
+package zed.rainxch.githubstore.core.domain.model
+
+data class DownloadedFile(
+    val fileName: String,
+    val filePath: String,
+    val fileSizeBytes: Long,
+    val downloadedAt: Long
+)

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/services/DesktopDownloader.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/services/DesktopDownloader.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import zed.rainxch.githubstore.core.domain.model.DownloadedFile
 import zed.rainxch.githubstore.feature.details.domain.model.DownloadProgress
 import java.io.File
 import java.io.FileOutputStream
@@ -23,7 +24,7 @@ class DesktopDownloader(
 
     override fun download(url: String, suggestedFileName: String?): Flow<DownloadProgress> = channelFlow {
         withContext(Dispatchers.IO) {
-            val dir = File(files.userDownloadsDir())
+            val dir = File(files.appDownloadsDir())
             if (!dir.exists()) dir.mkdirs()
 
             val safeName = (suggestedFileName?.takeIf { it.isNotBlank() }
@@ -82,7 +83,7 @@ class DesktopDownloader(
     }
 
     override suspend fun saveToFile(url: String, suggestedFileName: String?): String = withContext(Dispatchers.IO) {
-        val dir = File(files.userDownloadsDir())
+        val dir = File(files.appDownloadsDir()) // Changed from userDownloadsDir()
         val safeName = (suggestedFileName?.takeIf { it.isNotBlank() }
             ?: url.substringAfterLast('/')
                 .ifBlank { "asset-${UUID.randomUUID()}" })
@@ -101,7 +102,7 @@ class DesktopDownloader(
     }
 
     override suspend fun getDownloadedFilePath(fileName: String): String? = withContext(Dispatchers.IO) {
-        val dir = File(files.userDownloadsDir())
+        val dir = File(files.appDownloadsDir()) // Changed from userDownloadsDir()
         val file = File(dir, fileName)
 
         if (file.exists() && file.length() > 0) {
@@ -112,13 +113,13 @@ class DesktopDownloader(
     }
 
     override suspend fun cancelDownload(fileName: String): Boolean = withContext(Dispatchers.IO) {
-        val dir = File(files.userDownloadsDir())
+        val dir = File(files.appDownloadsDir()) // Changed from userDownloadsDir()
         val file = File(dir, fileName)
 
         if (file.exists()) {
             val deleted = file.delete()
             if (deleted) {
-                Logger.d { "Deleted file from Downloads: ${file.absolutePath}" }
+                Logger.d { "Deleted file from app Downloads: ${file.absolutePath}" }
             } else {
                 Logger.w { "Failed to delete file: ${file.absolutePath}" }
             }
@@ -127,6 +128,52 @@ class DesktopDownloader(
             false
         }
     }
+
+    override suspend fun listDownloadedFiles(): List<DownloadedFile> = withContext(Dispatchers.IO) {
+        val dir = File(files.appDownloadsDir()) // Already correct
+        if (!dir.exists()) return@withContext emptyList()
+
+        dir.listFiles()
+            ?.filter { it.isFile && it.length() > 0 }
+            ?.map { file ->
+                DownloadedFile(
+                    fileName = file.name,
+                    filePath = file.absolutePath,
+                    fileSizeBytes = file.length(),
+                    downloadedAt = file.lastModified()
+                )
+            }
+            ?.sortedByDescending { it.downloadedAt }
+            ?: emptyList()
+    }
+
+    override suspend fun getLatestDownload(): DownloadedFile? = withContext(Dispatchers.IO) {
+        listDownloadedFiles().firstOrNull()
+    }
+
+    override suspend fun getFileSize(filePath: String): Long? = withContext(Dispatchers.IO) {
+        try {
+            val file = File(filePath)
+            if (file.exists() && file.isFile) {
+                file.length()
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            Logger.e { "Failed to get file size for $filePath: ${e.message}" }
+            null
+        }
+    }
+
+    override suspend fun getLatestDownloadForAssets(assetNames: List<String>): DownloadedFile? =
+        withContext(Dispatchers.IO) {
+            listDownloadedFiles()
+                .firstOrNull { downloadedFile ->
+                    assetNames.any { assetName ->
+                        downloadedFile.fileName == assetName
+                    }
+                }
+        }
 
     companion object {
         private const val DEFAULT_BUFFER_SIZE = 8 * 1024


### PR DESCRIPTION
This commit introduces several enhancements to the download functionality:

-   **File Validation:** Before starting a new download, the system now checks if the file already exists. If it does, it validates the file size against the expected size. The download is skipped if the sizes match, preventing redundant downloads.
-   **Post-Download Verification:** After a download completes, the size of the downloaded file is verified to ensure its integrity.
-   **Automatic Cleanup:** The downloads directory is now automatically cleaned of files that do not belong to the current repository's release assets.
-   **Code Refactoring:**
    -   A new `DownloadedFile` data class has been created.
    -   The `Downloader` interface and its implementations (`AndroidDownloader`, `DesktopDownloader`) have been updated to support listing downloaded files, getting file sizes, and changing the download directory from the user's public downloads to a dedicated application downloads directory.
    -   The download cancellation logic in `DetailsViewModel`'s `onCleared` method has been simplified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced download management with intelligent file validation; existing downloads are reused if valid instead of being re-downloaded.
  * Automatic cleanup of downloads from other repositories to free up storage space.

* **Bug Fixes**
  * Improved file integrity verification to ensure downloaded assets match expected sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->