### PR TITLE
Refactor rate limit time calculation and organize imports

### DIFF
--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/RateLimitInfo.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/RateLimitInfo.kt
@@ -3,6 +3,7 @@ package zed.rainxch.core.domain.model
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 data class RateLimitInfo(
     val limit: Int,
@@ -14,8 +15,8 @@ data class RateLimitInfo(
         get() = remaining == 0
 
     fun timeUntilReset(): Duration {
-        val diff = resetTimestamp - Clock.System.now().toEpochMilliseconds()
-        return diff.seconds.coerceAtLeast(Duration.ZERO)
+        val reset = Instant.fromEpochSeconds(resetTimestamp)
+        return (reset - Clock.System.now()).coerceAtLeast(Duration.ZERO)
     }
 
     fun isCurrentlyLimited(): Boolean {

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/TimeFormatters.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/TimeFormatters.kt
@@ -1,11 +1,11 @@
 package zed.rainxch.core.presentation.utils
 
 import androidx.compose.runtime.Composable
-import zed.rainxch.githubstore.core.presentation.res.*
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.githubstore.core.presentation.res.*
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days


### PR DESCRIPTION
- Update `RateLimitInfo.timeUntilReset()` to use `Instant` and `Clock.System.now()` for more accurate duration calculation.
- Fix an issue where `resetTimestamp` was treated as milliseconds instead of seconds.
- Organize and clean up imports in `TimeFormatters.kt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal time calculation logic for rate limit handling using updated time representations.
  * Code organization and import structure optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->