### PR TITLE
feat(network): Add proxy setting to HttpClient

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/network/GitHubClient.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/network/GitHubClient.kt
@@ -5,6 +5,8 @@ import githubstore.composeapp.generated.resources.Res
 import githubstore.composeapp.generated.resources.rate_limit_exceeded
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.engine.ProxyBuilder
+import io.ktor.client.engine.http
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.HttpRequestRetry
@@ -35,6 +37,10 @@ fun buildGitHubHttpClient(
             requestTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
             connectTimeoutMillis = 30_000
             socketTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
+        }
+
+        engine {
+            // proxy = ProxyBuilder.http("")
         }
 
         install(HttpRequestRetry) {


### PR DESCRIPTION
Adds a commented-out proxy configuration block to the Ktor `HttpClient` engine settings. This allows for easier enabling and configuration of an HTTP proxy for debugging or network testing purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure updates to network configuration. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->