### PR TITLE
Add GitHub action to automate WinGet publishing

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,26 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish-msi:
+    name: Publish MSI to WinGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: zed.rainxch.githubstore
+          installers-regex: '\.msi$'
+          token: ${{ secrets.WINGET_TOKEN }}
+
+  publish-exe:
+    name: Publish EXE to WinGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: zed.rainxch.githubstore
+          installers-regex: '\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
- Create `.github/workflows/winget-publish.yml` to trigger on new releases.
- Implement jobs to publish both MSI and EXE installers using the `winget-releaser` action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated publishing of releases to WinGet, a Windows package manager, for both MSI and EXE installers when new releases are made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->