### PR TITLE
feat(android): Implement native splash screen

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -24,7 +24,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar"
+        android:theme="@style/Theme.GitHubStore.Splash"
         android:usesCleartextTraffic="false"
         tools:targetApi="29">
 

--- a/composeApp/src/androidMain/res/drawable/ic_splash.xml
+++ b/composeApp/src/androidMain/res/drawable/ic_splash.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_logo"
+    android:inset="48dp"
+    />

--- a/composeApp/src/androidMain/res/values/colors.xml
+++ b/composeApp/src/androidMain/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#101010</color>
 </resources>

--- a/composeApp/src/androidMain/res/values/splash.xml
+++ b/composeApp/src/androidMain/res/values/splash.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.GitHubStore.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash</item>
+        <item name="windowSplashScreenBackground">@color/ic_launcher_background</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat.DayNight.NoActionBar</item>
+    </style>
+</resources>


### PR DESCRIPTION
This commit introduces a native splash screen on Android using the `SplashScreen` API. It replaces the default blank window with a themed splash screen that displays the app logo.

- **feat(android)**: Added `splash.xml` to define the `Theme.GitHubStore.Splash` theme, which sets the splash screen icon and background color.
- **feat(android)**: Created `ic_splash.xml` drawable to display the app logo with appropriate insets on the splash screen.
- **style(android)**: Updated the `ic_launcher_background` color to `#101010` in `colors.xml`.
- **refactor(android)**: Updated `AndroidManifest.xml` to apply the new `Theme.GitHubStore.Splash` as the application's theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the splash screen with an animated logo and custom visual theme
  * Updated the launcher background to a darker color scheme for improved visual harmony and enhanced contrast
  * Configured a new application theme that applies after the splash screen is dismissed, ensuring consistent appearance throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->