### PR TITLE
docs: Add a warning about Android's potential lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,10 @@
 GitHub Store is a cross-platform app store for GitHub releases, designed to simplify discovering and installing open-source software. It automatically detects installable binaries (APK, EXE, DMG, AppImage, DEB, RPM), provides one-click installation, tracks updates, and presents repository information in a clean, app-store style interface.
 
 Built with Kotlin Multiplatform and Compose Multiplatform for Android and Desktop platforms.
+</div>
 
 > [!CAUTION]
 > Free and Open-Source Android is under threat. Google will turn Android into a locked-down platform, restricting your essential freedom to install apps of your choice. Make your voice heard – [LINK](https://keepandroidopen.org/).
-
-</div>
 
 <p align="middle">
     <img src="./screenshots/banner.jpeg" width="99%" />


### PR DESCRIPTION
This commit updates the README.md file to include a caution block about the potential threat to the free and open-source nature of Android. It also includes a link to encourage users to voice their concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CAUTION note with a link under Project Overview in the README to clarify Android platform considerations.
  * Cleaned up stray formatting (removed an orphan dash) to improve readability.
  * Outcome: clearer guidance for Android-related usage and tidier project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->