### PR TITLE
feat(linux): Prioritize AppImage for downloads

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/services/DesktopInstaller.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/core/data/services/DesktopInstaller.kt
@@ -78,8 +78,8 @@ class DesktopInstaller(
             PlatformType.MACOS -> listOf(".dmg", ".pkg")
             PlatformType.LINUX -> {
                 when (linuxPackageType) {
-                    LinuxPackageType.DEB -> listOf(".deb", ".appimage", ".rpm")
-                    LinuxPackageType.RPM -> listOf(".rpm", ".appimage", ".deb")
+                    LinuxPackageType.DEB -> listOf(".appimage", ".deb", ".rpm")
+                    LinuxPackageType.RPM -> listOf(".appimage", ".rpm", ".deb")
                     LinuxPackageType.UNIVERSAL -> listOf(".appimage", ".deb", ".rpm")
                 }
             }


### PR DESCRIPTION
On Linux, the installer now prioritizes `.appimage` files over `.deb` and `.rpm` packages when searching for downloadable assets. The fallback order for DEB-based systems is now `.appimage`, `.deb`, then `.rpm`, and for RPM-based systems, it is `.appimage`, `.rpm`, then `.deb`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package format selection logic for Linux installations to optimize system compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->