### PR TITLE
Update AppImage icon source path in build workflow

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -250,7 +250,7 @@ jobs:
           EOF
 
           # Copy icon to AppDir root (required by appimagetool)
-          cp composeApp/logo/app_icon.png "$APPDIR/github-store.png"
+          cp "$APPDIR/lib/GitHub-Store.png" "$APPDIR/github-store.png"
 
           # Build .AppImage
           OUTPUT="composeApp/build/compose/binaries/main/GitHub-Store-x86_64.AppImage"


### PR DESCRIPTION
Modified the build script to copy the application icon from the AppDir lib directory instead of the composeApp logo directory during the AppImage creation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux AppImage build process to use the app icon from the correct source location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->