### PR TITLE
The diffs introduce a robust background download and install orchestr…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(./gradlew :composeApp:assembleDebug :composeApp:jvmJar)",
       "Bash(./gradlew :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid)",
       "Bash(./gradlew :feature:details:presentation:compileDebugKotlinAndroid)",
-      "Bash(./gradlew :feature:apps:presentation:compileDebugKotlinAndroid)"
+      "Bash(./gradlew :feature:apps:presentation:compileDebugKotlinAndroid)",
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,10 @@
       "Bash(grep -r \"\\\\.FLATPAK\\\\|Flatpak\\\\|flatpak\" . --include=*.kt)",
       "Bash(./gradlew :composeApp:assembleDebug)",
       "Bash(./gradlew :composeApp:jvmJar)",
-      "Bash(./gradlew :composeApp:assembleDebug :composeApp:jvmJar)"
+      "Bash(./gradlew :composeApp:assembleDebug :composeApp:jvmJar)",
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid)",
+      "Bash(./gradlew :feature:details:presentation:compileDebugKotlinAndroid)",
+      "Bash(./gradlew :feature:apps:presentation:compileDebugKotlinAndroid)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "Bash(./gradlew :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid)",
       "Bash(./gradlew :feature:details:presentation:compileDebugKotlinAndroid)",
       "Bash(./gradlew :feature:apps:presentation:compileDebugKotlinAndroid)",
-      "Bash(./gradlew :core:data:compileDebugKotlinAndroid)"
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid)",
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid :feature:details:presentation:compileDebugKotlinAndroid :feature:apps:presentation:compileDebugKotlinAndroid)",
+      "Bash(./gradlew :composeApp:compileDebugKotlinAndroid :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid :feature:details:presentation:compileDebugKotlinAndroid :feature:apps:presentation:compileDebugKotlinAndroid)"
     ]
   }
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -63,6 +63,18 @@
                     android:scheme="githubstore" />
             </intent-filter>
 
+            <!-- Pending-install notification deep link -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="apps"
+                    android:scheme="githubstore" />
+            </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/composeApp/src/androidMain/res/xml/filepaths.xml
+++ b/composeApp/src/androidMain/res/xml/filepaths.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Public Downloads/GitHub Store folder (visible in file managers) -->
-    <external-path
-        name="ghs_downloads"
-        path="Download/GitHub Store/" />
-
-    <!-- Legacy app-private downloads (for migration) -->
+    <!-- App-private downloads (no permissions required) -->
     <external-files-path
-        name="ghs_legacy_downloads"
-        path="/" />
+        name="ghs_downloads"
+        path="Download/" />
+
+    <!-- Internal fallback when external files dir is unavailable -->
+    <files-path
+        name="ghs_internal_downloads"
+        path="downloads/" />
 
     <cache-path
         name="exports"

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -41,6 +41,19 @@ fun App(deepLinkUri: String? = null) {
                     )
                 }
 
+                DeepLinkDestination.Apps -> {
+                    // Pending-install notification dropped us here.
+                    // Navigate to the apps tab so the user can finish
+                    // the deferred install from the row.
+                    navController.navigate(GithubStoreGraph.AppsScreen) {
+                        popUpTo(GithubStoreGraph.HomeScreen) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+
                 DeepLinkDestination.None -> {
                     // ignore unrecognized deep links
                 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/deeplink/DeepLinkParser.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/deeplink/DeepLinkParser.kt
@@ -6,6 +6,13 @@ sealed interface DeepLinkDestination {
         val repo: String,
     ) : DeepLinkDestination
 
+    /**
+     * Deep link to the apps tab. Used by the pending-install
+     * notification to bring the user back to the row where they can
+     * complete a deferred install.
+     */
+    data object Apps : DeepLinkDestination
+
     data object None : DeepLinkDestination
 }
 
@@ -52,6 +59,14 @@ object DeepLinkParser {
 
     fun parse(uri: String): DeepLinkDestination {
         return when {
+            // Pending-install notification opens the apps tab. No path
+            // segments — the deferred install is keyed by package name
+            // on the row itself, so the link only needs to bring the
+            // user to the right tab.
+            uri == "githubstore://apps" || uri.startsWith("githubstore://apps?") -> {
+                DeepLinkDestination.Apps
+            }
+
             uri.startsWith("githubstore://repo/") -> {
                 val path = uri.removePrefix("githubstore://repo/")
                 val decoded = urlDecode(path)

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/deeplink/DeepLinkParser.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/deeplink/DeepLinkParser.kt
@@ -63,7 +63,7 @@ object DeepLinkParser {
             // segments — the deferred install is keyed by package name
             // on the row itself, so the link only needs to bring the
             // user to the right tab.
-            uri == "githubstore://apps" || uri.startsWith("githubstore://apps?") -> {
+            uri == "githubstore://apps" || uri == "githubstore://apps/" || uri.startsWith("githubstore://apps?") -> {
                 DeepLinkDestination.Apps
             }
 

--- a/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/13.json
+++ b/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/13.json
@@ -1,0 +1,646 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "2f803fb63da95fc8cbf638483ce7bcec",
+    "entities": [
+      {
+        "tableName": "installed_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `installedVersion` TEXT NOT NULL, `installedAssetName` TEXT, `installedAssetUrl` TEXT, `latestVersion` TEXT, `latestAssetName` TEXT, `latestAssetUrl` TEXT, `latestAssetSize` INTEGER, `appName` TEXT NOT NULL, `installSource` TEXT NOT NULL, `signingFingerprint` TEXT, `installedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, `lastUpdatedAt` INTEGER NOT NULL, `isUpdateAvailable` INTEGER NOT NULL, `updateCheckEnabled` INTEGER NOT NULL, `releaseNotes` TEXT, `systemArchitecture` TEXT NOT NULL, `fileExtension` TEXT NOT NULL, `isPendingInstall` INTEGER NOT NULL, `installedVersionName` TEXT, `installedVersionCode` INTEGER NOT NULL, `latestVersionName` TEXT, `latestVersionCode` INTEGER, `latestReleasePublishedAt` TEXT, `includePreReleases` INTEGER NOT NULL, `assetFilterRegex` TEXT, `fallbackToOlderReleases` INTEGER NOT NULL DEFAULT 0, `preferredAssetVariant` TEXT, `preferredVariantStale` INTEGER NOT NULL DEFAULT 0, `preferredAssetTokens` TEXT, `assetGlobPattern` TEXT, `pickedAssetIndex` INTEGER, `pickedAssetSiblingCount` INTEGER, `pendingInstallFilePath` TEXT, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersion",
+            "columnName": "installedVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAssetName",
+            "columnName": "installedAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAssetUrl",
+            "columnName": "installedAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetName",
+            "columnName": "latestAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetUrl",
+            "columnName": "latestAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetSize",
+            "columnName": "latestAssetSize",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSource",
+            "columnName": "installSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signingFingerprint",
+            "columnName": "signingFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpdateAvailable",
+            "columnName": "isUpdateAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateCheckEnabled",
+            "columnName": "updateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "releaseNotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "systemArchitecture",
+            "columnName": "systemArchitecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileExtension",
+            "columnName": "fileExtension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPendingInstall",
+            "columnName": "isPendingInstall",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersionName",
+            "columnName": "installedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedVersionCode",
+            "columnName": "installedVersionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestVersionName",
+            "columnName": "latestVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionCode",
+            "columnName": "latestVersionCode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestReleasePublishedAt",
+            "columnName": "latestReleasePublishedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includePreReleases",
+            "columnName": "includePreReleases",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetFilterRegex",
+            "columnName": "assetFilterRegex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fallbackToOlderReleases",
+            "columnName": "fallbackToOlderReleases",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetVariant",
+            "columnName": "preferredAssetVariant",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preferredVariantStale",
+            "columnName": "preferredVariantStale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetTokens",
+            "columnName": "preferredAssetTokens",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assetGlobPattern",
+            "columnName": "assetGlobPattern",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickedAssetIndex",
+            "columnName": "pickedAssetIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pickedAssetSiblingCount",
+            "columnName": "pickedAssetSiblingCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingInstallFilePath",
+            "columnName": "pendingInstallFilePath",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "favorite_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "update_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL, `appName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoName` TEXT NOT NULL, `fromVersion` TEXT NOT NULL, `toVersion` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `updateSource` TEXT NOT NULL, `success` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromVersion",
+            "columnName": "fromVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toVersion",
+            "columnName": "toVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateSource",
+            "columnName": "updateSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "starred_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `stargazersCount` INTEGER NOT NULL, `forksCount` INTEGER NOT NULL, `openIssuesCount` INTEGER NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `starredAt` INTEGER, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stargazersCount",
+            "columnName": "stargazersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forksCount",
+            "columnName": "forksCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openIssuesCount",
+            "columnName": "openIssuesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "starredAt",
+            "columnName": "starredAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "cache_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `jsonData` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jsonData",
+            "columnName": "jsonData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "seen_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `seenAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL, PRIMARY KEY(`query`))",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2f803fb63da95fc8cbf638483ce7bcec')"
+    ]
+  }
+}

--- a/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/14.json
+++ b/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/14.json
@@ -1,0 +1,656 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "e3d0245a19c8fa17e003a7b48beddbbb",
+    "entities": [
+      {
+        "tableName": "installed_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `installedVersion` TEXT NOT NULL, `installedAssetName` TEXT, `installedAssetUrl` TEXT, `latestVersion` TEXT, `latestAssetName` TEXT, `latestAssetUrl` TEXT, `latestAssetSize` INTEGER, `appName` TEXT NOT NULL, `installSource` TEXT NOT NULL, `signingFingerprint` TEXT, `installedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, `lastUpdatedAt` INTEGER NOT NULL, `isUpdateAvailable` INTEGER NOT NULL, `updateCheckEnabled` INTEGER NOT NULL, `releaseNotes` TEXT, `systemArchitecture` TEXT NOT NULL, `fileExtension` TEXT NOT NULL, `isPendingInstall` INTEGER NOT NULL, `installedVersionName` TEXT, `installedVersionCode` INTEGER NOT NULL, `latestVersionName` TEXT, `latestVersionCode` INTEGER, `latestReleasePublishedAt` TEXT, `includePreReleases` INTEGER NOT NULL, `assetFilterRegex` TEXT, `fallbackToOlderReleases` INTEGER NOT NULL DEFAULT 0, `preferredAssetVariant` TEXT, `preferredVariantStale` INTEGER NOT NULL DEFAULT 0, `preferredAssetTokens` TEXT, `assetGlobPattern` TEXT, `pickedAssetIndex` INTEGER, `pickedAssetSiblingCount` INTEGER, `pendingInstallFilePath` TEXT, `pendingInstallVersion` TEXT, `pendingInstallAssetName` TEXT, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersion",
+            "columnName": "installedVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAssetName",
+            "columnName": "installedAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAssetUrl",
+            "columnName": "installedAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetName",
+            "columnName": "latestAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetUrl",
+            "columnName": "latestAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetSize",
+            "columnName": "latestAssetSize",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSource",
+            "columnName": "installSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signingFingerprint",
+            "columnName": "signingFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpdateAvailable",
+            "columnName": "isUpdateAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateCheckEnabled",
+            "columnName": "updateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "releaseNotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "systemArchitecture",
+            "columnName": "systemArchitecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileExtension",
+            "columnName": "fileExtension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPendingInstall",
+            "columnName": "isPendingInstall",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersionName",
+            "columnName": "installedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedVersionCode",
+            "columnName": "installedVersionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestVersionName",
+            "columnName": "latestVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionCode",
+            "columnName": "latestVersionCode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestReleasePublishedAt",
+            "columnName": "latestReleasePublishedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includePreReleases",
+            "columnName": "includePreReleases",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetFilterRegex",
+            "columnName": "assetFilterRegex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fallbackToOlderReleases",
+            "columnName": "fallbackToOlderReleases",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetVariant",
+            "columnName": "preferredAssetVariant",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preferredVariantStale",
+            "columnName": "preferredVariantStale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetTokens",
+            "columnName": "preferredAssetTokens",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assetGlobPattern",
+            "columnName": "assetGlobPattern",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickedAssetIndex",
+            "columnName": "pickedAssetIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pickedAssetSiblingCount",
+            "columnName": "pickedAssetSiblingCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingInstallFilePath",
+            "columnName": "pendingInstallFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstallVersion",
+            "columnName": "pendingInstallVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstallAssetName",
+            "columnName": "pendingInstallAssetName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "favorite_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "update_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL, `appName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoName` TEXT NOT NULL, `fromVersion` TEXT NOT NULL, `toVersion` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `updateSource` TEXT NOT NULL, `success` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromVersion",
+            "columnName": "fromVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toVersion",
+            "columnName": "toVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateSource",
+            "columnName": "updateSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "starred_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `stargazersCount` INTEGER NOT NULL, `forksCount` INTEGER NOT NULL, `openIssuesCount` INTEGER NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `starredAt` INTEGER, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stargazersCount",
+            "columnName": "stargazersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forksCount",
+            "columnName": "forksCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openIssuesCount",
+            "columnName": "openIssuesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "starredAt",
+            "columnName": "starredAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "cache_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `jsonData` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jsonData",
+            "columnName": "jsonData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "seen_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `seenAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL, PRIMARY KEY(`query`))",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e3d0245a19c8fa17e003a7b48beddbbb')"
+    ]
+  }
+}

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -14,6 +14,7 @@ import zed.rainxch.core.data.services.AndroidInstaller
 import zed.rainxch.core.data.services.AndroidInstallerInfoExtractor
 import zed.rainxch.core.data.services.AndroidLocalizationManager
 import zed.rainxch.core.data.services.AndroidPackageMonitor
+import zed.rainxch.core.data.services.AndroidPendingInstallNotifier
 import zed.rainxch.core.data.services.AndroidUpdateScheduleManager
 import zed.rainxch.core.data.services.FileLocationsProvider
 import zed.rainxch.core.data.services.LocalizationManager
@@ -28,6 +29,7 @@ import zed.rainxch.core.domain.network.Downloader
 import zed.rainxch.core.domain.system.Installer
 import zed.rainxch.core.domain.system.InstallerStatusProvider
 import zed.rainxch.core.domain.system.PackageMonitor
+import zed.rainxch.core.domain.system.PendingInstallNotifier
 import zed.rainxch.core.domain.system.UpdateScheduleManager
 import zed.rainxch.core.domain.utils.AppLauncher
 import zed.rainxch.core.domain.utils.BrowserHelper
@@ -81,6 +83,10 @@ actual val corePlatformModule =
 
         single<FileLocationsProvider> {
             AndroidFileLocationsProvider(context = get())
+        }
+
+        single<PendingInstallNotifier> {
+            AndroidPendingInstallNotifier(context = androidContext())
         }
 
         single<PackageMonitor> {

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
@@ -14,6 +14,8 @@ import zed.rainxch.core.data.local.db.migrations.MIGRATION_8_9
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_9_10
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_10_11
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_11_12
+import zed.rainxch.core.data.local.db.migrations.MIGRATION_12_13
+import zed.rainxch.core.data.local.db.migrations.MIGRATION_13_14
 
 fun initDatabase(context: Context): AppDatabase {
     val appContext = context.applicationContext
@@ -35,5 +37,7 @@ fun initDatabase(context: Context): AppDatabase {
             MIGRATION_9_10,
             MIGRATION_10_11,
             MIGRATION_11_12,
+            MIGRATION_12_13,
+            MIGRATION_13_14,
         ).build()
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_12_13.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_12_13.kt
@@ -1,0 +1,23 @@
+package zed.rainxch.core.data.local.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Adds `pendingInstallFilePath` to `installed_apps`.
+ *
+ * Set by `DefaultDownloadOrchestrator` when an
+ * `InstallPolicy.InstallWhileForeground` download finishes after the
+ * foreground screen has been destroyed. The apps list shows a
+ * "Ready to install" row with a one-tap install action when this is
+ * non-null. Cleared on successful install.
+ *
+ * Nullable, no default — existing rows have `null` and behave the
+ * same as before.
+ */
+val MIGRATION_12_13 =
+    object : Migration(12, 13) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE installed_apps ADD COLUMN pendingInstallFilePath TEXT")
+        }
+    }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_13_14.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_13_14.kt
@@ -1,0 +1,29 @@
+package zed.rainxch.core.data.local.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Adds version + asset name metadata for parked downloads to
+ * `installed_apps`:
+ *
+ *  - `pendingInstallVersion`: release tag of the version represented
+ *    by `pendingInstallFilePath`. Lets the Details screen detect
+ *    "the parked file matches the currently-selected release" and
+ *    skip re-downloading on install.
+ *  - `pendingInstallAssetName`: original (unscoped) asset filename
+ *    of the parked file. Pairs with `pendingInstallVersion` for the
+ *    Details-screen "ready to install" match.
+ *
+ * Both nullable, no default — existing rows have `null` for both
+ * and continue working unchanged (the apps list still shows
+ * "Ready to install" based on `pendingInstallFilePath` alone; only
+ * the Details-screen short-circuit needs the version match).
+ */
+val MIGRATION_13_14 =
+    object : Migration(13, 14) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE installed_apps ADD COLUMN pendingInstallVersion TEXT")
+            db.execSQL("ALTER TABLE installed_apps ADD COLUMN pendingInstallAssetName TEXT")
+        }
+    }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidFileLocationsProvider.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidFileLocationsProvider.kt
@@ -8,8 +8,8 @@ class AndroidFileLocationsProvider(
     private val context: Context,
 ) : zed.rainxch.core.data.services.FileLocationsProvider {
     override fun appDownloadsDir(): String {
-        val publicDownloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        val dir = File(publicDownloads, "GitHub Store")
+        val dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            ?: File(context.filesDir, "downloads")
         if (!dir.exists()) dir.mkdirs()
         return dir.absolutePath
     }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidFileLocationsProvider.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidFileLocationsProvider.kt
@@ -10,7 +10,9 @@ class AndroidFileLocationsProvider(
     override fun appDownloadsDir(): String {
         val dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
             ?: File(context.filesDir, "downloads")
-        if (!dir.exists()) dir.mkdirs()
+        if (!dir.exists() && !dir.mkdirs() && !dir.exists()) {
+            throw IllegalStateException("Failed to create downloads directory: ${dir.absolutePath}")
+        }
         return dir.absolutePath
     }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstallerInfoExtractor.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstallerInfoExtractor.kt
@@ -19,28 +19,13 @@ class AndroidInstallerInfoExtractor(
         withContext(Dispatchers.IO) {
             try {
                 val packageManager = context.packageManager
-                val flags =
-                    PackageManager.GET_META_DATA or
-                        PackageManager.GET_ACTIVITIES or
-                        GET_SIGNING_CERTIFICATES
 
-                val packageInfo =
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        packageManager.getPackageArchiveInfo(
-                            filePath,
-                            PackageManager.PackageInfoFlags.of(flags.toLong()),
-                        )
-                    } else {
-                        @Suppress("DEPRECATION")
-                        packageManager.getPackageArchiveInfo(filePath, flags)
-                    }
+                val packageInfo = parseApk(packageManager, filePath)
 
                 if (packageInfo == null) {
                     Logger.e {
                         "Failed to parse APK at $filePath, file exists: ${
-                            File(
-                                filePath,
-                            ).exists()
+                            File(filePath).exists()
                         }, size: ${File(filePath).length()}"
                     }
                     return@withContext null
@@ -58,36 +43,8 @@ class AndroidInstallerInfoExtractor(
                         @Suppress("DEPRECATION")
                         packageInfo.versionCode.toLong()
                     }
-                val fingerprint: String? =
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        val sigInfo = packageInfo.signingInfo
-                        val certs =
-                            if (sigInfo?.hasMultipleSigners() == true) {
-                                sigInfo.apkContentsSigners
-                            } else {
-                                sigInfo?.signingCertificateHistory
-                            }
-                        certs?.firstOrNull()?.toByteArray()?.let { certBytes ->
-                            MessageDigest
-                                .getInstance("SHA-256")
-                                .digest(certBytes)
-                                .joinToString(":") { "%02X".format(it) }
-                        }
-                    } else {
-                        @Suppress("DEPRECATION")
-                        val legacyInfo =
-                            packageManager.getPackageArchiveInfo(
-                                filePath,
-                                PackageManager.GET_SIGNATURES,
-                            )
-                        @Suppress("DEPRECATION")
-                        legacyInfo?.signatures?.firstOrNull()?.toByteArray()?.let { certBytes ->
-                            MessageDigest
-                                .getInstance("SHA-256")
-                                .digest(certBytes)
-                                .joinToString(":") { "%02X".format(it) }
-                        }
-                    }
+
+                val fingerprint = extractSigningFingerprint(packageManager, packageInfo, filePath)
 
                 ApkPackageInfo(
                     appName = appName,
@@ -101,4 +58,113 @@ class AndroidInstallerInfoExtractor(
                 null
             }
         }
+
+    /**
+     * Tries to parse the APK with full flags first (metadata + signing).
+     * If that fails, retries with minimal flags since some APKs / Android
+     * versions choke on GET_SIGNING_CERTIFICATES combined with other flags.
+     */
+    private fun parseApk(
+        packageManager: PackageManager,
+        filePath: String,
+    ): android.content.pm.PackageInfo? {
+        val fullFlags =
+            PackageManager.GET_META_DATA or
+                PackageManager.GET_ACTIVITIES or
+                GET_SIGNING_CERTIFICATES
+
+        val full = getPackageArchiveInfoCompat(packageManager, filePath, fullFlags)
+        if (full != null) return full
+
+        Logger.w {
+            "Full-flag parse failed for $filePath, retrying with minimal flags"
+        }
+
+        // Retry without signing — the fingerprint will be extracted
+        // separately in extractSigningFingerprint.
+        val minimalFlags = PackageManager.GET_META_DATA
+        return getPackageArchiveInfoCompat(packageManager, filePath, minimalFlags)
+    }
+
+    private fun getPackageArchiveInfoCompat(
+        packageManager: PackageManager,
+        filePath: String,
+        flags: Int,
+    ): android.content.pm.PackageInfo? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageArchiveInfo(
+                filePath,
+                PackageManager.PackageInfoFlags.of(flags.toLong()),
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageArchiveInfo(filePath, flags)
+        }
+
+    /**
+     * Extracts the signing fingerprint from an already-parsed PackageInfo
+     * if available, otherwise does a separate lightweight parse with only
+     * the signing flag.
+     */
+    private fun extractSigningFingerprint(
+        packageManager: PackageManager,
+        packageInfo: android.content.pm.PackageInfo,
+        filePath: String,
+    ): String? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            // Try from the already-parsed info first (works when
+            // the full-flag parse succeeded).
+            val sigInfo = packageInfo.signingInfo
+            if (sigInfo != null) {
+                val certs =
+                    if (sigInfo.hasMultipleSigners()) {
+                        sigInfo.apkContentsSigners
+                    } else {
+                        sigInfo.signingCertificateHistory
+                    }
+                certs?.firstOrNull()?.toByteArray()?.let { certBytes ->
+                    return sha256Fingerprint(certBytes)
+                }
+            }
+
+            // Signing info missing (minimal-flag fallback path) —
+            // do a separate parse with only the signing flag.
+            val sigOnly = getPackageArchiveInfoCompat(
+                packageManager,
+                filePath,
+                GET_SIGNING_CERTIFICATES,
+            )
+            val fallbackSigInfo = sigOnly?.signingInfo
+            if (fallbackSigInfo != null) {
+                val certs =
+                    if (fallbackSigInfo.hasMultipleSigners()) {
+                        fallbackSigInfo.apkContentsSigners
+                    } else {
+                        fallbackSigInfo.signingCertificateHistory
+                    }
+                certs?.firstOrNull()?.toByteArray()?.let { certBytes ->
+                    return sha256Fingerprint(certBytes)
+                }
+            }
+
+            return null
+        } else {
+            @Suppress("DEPRECATION")
+            val legacyInfo =
+                packageManager.getPackageArchiveInfo(
+                    filePath,
+                    PackageManager.GET_SIGNATURES,
+                )
+            @Suppress("DEPRECATION")
+            return legacyInfo?.signatures?.firstOrNull()?.toByteArray()?.let { certBytes ->
+                sha256Fingerprint(certBytes)
+            }
+        }
+    }
+
+    private fun sha256Fingerprint(certBytes: ByteArray): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(certBytes)
+            .joinToString(":") { "%02X".format(it) }
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstallerInfoExtractor.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidInstallerInfoExtractor.kt
@@ -83,7 +83,14 @@ class AndroidInstallerInfoExtractor(
         // Retry without signing — the fingerprint will be extracted
         // separately in extractSigningFingerprint.
         val minimalFlags = PackageManager.GET_META_DATA
-        return getPackageArchiveInfoCompat(packageManager, filePath, minimalFlags)
+        val minimal = getPackageArchiveInfoCompat(packageManager, filePath, minimalFlags)
+        if (minimal != null) return minimal
+
+        Logger.w {
+            "Minimal-flag parse also failed for $filePath, retrying with zero flags"
+        }
+
+        return getPackageArchiveInfoCompat(packageManager, filePath, 0)
     }
 
     private fun getPackageArchiveInfoCompat(
@@ -116,13 +123,15 @@ class AndroidInstallerInfoExtractor(
             // the full-flag parse succeeded).
             val sigInfo = packageInfo.signingInfo
             if (sigInfo != null) {
-                val certs =
+                val cert =
                     if (sigInfo.hasMultipleSigners()) {
-                        sigInfo.apkContentsSigners
+                        sigInfo.apkContentsSigners?.firstOrNull()
                     } else {
-                        sigInfo.signingCertificateHistory
+                        // History is oldest→newest; last entry is the
+                        // current signer after key rotation.
+                        sigInfo.signingCertificateHistory?.lastOrNull()
                     }
-                certs?.firstOrNull()?.toByteArray()?.let { certBytes ->
+                cert?.toByteArray()?.let { certBytes ->
                     return sha256Fingerprint(certBytes)
                 }
             }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidPendingInstallNotifier.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidPendingInstallNotifier.kt
@@ -1,0 +1,146 @@
+package zed.rainxch.core.data.services
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import zed.rainxch.core.domain.system.PendingInstallNotifier
+
+/**
+ * Android implementation of [PendingInstallNotifier].
+ *
+ * # Behaviour
+ *
+ * - Each pending install gets its own notification, keyed by the
+ *   package name's hash code (so two pending installs of different
+ *   apps don't replace each other in the shade).
+ * - Tapping the notification (or the explicit "Open" action) launches
+ *   `MainActivity` via the `githubstore://apps` deep link, which the
+ *   parser routes to the apps tab where the user finishes the install.
+ * - Channel `app_updates` (already declared in `GithubStoreApp`) is
+ *   reused — pending installs are conceptually a flavour of update
+ *   notification and don't deserve a separate channel.
+ *
+ * # Permission gating
+ *
+ * On Android 13+, posting requires `POST_NOTIFICATIONS`. We check it
+ * silently rather than throwing — if the user denied the permission,
+ * the install still completes, they just don't get notified. The apps
+ * row still shows the pending state, so this is a graceful degrade.
+ */
+class AndroidPendingInstallNotifier(
+    private val context: Context,
+) : PendingInstallNotifier {
+    @SuppressLint("MissingPermission")
+    override fun notifyPending(
+        packageName: String,
+        repoOwner: String,
+        repoName: String,
+        appName: String,
+        versionTag: String,
+    ) {
+        if (!hasNotificationPermission()) return
+
+        // Deep link straight to the *Details* page for this specific
+        // app. The existing `githubstore://repo/owner/name` route is
+        // already wired in `DeepLinkParser` and lands on Details with
+        // the right repository pre-loaded — the user can tap install
+        // immediately. The Details page also detects the parked file
+        // via `pendingInstallFilePath` and skips re-downloading.
+        val safeOwner = sanitizeForUri(repoOwner)
+        val safeRepo = sanitizeForUri(repoName)
+        val uri =
+            if (safeOwner.isNotEmpty() && safeRepo.isNotEmpty()) {
+                "githubstore://repo/$safeOwner/$safeRepo"
+            } else {
+                // Synthetic-key fallback (e.g. for fresh installs
+                // where we don't know the package's owner/repo
+                // yet) — open the apps tab as before.
+                FALLBACK_URI
+            }
+        val deepLinkIntent =
+            Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+                setPackage(context.packageName)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+        val pendingIntent =
+            PendingIntent.getActivity(
+                context,
+                packageName.hashCode(),
+                deepLinkIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val notification =
+            NotificationCompat
+                .Builder(context, UPDATES_CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download_done)
+                .setContentTitle(appName)
+                .setContentText(versionTag)
+                .setSubText(SUBTEXT)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
+                .build()
+
+        NotificationManagerCompat
+            .from(context)
+            .notify(notificationIdFor(packageName), notification)
+    }
+
+    override fun clearPending(packageName: String) {
+        NotificationManagerCompat
+            .from(context)
+            .cancel(notificationIdFor(packageName))
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Stable per-package notification id. We hash the package name and
+     * mask off the high bits so it lands in a positive int range that
+     * doesn't collide with the existing notification ids used by the
+     * update workers (1004, 1005). Hash collisions are vanishingly
+     * rare in practice for package names; if they happen the worst
+     * case is that two pending installs share a notification, which
+     * is the same outcome as having only one notifier.
+     */
+    private fun notificationIdFor(packageName: String): Int =
+        NOTIFICATION_ID_BASE + (packageName.hashCode() and 0x00FFFFFF)
+
+    /**
+     * Defensive sanitisation for the deep-link path components.
+     * `DeepLinkParser.isStrictlyValidOwnerRepo` already rejects
+     * weird input, so this just strips characters that would break
+     * URI parsing before they reach the parser.
+     */
+    private fun sanitizeForUri(input: String): String {
+        if (input.isBlank()) return ""
+        return input.filter { ch ->
+            ch.isLetterOrDigit() || ch == '-' || ch == '.' || ch == '_'
+        }
+    }
+
+    private companion object {
+        const val UPDATES_CHANNEL_ID = "app_updates"
+        const val FALLBACK_URI = "githubstore://apps"
+        const val SUBTEXT = "Ready to install"
+
+        // Existing worker notifications use 1001-1005; start the
+        // pending-install id space comfortably above that.
+        const val NOTIFICATION_ID_BASE = 2000
+    }
+}

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AutoUpdateWorker.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AutoUpdateWorker.kt
@@ -152,10 +152,9 @@ class AutoUpdateWorker(
 
         val apkInfo =
             installer.getApkInfoExtractor().extractPackageInfo(filePath)
-                ?: throw IllegalStateException("Failed to extract APK info for ${app.appName}")
 
-        // Validate package name matches
-        if (apkInfo.packageName != app.packageName) {
+        // Validate package name matches (only when extraction succeeded)
+        if (apkInfo != null && apkInfo.packageName != app.packageName) {
             Logger.e {
                 "AutoUpdateWorker: Package name mismatch for ${app.appName}! " +
                     "Expected: ${app.packageName}, got: ${apkInfo.packageName}. " +
@@ -168,7 +167,7 @@ class AutoUpdateWorker(
 
         val currentApp = installedAppsRepository.getAppByPackage(app.packageName)
 
-        if (currentApp?.signingFingerprint != null) {
+        if (apkInfo != null && currentApp?.signingFingerprint != null) {
             val expected = currentApp.signingFingerprint!!.trim().uppercase()
             val actual = apkInfo.signingFingerprint?.trim()?.uppercase()
             if (actual == null || expected != actual) {
@@ -181,28 +180,34 @@ class AutoUpdateWorker(
                     "Signing fingerprint verification failed for ${app.appName}, blocking auto-update",
                 )
             }
+        }
 
+        if (apkInfo == null) {
+            Logger.w { "AutoUpdateWorker: APK info extraction failed for ${app.appName}, installing without validation" }
+        }
+
+        if (currentApp != null) {
             installedAppsRepository.updateApp(
                 currentApp.copy(
                     isPendingInstall = true,
                     latestVersion = latestVersion,
                     latestAssetName = assetName,
                     latestAssetUrl = assetUrl,
-                    latestVersionName = apkInfo.versionName,
-                    latestVersionCode = apkInfo.versionCode,
+                    latestVersionName = apkInfo?.versionName ?: latestVersion,
+                    latestVersionCode = apkInfo?.versionCode ?: 0L,
                 ),
             )
-
-            Logger.d { "AutoUpdateWorker: Installing ${app.appName} via Shizuku" }
-            try {
-                installer.install(filePath, ext)
-            } catch (e: Exception) {
-                installedAppsRepository.updatePendingStatus(app.packageName, false)
-                throw e
-            }
-
-            Logger.d { "AutoUpdateWorker: Install command completed for ${app.appName}, waiting for system confirmation via broadcast" }
         }
+
+        Logger.d { "AutoUpdateWorker: Installing ${app.appName} via Shizuku" }
+        try {
+            installer.install(filePath, ext)
+        } catch (e: Exception) {
+            installedAppsRepository.updatePendingStatus(app.packageName, false)
+            throw e
+        }
+
+        Logger.d { "AutoUpdateWorker: Install command completed for ${app.appName}, waiting for system confirmation via broadcast" }
     }
 
     private fun createForegroundInfo(

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withTimeout
 import org.koin.dsl.module
 import zed.rainxch.core.data.cache.CacheManager
 import zed.rainxch.core.data.data_source.TokenStore
+import zed.rainxch.core.data.services.DefaultDownloadOrchestrator
 import zed.rainxch.core.data.data_source.impl.DefaultTokenStore
 import zed.rainxch.core.data.local.db.AppDatabase
 import zed.rainxch.core.data.local.db.dao.CacheDao
@@ -38,6 +39,7 @@ import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.Platform
 import zed.rainxch.core.domain.model.ProxyConfig
 import zed.rainxch.core.domain.network.ProxyTester
+import zed.rainxch.core.domain.system.DownloadOrchestrator
 import zed.rainxch.core.domain.repository.AuthenticationState
 import zed.rainxch.core.domain.repository.FavouritesRepository
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
@@ -134,6 +136,19 @@ val coreModule =
 
         single<CacheManager> {
             CacheManager(cacheDao = get())
+        }
+
+        // Application-scoped download / install orchestrator. Lives
+        // for the process lifetime so downloads survive screen
+        // navigation. ViewModels are observers, never owners.
+        single<DownloadOrchestrator> {
+            DefaultDownloadOrchestrator(
+                downloader = get(),
+                installer = get(),
+                installedAppsRepository = get(),
+                pendingInstallNotifier = get(),
+                appScope = get(),
+            )
         }
     }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/AppDatabase.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/AppDatabase.kt
@@ -27,7 +27,7 @@ import zed.rainxch.core.data.local.db.entities.UpdateHistoryEntity
         SeenRepoEntity::class,
         SearchHistoryEntity::class,
     ],
-    version = 12,
+    version = 14,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/InstalledAppDao.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/InstalledAppDao.kt
@@ -143,6 +143,31 @@ interface InstalledAppDao {
     )
 
     /**
+     * Sets the path + version + asset name of a
+     * downloaded-but-not-yet-installed asset. Pass all `null` to
+     * clear (e.g. after the user installs the file).
+     *
+     * The version + asset name pair is what the Details screen uses
+     * to detect "the parked file matches the currently-selected
+     * release" and skip the redundant re-download.
+     */
+    @Query(
+        """
+        UPDATE installed_apps
+           SET pendingInstallFilePath = :path,
+               pendingInstallVersion = :version,
+               pendingInstallAssetName = :assetName
+         WHERE packageName = :packageName
+        """,
+    )
+    suspend fun updatePendingInstallFilePath(
+        packageName: String,
+        path: String?,
+        version: String?,
+        assetName: String?,
+    )
+
+    /**
      * Atomically clears the "update available" badge and any cached
      * latest-release metadata for [packageName], while bumping
      * `lastCheckedAt`. Used by `checkForUpdates` whenever the current

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/entities/InstalledAppEntity.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/entities/InstalledAppEntity.kt
@@ -121,4 +121,36 @@ data class InstalledAppEntity(
      * Pairs with [pickedAssetIndex] for same-position fallback.
      */
     val pickedAssetSiblingCount: Int? = null,
+    /**
+     * Absolute path to a downloaded but not-yet-installed APK / asset.
+     *
+     * Set by `DefaultDownloadOrchestrator` when an
+     * `InstallPolicy.InstallWhileForeground` download finishes after
+     * the foreground screen has been destroyed (the user navigated
+     * away mid-download). The apps list shows a "Ready to install"
+     * row with a one-tap install action when this is non-null.
+     *
+     * Cleared by the orchestrator on successful install or by the
+     * user dismissing the row.
+     *
+     * Survives process restarts: the file lives on disk and the
+     * column points back at it. Both are cleaned up if the file is
+     * missing on next read.
+     */
+    val pendingInstallFilePath: String? = null,
+    /**
+     * Release tag of the version represented by [pendingInstallFilePath].
+     * Used by the Details screen to detect "the parked file matches
+     * the currently-selected release" — when both [pendingInstallVersion]
+     * and [pendingInstallAssetName] match the user's selection, the
+     * install button skips the download phase and dispatches the
+     * existing install dialog flow on the parked file directly.
+     */
+    val pendingInstallVersion: String? = null,
+    /**
+     * Asset filename (the original, not the scoped form) of the
+     * parked file. Pairs with [pendingInstallVersion] for
+     * Details-screen "ready to install" detection.
+     */
+    val pendingInstallAssetName: String? = null,
 )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/InstalledAppsMappers.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/InstalledAppsMappers.kt
@@ -46,6 +46,9 @@ fun InstalledApp.toEntity(): InstalledAppEntity =
         assetGlobPattern = assetGlobPattern,
         pickedAssetIndex = pickedAssetIndex,
         pickedAssetSiblingCount = pickedAssetSiblingCount,
+        pendingInstallFilePath = pendingInstallFilePath,
+        pendingInstallVersion = pendingInstallVersion,
+        pendingInstallAssetName = pendingInstallAssetName,
     )
 
 fun InstalledAppEntity.toDomain(): InstalledApp =
@@ -91,4 +94,7 @@ fun InstalledAppEntity.toDomain(): InstalledApp =
         assetGlobPattern = assetGlobPattern,
         pickedAssetIndex = pickedAssetIndex,
         pickedAssetSiblingCount = pickedAssetSiblingCount,
+        pendingInstallFilePath = pendingInstallFilePath,
+        pendingInstallVersion = pendingInstallVersion,
+        pendingInstallAssetName = pendingInstallAssetName,
     )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -516,6 +516,20 @@ class InstalledAppsRepositoryImpl(
         )
     }
 
+    override suspend fun setPendingInstallFilePath(
+        packageName: String,
+        path: String?,
+        version: String?,
+        assetName: String?,
+    ) {
+        installedAppsDao.updatePendingInstallFilePath(
+            packageName = packageName,
+            path = path,
+            version = version,
+            assetName = assetName,
+        )
+    }
+
     override suspend fun previewMatchingAssets(
         owner: String,
         repo: String,

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
@@ -1,0 +1,559 @@
+package zed.rainxch.core.data.services
+
+import co.touchlab.kermit.Logger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import zed.rainxch.core.domain.network.Downloader
+import zed.rainxch.core.domain.repository.InstalledAppsRepository
+import zed.rainxch.core.domain.system.DownloadOrchestrator
+import zed.rainxch.core.domain.system.DownloadSpec
+import zed.rainxch.core.domain.system.DownloadStage
+import zed.rainxch.core.domain.system.InstallOutcome
+import zed.rainxch.core.domain.system.InstallPolicy
+import zed.rainxch.core.domain.system.Installer
+import zed.rainxch.core.domain.system.OrchestratedDownload
+import zed.rainxch.core.domain.system.PendingInstallNotifier
+import zed.rainxch.core.domain.util.AssetFileName
+import kotlin.random.Random
+
+/**
+ * Default implementation of [DownloadOrchestrator].
+ *
+ * # Lifetime
+ *
+ * Owned by Koin as a singleton with the application-scoped
+ * [CoroutineScope] (see `coreModule`'s `CoroutineScope` factory). All
+ * downloads run in [appScope] so they outlive any ViewModel that
+ * triggered them. The orchestrator itself never cancels its scope —
+ * the process going away does that for free.
+ *
+ * # Concurrency
+ *
+ * Uses a per-package [Mutex] surfaced via [stateMutex] to serialize
+ * map mutations. Actual download/install work runs in [appScope] so
+ * the mutex is only held for short metadata writes — never across
+ * the long-running download.
+ *
+ * Up to [DEFAULT_MAX_CONCURRENT] downloads run at once. Further
+ * enqueue calls don't block — they just spawn a coroutine that
+ * `delay`s while the active count is at capacity. The simpler "always
+ * spawn, let the platform Downloader queue internally" approach is
+ * tempting, but OkHttp doesn't queue — it'd open every connection at
+ * once and likely hit GitHub's rate limit.
+ *
+ * # Filename namespacing
+ *
+ * Every download is written to disk with the
+ * `<owner>_<repo>_<original>.ext` form via [AssetFileName.scoped].
+ * This is the only place that name transformation lives — callers
+ * pass the original asset name and the orchestrator handles the rest.
+ * The scoped name is also what gets passed to [Downloader.download],
+ * so the Downloader's per-name dedup map is automatically scoped.
+ *
+ * # Install policies
+ *
+ * See [InstallPolicy] for the rules. Implementation detail: the
+ * "screen still attached" check at install time is done by re-reading
+ * `installPolicy` from the live state map *after* the download
+ * completes — never from a captured local — so a [downgradeToDeferred]
+ * call lands atomically against the in-flight download.
+ */
+class DefaultDownloadOrchestrator(
+    private val downloader: Downloader,
+    private val installer: Installer,
+    private val installedAppsRepository: InstalledAppsRepository,
+    private val pendingInstallNotifier: PendingInstallNotifier,
+    private val appScope: CoroutineScope,
+) : DownloadOrchestrator {
+    private companion object {
+        private const val DEFAULT_MAX_CONCURRENT = 3
+        private const val QUEUE_POLL_DELAY_MS = 200L
+    }
+
+    private val _downloads = MutableStateFlow<Map<String, OrchestratedDownload>>(emptyMap())
+    override val downloads: StateFlow<Map<String, OrchestratedDownload>> = _downloads.asStateFlow()
+
+    /**
+     * Mutex guarding map mutations *and* the active-count check used
+     * by the queue. Held only for short critical sections — never
+     * across `Downloader.download(...).collect`.
+     */
+    private val stateMutex = Mutex()
+
+    /**
+     * Job handles per package, used by [cancel] to interrupt the
+     * download. Separate from `_downloads` because Job is mutable
+     * state that doesn't belong in an immutable StateFlow value.
+     */
+    private val activeJobs = mutableMapOf<String, Job>()
+
+    override fun observe(packageName: String): Flow<OrchestratedDownload?> =
+        _downloads
+            .map { it[packageName] }
+            .distinctUntilChanged()
+
+    override suspend fun enqueue(spec: DownloadSpec): String {
+        // Idempotent: if a download for this package is already
+        // running (or queued, or awaiting install), return its id and
+        // upgrade the install policy if the new caller wants a
+        // stronger guarantee. Common case: user taps Update twice in
+        // a row and we don't want to spawn two downloads.
+        stateMutex.withLock {
+            val existing = _downloads.value[spec.packageName]
+            if (existing != null && existing.stage != DownloadStage.Failed &&
+                existing.stage != DownloadStage.Cancelled
+            ) {
+                // Allow caller to upgrade policy: e.g. apps list
+                // started a Deferred download, then user opened
+                // Details and we want to flip to InstallWhileForeground.
+                if (existing.installPolicy != spec.installPolicy &&
+                    existing.installPolicy.priority < spec.installPolicy.priority
+                ) {
+                    _downloads.update { state ->
+                        state + (spec.packageName to existing.copy(installPolicy = spec.installPolicy))
+                    }
+                }
+                return existing.id
+            }
+        }
+
+        val id = generateId()
+        val initial =
+            OrchestratedDownload(
+                id = id,
+                packageName = spec.packageName,
+                repoOwner = spec.repoOwner,
+                repoName = spec.repoName,
+                displayAppName = spec.displayAppName,
+                assetName = spec.asset.name,
+                assetSize = spec.asset.size,
+                downloadUrl = spec.asset.downloadUrl,
+                releaseTag = spec.releaseTag,
+                filePath = null,
+                installPolicy = spec.installPolicy,
+                stage = DownloadStage.Queued,
+                progressPercent = null,
+            )
+        stateMutex.withLock {
+            _downloads.update { it + (spec.packageName to initial) }
+        }
+
+        val job =
+            appScope.launch {
+                try {
+                    runDownload(spec)
+                } catch (e: CancellationException) {
+                    // Honour structured concurrency. The cancel path
+                    // is responsible for cleaning state.
+                    Logger.d { "Orchestrator: download cancelled for ${spec.packageName}" }
+                    throw e
+                } catch (t: Throwable) {
+                    Logger.e(t) { "Orchestrator: download/install failed for ${spec.packageName}" }
+                    markFailed(spec.packageName, t.message)
+                } finally {
+                    stateMutex.withLock {
+                        if (activeJobs[spec.packageName]?.isCompleted == true ||
+                            activeJobs[spec.packageName] == null
+                        ) {
+                            activeJobs.remove(spec.packageName)
+                        }
+                    }
+                }
+            }
+        stateMutex.withLock {
+            activeJobs[spec.packageName] = job
+        }
+        return id
+    }
+
+    /**
+     * The actual download/install pipeline. Runs entirely inside
+     * [appScope].
+     *
+     *  1. Wait for a slot if [DEFAULT_MAX_CONCURRENT] is at capacity
+     *  2. Stream bytes via [Downloader] under the scoped filename,
+     *     emitting progress updates
+     *  3. Read the latest [InstallPolicy] from state — this is the
+     *     race-safe read that lets [downgradeToDeferred] land
+     *  4. Branch on policy: install in-process, defer to user, or
+     *     hand off to the dialog-driven Details flow
+     */
+    private suspend fun runDownload(spec: DownloadSpec) {
+        // Wait for a worker slot. Polling is acceptable here because
+        // the wait is not on the user's critical path (a queued
+        // download is by definition something the user is OK waiting
+        // on).
+        while (true) {
+            val activeNow =
+                stateMutex.withLock {
+                    _downloads.value.values.count { it.stage == DownloadStage.Downloading }
+                }
+            if (activeNow < DEFAULT_MAX_CONCURRENT) break
+            kotlinx.coroutines.delay(QUEUE_POLL_DELAY_MS)
+        }
+
+        val scopedName =
+            AssetFileName.scoped(
+                owner = spec.repoOwner,
+                repo = spec.repoName,
+                originalName = spec.asset.name,
+            )
+
+        // Move to Downloading. Initialize totalBytes from the asset's
+        // declared size — the server's Content-Length might disagree
+        // (or be missing), in which case the download flow will
+        // override it with the live value below.
+        updateEntry(spec.packageName) {
+            it.copy(
+                stage = DownloadStage.Downloading,
+                bytesDownloaded = 0L,
+                totalBytes = spec.asset.size.takeIf { size -> size > 0 },
+            )
+        }
+
+        downloader.download(spec.asset.downloadUrl, scopedName).collect { progress ->
+            updateEntry(spec.packageName) {
+                it.copy(
+                    progressPercent = progress.percent,
+                    bytesDownloaded = progress.bytesDownloaded,
+                    // Prefer the live Content-Length when present;
+                    // fall back to whatever we already had (asset.size).
+                    totalBytes = progress.totalBytes ?: it.totalBytes,
+                )
+            }
+        }
+
+        val filePath =
+            downloader.getDownloadedFilePath(scopedName)
+                ?: throw IllegalStateException("Downloaded file missing: $scopedName")
+
+        updateEntry(spec.packageName) {
+            it.copy(filePath = filePath, progressPercent = 100)
+        }
+
+        // Race-safe read of the *current* install policy. The
+        // ViewModel may have called downgradeToDeferred while the
+        // download was in flight; that mutation lands here.
+        val effectivePolicy =
+            stateMutex.withLock {
+                _downloads.value[spec.packageName]?.installPolicy ?: spec.installPolicy
+            }
+
+        when (effectivePolicy) {
+            InstallPolicy.AlwaysInstall -> runInstall(spec, filePath)
+
+            // InstallWhileForeground: park *without* notifying. The
+            // foreground VM is expected to be observing and will run
+            // its own dialog-driven install on the file. The notifier
+            // only fires when the policy gets downgraded to Deferred
+            // (either explicitly via downgradeToDeferred, or
+            // originally), so the user only sees a notification when
+            // there's nobody watching the download interactively.
+            InstallPolicy.InstallWhileForeground -> parkForUser(spec, filePath, notify = false)
+
+            InstallPolicy.DeferUntilUserAction -> parkForUser(spec, filePath, notify = true)
+        }
+    }
+
+    /**
+     * Invokes the platform installer for [filePath]. On success the
+     * orchestrator entry is moved to [DownloadStage.Completed] (the
+     * consuming ViewModel will dismiss it from the map).
+     *
+     * Validation (signing fingerprint, package mismatch, etc.) is
+     * deliberately NOT done here. The dialog-driven path in
+     * `DetailsViewModel` handles those because they need user
+     * interaction. The orchestrator's "always install" path is used
+     * for Shizuku silent installs where the user has explicitly opted
+     * out of confirmations.
+     */
+    private suspend fun runInstall(spec: DownloadSpec, filePath: String) {
+        updateEntry(spec.packageName) { it.copy(stage = DownloadStage.Installing) }
+        val ext = spec.asset.name.substringAfterLast('.', "").lowercase()
+        try {
+            installer.ensurePermissionsOrThrow(ext)
+            installer.install(filePath, ext)
+            // Successful install — clear any pending file path on
+            // the row (if it was set from a prior aborted attempt)
+            // and move the orchestrator entry to Completed.
+            try {
+                installedAppsRepository.setPendingInstallFilePath(spec.packageName, null)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e) { "Orchestrator: failed to clear pending install path" }
+            }
+            pendingInstallNotifier.clearPending(spec.packageName)
+            updateEntry(spec.packageName) { it.copy(stage = DownloadStage.Completed) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Logger.e(t) { "Orchestrator: install failed for ${spec.packageName}" }
+            markFailed(spec.packageName, t.message)
+        }
+    }
+
+    /**
+     * "Park" path: download finished but the install policy says
+     * "don't auto-install". Persists the file path on the InstalledApp
+     * row so the apps list can show a "Ready to install" row, optionally
+     * fires the notification, and moves the orchestrator entry to
+     * [DownloadStage.AwaitingInstall].
+     *
+     * @param notify Whether to poke the notifier. False for the
+     *   InstallWhileForeground case (the foreground VM is watching);
+     *   true for the DeferUntilUserAction case (no foreground watcher).
+     */
+    private suspend fun parkForUser(
+        spec: DownloadSpec,
+        filePath: String,
+        notify: Boolean,
+    ) {
+        try {
+            installedAppsRepository.setPendingInstallFilePath(
+                packageName = spec.packageName,
+                path = filePath,
+                version = spec.releaseTag,
+                assetName = spec.asset.name,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.e(e) { "Orchestrator: failed to persist pending install path" }
+            // Persistence is best-effort — the orchestrator state
+            // still has the file path, so the row can render via
+            // observe() during the same process lifetime. Survives
+            // process death is what we lose.
+        }
+        if (notify) {
+            pendingInstallNotifier.notifyPending(
+                packageName = spec.packageName,
+                repoOwner = spec.repoOwner,
+                repoName = spec.repoName,
+                appName = spec.displayAppName,
+                versionTag = spec.releaseTag,
+            )
+        }
+        updateEntry(spec.packageName) { it.copy(stage = DownloadStage.AwaitingInstall) }
+    }
+
+    override suspend fun downgradeToDeferred(packageName: String) {
+        // Snapshot what we need under the lock and decide whether to
+        // notify outside it (notifier is third-party code, don't hold
+        // the mutex across it).
+        val shouldNotify: Boolean
+        val notifySpec: NotifyData?
+        stateMutex.withLock {
+            val existing = _downloads.value[packageName] ?: return
+            when (existing.stage) {
+                DownloadStage.Queued, DownloadStage.Downloading -> {
+                    // In-flight: just flip the policy. parkForUser
+                    // will see it later and notify.
+                    _downloads.update { state ->
+                        state + (
+                            packageName to existing.copy(
+                                installPolicy = InstallPolicy.DeferUntilUserAction,
+                            )
+                        )
+                    }
+                    shouldNotify = false
+                    notifySpec = null
+                }
+
+                DownloadStage.AwaitingInstall -> {
+                    // Race: the orchestrator already parked the file
+                    // (silently, because the policy was
+                    // InstallWhileForeground) but the foreground VM
+                    // is now going away. We need to retroactively
+                    // notify the user so they don't lose track of
+                    // the ready-to-install file.
+                    val needsNotify =
+                        existing.installPolicy == InstallPolicy.InstallWhileForeground
+                    _downloads.update { state ->
+                        state + (
+                            packageName to existing.copy(
+                                installPolicy = InstallPolicy.DeferUntilUserAction,
+                            )
+                        )
+                    }
+                    shouldNotify = needsNotify
+                    notifySpec = if (needsNotify) {
+                        NotifyData(
+                            packageName = existing.packageName,
+                            repoOwner = existing.repoOwner,
+                            repoName = existing.repoName,
+                            appName = existing.displayAppName,
+                            versionTag = existing.releaseTag,
+                        )
+                    } else {
+                        null
+                    }
+                }
+
+                DownloadStage.Installing,
+                DownloadStage.Completed,
+                DownloadStage.Cancelled,
+                DownloadStage.Failed,
+                -> {
+                    // Too late or terminal — nothing meaningful to do.
+                    shouldNotify = false
+                    notifySpec = null
+                }
+            }
+        }
+        if (shouldNotify && notifySpec != null) {
+            pendingInstallNotifier.notifyPending(
+                packageName = notifySpec.packageName,
+                repoOwner = notifySpec.repoOwner,
+                repoName = notifySpec.repoName,
+                appName = notifySpec.appName,
+                versionTag = notifySpec.versionTag,
+            )
+        }
+    }
+
+    private data class NotifyData(
+        val packageName: String,
+        val repoOwner: String,
+        val repoName: String,
+        val appName: String,
+        val versionTag: String,
+    )
+
+    override suspend fun cancel(packageName: String) {
+        val job = stateMutex.withLock { activeJobs.remove(packageName) }
+        job?.cancel()
+
+        // Best-effort: delete the partial file via the downloader's
+        // cancellation hook. The downloader's cancel path is keyed
+        // on the scoped filename — we can recompute it from the
+        // entry's owner/repo/asset name.
+        val entry = _downloads.value[packageName]
+        if (entry != null) {
+            val scopedName =
+                AssetFileName.scoped(entry.repoOwner, entry.repoName, entry.assetName)
+            try {
+                downloader.cancelDownload(scopedName)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e) { "Orchestrator: cancelDownload failed for $scopedName" }
+            }
+        }
+
+        stateMutex.withLock {
+            _downloads.update { it - packageName }
+        }
+    }
+
+    override suspend fun installPending(packageName: String): InstallOutcome? {
+        val entry = _downloads.value[packageName]
+            ?: run {
+                // The orchestrator's in-memory entry may be gone (e.g.
+                // process restart). Fall back to the persisted
+                // pendingInstallFilePath on the InstalledApp row.
+                val app = try {
+                    installedAppsRepository.getAppByPackage(packageName)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.e(e) { "Orchestrator: getAppByPackage failed" }
+                    null
+                }
+                val filePath = app?.pendingInstallFilePath ?: return null
+                val ext = filePath.substringAfterLast('.', "").lowercase()
+                return runStandaloneInstall(packageName, filePath, ext)
+            }
+
+        val filePath = entry.filePath ?: return null
+        val ext = entry.assetName.substringAfterLast('.', "").lowercase()
+        return runStandaloneInstall(packageName, filePath, ext)
+    }
+
+    private suspend fun runStandaloneInstall(
+        packageName: String,
+        filePath: String,
+        ext: String,
+    ): InstallOutcome? {
+        updateEntry(packageName) { it.copy(stage = DownloadStage.Installing) }
+        return try {
+            installer.ensurePermissionsOrThrow(ext)
+            val outcome = installer.install(filePath, ext)
+            try {
+                installedAppsRepository.setPendingInstallFilePath(packageName, null)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e) { "Orchestrator: failed to clear pending install path post-install" }
+            }
+            pendingInstallNotifier.clearPending(packageName)
+            updateEntry(packageName) { it.copy(stage = DownloadStage.Completed) }
+            outcome
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Logger.e(t) { "Orchestrator: standalone install failed for $packageName" }
+            markFailed(packageName, t.message)
+            null
+        }
+    }
+
+    override fun dismiss(packageName: String) {
+        // Synchronous dismiss — no Mutex needed for the read-modify-write
+        // because StateFlow.update is itself atomic. We just don't
+        // touch activeJobs (cancel does that).
+        _downloads.update { it - packageName }
+    }
+
+    private suspend fun updateEntry(
+        packageName: String,
+        transform: (OrchestratedDownload) -> OrchestratedDownload,
+    ) {
+        stateMutex.withLock {
+            _downloads.update { state ->
+                val current = state[packageName] ?: return@update state
+                state + (packageName to transform(current))
+            }
+        }
+    }
+
+    private suspend fun markFailed(packageName: String, message: String?) {
+        stateMutex.withLock {
+            _downloads.update { state ->
+                val current = state[packageName] ?: return@update state
+                state + (packageName to current.copy(stage = DownloadStage.Failed, errorMessage = message))
+            }
+        }
+    }
+
+    private fun generateId(): String =
+        // Cheap unique id without pulling in java.util.UUID — works
+        // on all KMP targets. Collisions are statistically negligible
+        // for the lifetime of the orchestrator.
+        Random.nextLong().toULong().toString(36) + Random.nextLong().toULong().toString(36)
+}
+
+/**
+ * Orderable strength of an install policy. Higher = stronger
+ * guarantee. Used by [DefaultDownloadOrchestrator.enqueue] when an
+ * existing download is re-enqueued with a different policy: we only
+ * upgrade (never downgrade) so the original caller's intent is
+ * preserved unless an even more committed caller arrives.
+ */
+private val InstallPolicy.priority: Int
+    get() = when (this) {
+        InstallPolicy.DeferUntilUserAction -> 0
+        InstallPolicy.InstallWhileForeground -> 1
+        InstallPolicy.AlwaysInstall -> 2
+    }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
@@ -450,6 +450,24 @@ class DefaultDownloadOrchestrator(
             } catch (e: Exception) {
                 Logger.w(e) { "Orchestrator: cancelDownload failed for $scopedName" }
             }
+
+            // If the entry was parked (AwaitingInstall), clean up the
+            // persistent pending-install metadata and notification so
+            // the apps row doesn't keep showing "ready to install".
+            if (entry.stage == DownloadStage.AwaitingInstall) {
+                try {
+                    installedAppsRepository.setPendingInstallFilePath(packageName, null)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "Orchestrator: failed to clear pending path on cancel" }
+                }
+                try {
+                    pendingInstallNotifier.clearPending(packageName)
+                } catch (e: Exception) {
+                    Logger.w(e) { "Orchestrator: failed to clear notification on cancel" }
+                }
+            }
         }
 
         stateMutex.withLock {
@@ -490,15 +508,20 @@ class DefaultDownloadOrchestrator(
         return try {
             installer.ensurePermissionsOrThrow(ext)
             val outcome = installer.install(filePath, ext)
-            try {
-                installedAppsRepository.setPendingInstallFilePath(packageName, null)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.w(e) { "Orchestrator: failed to clear pending install path post-install" }
+            if (outcome == InstallOutcome.COMPLETED) {
+                try {
+                    installedAppsRepository.setPendingInstallFilePath(packageName, null)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "Orchestrator: failed to clear pending install path post-install" }
+                }
+                pendingInstallNotifier.clearPending(packageName)
+                updateEntry(packageName) { it.copy(stage = DownloadStage.Completed) }
             }
-            pendingInstallNotifier.clearPending(packageName)
-            updateEntry(packageName) { it.copy(stage = DownloadStage.Completed) }
+            // DELEGATED_TO_SYSTEM: the system installer dialog is
+            // showing. Don't clear pending metadata or mark Completed —
+            // PackageEventReceiver handles the final state transition.
             outcome
         } catch (e: CancellationException) {
             throw e

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
@@ -15,10 +15,12 @@ import zed.rainxch.core.data.services.DesktopFileLocationsProvider
 import zed.rainxch.core.data.services.DesktopInstaller
 import zed.rainxch.core.data.services.DesktopLocalizationManager
 import zed.rainxch.core.data.services.DesktopPackageMonitor
+import zed.rainxch.core.data.services.DesktopPendingInstallNotifier
 import zed.rainxch.core.data.services.DesktopUpdateScheduleManager
 import zed.rainxch.core.data.services.FileLocationsProvider
 import zed.rainxch.core.domain.system.Installer
 import zed.rainxch.core.domain.system.InstallerStatusProvider
+import zed.rainxch.core.domain.system.PendingInstallNotifier
 import zed.rainxch.core.domain.system.UpdateScheduleManager
 import zed.rainxch.core.data.services.LocalizationManager
 import zed.rainxch.core.data.services.DesktopInstallerStatusProvider
@@ -97,5 +99,9 @@ actual val corePlatformModule = module {
 
     single<UpdateScheduleManager> {
         DesktopUpdateScheduleManager()
+    }
+
+    single<PendingInstallNotifier> {
+        DesktopPendingInstallNotifier()
     }
 }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopPendingInstallNotifier.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopPendingInstallNotifier.kt
@@ -1,0 +1,25 @@
+package zed.rainxch.core.data.services
+
+import zed.rainxch.core.domain.system.PendingInstallNotifier
+
+/**
+ * Desktop has no pending-install flow:
+ *  - The apps tab is hidden on Desktop (set via `Platform.ANDROID` gate
+ *    in the bottom nav), so the user has no place to "tap to install"
+ *  - Desktop installs always run in-process and complete synchronously
+ *    via the OS package manager dialog
+ *
+ * Notifier is a no-op so the orchestrator can still call into it
+ * unconditionally without platform branching.
+ */
+class DesktopPendingInstallNotifier : PendingInstallNotifier {
+    override fun notifyPending(
+        packageName: String,
+        repoOwner: String,
+        repoName: String,
+        appName: String,
+        versionTag: String,
+    ) = Unit
+
+    override fun clearPending(packageName: String) = Unit
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/InstalledApp.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/InstalledApp.kt
@@ -90,4 +90,26 @@ data class InstalledApp(
      * Pairs with [pickedAssetIndex] for the same-position fallback.
      */
     val pickedAssetSiblingCount: Int? = null,
+    /**
+     * Absolute path to a downloaded asset that's waiting for the user
+     * to confirm install. Non-null means: the orchestrator finished
+     * the download in `InstallWhileForeground` mode but the foreground
+     * screen had gone away by then, so the bytes are parked and the
+     * apps list shows a "ready to install" row.
+     *
+     * Cleared by the orchestrator after a successful install or when
+     * the user dismisses the row.
+     */
+    val pendingInstallFilePath: String? = null,
+    /**
+     * Release tag of the version represented by [pendingInstallFilePath].
+     * Used by Details to detect "the parked file matches the
+     * currently-selected release" and skip re-downloading on install.
+     */
+    val pendingInstallVersion: String? = null,
+    /**
+     * Original (unscoped) asset filename of the parked file. Pairs
+     * with [pendingInstallVersion] for the Details-screen match.
+     */
+    val pendingInstallAssetName: String? = null,
 )

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/InstalledAppsRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/InstalledAppsRepository.kt
@@ -105,6 +105,28 @@ interface InstalledAppsRepository {
     suspend fun clearPreferredVariant(packageName: String)
 
     /**
+     * Sets (or clears) the path + version + asset name of a
+     * downloaded-but-not-yet-installed asset for [packageName].
+     *
+     * Used by `DefaultDownloadOrchestrator` when an
+     * `InstallPolicy.InstallWhileForeground` download completes
+     * after the foreground screen has been destroyed — the file is
+     * parked, these three columns are set, and the apps list shows
+     * a "Ready to install" row. The Details screen also uses
+     * [version] + [assetName] to detect "the parked file matches
+     * the currently-selected release" and skip re-downloading.
+     *
+     * Pass `null` for all three to clear (after a successful install
+     * or after the user dismissed the row).
+     */
+    suspend fun setPendingInstallFilePath(
+        packageName: String,
+        path: String?,
+        version: String? = null,
+        assetName: String? = null,
+    )
+
+    /**
      * Dry-run helper for the per-app advanced settings sheet. Fetches a
      * window of releases for [owner]/[repo] (honouring [includePreReleases])
      * and returns the assets in the most-recent release that match

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/DownloadOrchestrator.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/DownloadOrchestrator.kt
@@ -1,0 +1,274 @@
+package zed.rainxch.core.domain.system
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import zed.rainxch.core.domain.model.GithubAsset
+
+/**
+ * Application-scoped manager for in-flight downloads and installs.
+ *
+ * # Why this exists
+ *
+ * Before this interface, every download/install ran inside the calling
+ * ViewModel's `viewModelScope`. Two problems followed:
+ *
+ *   1. **Screen-leave kills installs** — navigating away from the
+ *      details screen mid-download cancels the OkHttp call and deletes
+ *      the partial file. Users had to camp on the screen to update
+ *      anything.
+ *
+ *   2. **No cross-screen coordination** — the apps list and the details
+ *      screen each had their own download bookkeeping. Hopping between
+ *      screens lost progress, status, and cancel handles.
+ *
+ * The orchestrator solves both by owning a long-lived [CoroutineScope]
+ * tied to the application's lifetime. ViewModels become **observers**
+ * of [downloads] rather than **owners** of any work — when a screen is
+ * destroyed, the work keeps running and the next screen instance picks
+ * the state right back up.
+ *
+ * # Install policies
+ *
+ * Each enqueued download declares an [InstallPolicy] that controls what
+ * happens when the bytes are on disk:
+ *
+ *   - [InstallPolicy.AlwaysInstall] — fire the installer no matter what.
+ *     Used for **Shizuku** silent installs, where there's no UI dialog
+ *     and the user has explicitly opted into the unattended path.
+ *
+ *   - [InstallPolicy.InstallWhileForeground] — fire the installer **only
+ *     if the screen that requested the download is still alive**. The
+ *     ViewModel must call [downgradeToDeferred] in `onCleared()`. If the
+ *     downgrade lands before the download completes, the installer is
+ *     not invoked; instead the file is parked, the row is marked
+ *     "pending install", and the notifier is poked.
+ *
+ *   - [InstallPolicy.DeferUntilUserAction] — never auto-install. Used by
+ *     the apps list when the user has tapped "Update" but the screen
+ *     might leave at any moment, and by recovery flows. The file lands
+ *     on disk and the user installs it explicitly.
+ *
+ * # Concurrency model
+ *
+ * Up to [maxConcurrent] downloads run in parallel; further `enqueue`
+ * calls join an internal queue. Cancellation is per-package: cancelling
+ * one download doesn't touch the others. Implementations should
+ * surface a `SupervisorJob` so a single failed download can't poison
+ * the scope.
+ *
+ * # Filename namespacing
+ *
+ * The orchestrator scopes filenames as `owner_repo_originalName.ext`
+ * before passing them to the [zed.rainxch.core.domain.network.Downloader]
+ * — this prevents collisions between two repos that ship installers
+ * with the same name (e.g. `app.apk`).
+ */
+interface DownloadOrchestrator {
+    /**
+     * Live snapshot of every download the orchestrator currently knows
+     * about, keyed by package name. Includes downloads in every stage
+     * (queued, downloading, awaiting install, failed, cancelled). The
+     * map is updated atomically so consumers can use plain `collect`
+     * without worrying about torn reads.
+     *
+     * Entries are removed when:
+     *  - The install completes (foreground or Shizuku) and
+     *    [dismiss] is called by the consuming ViewModel
+     *  - The user explicitly dismisses a failed/cancelled download
+     *  - The orchestrator is cleared (process death)
+     *
+     * Pending-install entries (`stage = AwaitingInstall`) survive
+     * across screen instances precisely so the apps list can show
+     * "ready to install" rows.
+     */
+    val downloads: StateFlow<Map<String, OrchestratedDownload>>
+
+    /**
+     * Convenience flow that emits the entry for [packageName] whenever
+     * it changes — equivalent to `downloads.map { it[packageName] }`
+     * with `distinctUntilChanged`. Use this from a ViewModel observing
+     * a single app.
+     */
+    fun observe(packageName: String): Flow<OrchestratedDownload?>
+
+    /**
+     * Enqueues a download for [spec]. If a download for the same
+     * package is already in progress, this returns the existing
+     * download's id without starting a new one — duplicates are a
+     * silent no-op so consumers can be naïve about idempotency.
+     *
+     * @return the orchestrator's internal id for the download. Use it
+     *   with [cancel] / [dismiss] for safe targeting (the package name
+     *   also works but is less precise if a row gets re-enqueued).
+     */
+    suspend fun enqueue(spec: DownloadSpec): String
+
+    /**
+     * Atomically swaps the install policy for [packageName] to
+     * [InstallPolicy.DeferUntilUserAction]. Called by foreground
+     * ViewModels in `onCleared()` so a download that was started with
+     * [InstallPolicy.InstallWhileForeground] doesn't auto-install
+     * after the screen goes away.
+     *
+     * Race-safe: if the download has already finished and the install
+     * is in progress, this is a no-op (the install completes). If the
+     * download is still running, the policy flips immediately and the
+     * orchestrator parks the file when bytes are done.
+     *
+     * No-op if no download exists for [packageName].
+     */
+    suspend fun downgradeToDeferred(packageName: String)
+
+    /**
+     * Cancels the download for [packageName] (if any), deletes the
+     * partial file, and removes the entry from [downloads]. Safe to
+     * call from any thread; idempotent.
+     */
+    suspend fun cancel(packageName: String)
+
+    /**
+     * Triggers the install of a previously-deferred download. Looks up
+     * the file via [OrchestratedDownload.filePath] for [packageName],
+     * runs the platform installer, and removes the entry on success.
+     *
+     * Used by:
+     *  - The apps list "Install" button when a row is in
+     *    [DownloadStage.AwaitingInstall]
+     *  - The notification action that opens the apps list and resumes
+     *
+     * Validation (signing fingerprint, package mismatch) is the
+     * caller's responsibility — the orchestrator runs the bare
+     * `installer.install` call. The dialog-driven path in
+     * `DetailsViewModel` continues to handle the screen-attached
+     * case where the validation surface lives.
+     */
+    suspend fun installPending(packageName: String): InstallOutcome?
+
+    /**
+     * Removes the entry for [packageName] from [downloads]. Used when
+     * the consuming ViewModel has handled a terminal state (success,
+     * error, cancellation) and doesn't want it sticking around in the
+     * map.
+     */
+    fun dismiss(packageName: String)
+}
+
+/**
+ * What the caller wants the orchestrator to do with a single asset.
+ */
+data class DownloadSpec(
+    /** Package name being installed/updated. Used as the map key. */
+    val packageName: String,
+    /** Repository owner — half of the filename namespace prefix. */
+    val repoOwner: String,
+    /** Repository name — the other half. */
+    val repoName: String,
+    /** Asset to download. The orchestrator pulls URL/name/size from this. */
+    val asset: GithubAsset,
+    /** Display name shown in notifications and progress UI. */
+    val displayAppName: String,
+    /** What to do with the file once it's on disk. See [InstallPolicy]. */
+    val installPolicy: InstallPolicy,
+    /**
+     * Release tag of the version being downloaded. Stored on the
+     * orchestrator entry for log / display purposes; the orchestrator
+     * itself doesn't interpret it.
+     */
+    val releaseTag: String,
+)
+
+/**
+ * Snapshot of one download's state in [DownloadOrchestrator.downloads].
+ * Immutable — every state transition produces a new instance.
+ */
+data class OrchestratedDownload(
+    val id: String,
+    val packageName: String,
+    val repoOwner: String,
+    val repoName: String,
+    val displayAppName: String,
+    val assetName: String,
+    val assetSize: Long,
+    val downloadUrl: String,
+    val releaseTag: String,
+    /** Path on disk once the download has completed. Null until then. */
+    val filePath: String?,
+    /** Current install policy — can change mid-flight via downgrade. */
+    val installPolicy: InstallPolicy,
+    val stage: DownloadStage,
+    /** 0..100, null when content-length is unknown. */
+    val progressPercent: Int?,
+    /**
+     * Bytes received so far. Updated on every emission of the
+     * underlying download flow — gives the UI a smooth byte counter
+     * even when the percent integer hasn't ticked over.
+     */
+    val bytesDownloaded: Long = 0L,
+    /**
+     * Total bytes expected. Falls back to [assetSize] when the
+     * server doesn't send `Content-Length`. Null only in rare cases
+     * where neither is known up front.
+     */
+    val totalBytes: Long? = null,
+    /** Error message if [stage] is [DownloadStage.Failed]. */
+    val errorMessage: String? = null,
+)
+
+/**
+ * Lifecycle stages a download moves through. Forward-only except via
+ * [DownloadOrchestrator.cancel] which can interrupt anything before
+ * `Completed`.
+ */
+enum class DownloadStage {
+    /** Sitting in the queue, waiting for a worker slot. */
+    Queued,
+
+    /** OkHttp is actively pulling bytes. */
+    Downloading,
+
+    /** Bytes are on disk; the orchestrator is about to invoke the installer. */
+    Installing,
+
+    /**
+     * Bytes are on disk and the install policy said "wait for the user".
+     * The apps list shows a one-tap install button for entries in this
+     * stage. The notifier was poked when the entry first landed here.
+     */
+    AwaitingInstall,
+
+    /** Installer reported success. The entry is eligible for [DownloadOrchestrator.dismiss]. */
+    Completed,
+
+    /** Cancelled by [DownloadOrchestrator.cancel]. */
+    Cancelled,
+
+    /** Download or install failed. See [OrchestratedDownload.errorMessage]. */
+    Failed,
+}
+
+/**
+ * What the orchestrator should do with the bytes once they're on disk.
+ * See the interface kdoc for the rationale behind each policy.
+ */
+enum class InstallPolicy {
+    /**
+     * Always invoke the installer when the download finishes. Used
+     * for Shizuku silent installs and other unattended paths.
+     */
+    AlwaysInstall,
+
+    /**
+     * Invoke the installer only if the screen that requested the
+     * download is still attached. Foreground ViewModels declare this
+     * and call [DownloadOrchestrator.downgradeToDeferred] in
+     * `onCleared()`.
+     */
+    InstallWhileForeground,
+
+    /**
+     * Never auto-install. The file is parked in
+     * [DownloadStage.AwaitingInstall] and the user installs from the
+     * apps list explicitly.
+     */
+    DeferUntilUserAction,
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/PendingInstallNotifier.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/PendingInstallNotifier.kt
@@ -1,0 +1,50 @@
+package zed.rainxch.core.domain.system
+
+/**
+ * Surfaces "your download is ready, tap to install" notifications.
+ *
+ * Used by [DownloadOrchestrator] when an [InstallPolicy.InstallWhileForeground]
+ * download finishes after the foreground screen has been destroyed
+ * (the user navigated away mid-download). The notification gives them
+ * a one-tap path back into the app to complete the install.
+ *
+ * Platform contracts:
+ *  - **Android**: real notification with a deep link into the apps
+ *    screen. Channel id `pending_installs`. Tapping the notification
+ *    or its action button opens the apps tab; the user installs from
+ *    the row.
+ *  - **JVM/Desktop**: no-op (Desktop doesn't background-install APKs;
+ *    the apps tab is hidden on Desktop anyway).
+ */
+interface PendingInstallNotifier {
+    /**
+     * Posts (or updates) the notification for [packageName].
+     *
+     * @param packageName Used as a stable notification id so multiple
+     *   pending installs each get their own row instead of replacing
+     *   each other.
+     * @param repoOwner GitHub owner — used to build the
+     *   `githubstore://repo/owner/name` deep link so tapping the
+     *   notification opens the Details page for *this specific app*.
+     * @param repoName GitHub repo — paired with [repoOwner] for the
+     *   deep link.
+     * @param appName User-visible app name shown as the notification
+     *   title.
+     * @param versionTag Release tag shown as the notification body
+     *   (e.g. "v1.2.3").
+     */
+    fun notifyPending(
+        packageName: String,
+        repoOwner: String,
+        repoName: String,
+        appName: String,
+        versionTag: String,
+    )
+
+    /**
+     * Dismisses the pending-install notification for [packageName].
+     * Called by the orchestrator when the user installs the file
+     * (either from the apps row or from the notification action).
+     */
+    fun clearPending(packageName: String)
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/PendingInstallNotifier.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/PendingInstallNotifier.kt
@@ -9,10 +9,10 @@ package zed.rainxch.core.domain.system
  * a one-tap path back into the app to complete the install.
  *
  * Platform contracts:
- *  - **Android**: real notification with a deep link into the apps
- *    screen. Channel id `pending_installs`. Tapping the notification
- *    or its action button opens the apps tab; the user installs from
- *    the row.
+ *  - **Android**: real notification with a deep link into the Details
+ *    page for the specific app (`githubstore://repo/owner/name`).
+ *    Falls back to the apps tab (`githubstore://apps`) when owner/repo
+ *    are unavailable. Channel id `app_updates`.
  *  - **JVM/Desktop**: no-op (Desktop doesn't background-install APKs;
  *    the apps tab is hidden on Desktop anyway).
  */

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetFileName.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetFileName.kt
@@ -1,0 +1,139 @@
+package zed.rainxch.core.domain.util
+
+/**
+ * Builds a filename safe for the local downloads directory that's also
+ * unique across repositories.
+ *
+ * # Why this exists
+ *
+ * Two different repos can ship installers with the same filename
+ * (`app.apk`, `release.apk`, `installer.exe` are all common). Without
+ * a per-repo namespace prefix, downloading both clobbers the first
+ * file, breaks the orchestrator's "active downloads by filename"
+ * tracking, and can install the wrong APK on top of the right row.
+ *
+ * # Output format
+ *
+ *     <owner>_<repo>_<original-name>.<ext>
+ *
+ * Examples:
+ *
+ *     ente-io  / ente / ente-auth-3.2.5-arm64-v8a.apk
+ *       → ente-io_ente_ente-auth-3.2.5-arm64-v8a.apk
+ *
+ *     APKMirror / SomeApp / app.apk
+ *       → apkmirror_someapp_app.apk
+ *
+ *     d4rk7355608 / Apps_Manager / Apps Manager-v1.0.apk
+ *       → d4rk7355608_apps_manager_apps_manager-v1.0.apk
+ *
+ * # Sanitization
+ *
+ * Every component is independently sanitized to:
+ *  - Lowercase (filesystem case-folding portability — APFS folds, ext4
+ *    doesn't, NTFS varies — folding eagerly avoids cross-platform
+ *    surprises)
+ *  - Strip path traversal: `..`, `/`, `\`
+ *  - Replace whitespace and shell-unfriendly characters with `_`
+ *  - Collapse runs of `_`
+ *
+ * The original extension is preserved separately so the system
+ * installer's MIME-type detection still works (`.apk`, `.exe`, `.dmg`,
+ * etc.).
+ */
+object AssetFileName {
+    /**
+     * Characters that need replacement. Path separators must go;
+     * everything else is for sanity (whitespace, shell metacharacters,
+     * Windows-illegal chars `< > : " | ? *`). The output keeps `-` and
+     * letters/digits intact because those are the most common tokens
+     * in real filenames.
+     */
+    private val FORBIDDEN = Regex("""[^a-z0-9.\-]""")
+
+    private val MULTI_UNDERSCORE = Regex("_+")
+
+    /**
+     * The maximum length of any single component (owner, repo, name).
+     * 64 chars × 3 components + 2 separators + extension stays
+     * comfortably under the 255-byte filename limit on every
+     * filesystem we target.
+     */
+    private const val MAX_COMPONENT_LEN = 64
+
+    fun scoped(
+        owner: String,
+        repo: String,
+        originalName: String,
+    ): String {
+        val safeOwner = sanitizeComponent(owner).take(MAX_COMPONENT_LEN)
+        val safeRepo = sanitizeComponent(repo).take(MAX_COMPONENT_LEN)
+
+        // Split extension off the original name first so we don't
+        // mangle the dot. Extension carries semantic meaning (the
+        // installer dispatches on it), so we keep it intact and just
+        // sanitize the body.
+        val originalLower = originalName.lowercase()
+        val dotIndex = originalLower.lastIndexOf('.')
+        val (body, ext) =
+            if (dotIndex > 0 && dotIndex < originalLower.length - 1) {
+                originalLower.substring(0, dotIndex) to originalLower.substring(dotIndex)
+            } else {
+                originalLower to ""
+            }
+        val safeBody = sanitizeComponent(body).take(MAX_COMPONENT_LEN)
+        val safeExt = sanitizeExtension(ext)
+
+        // Compose. Empty components are replaced with `unknown` so we
+        // never produce a name like `__app.apk` (the multi-underscore
+        // collapse would still produce `_app.apk`, which is uglier
+        // than carrying a placeholder).
+        val ownerPart = safeOwner.ifBlank { "unknown" }
+        val repoPart = safeRepo.ifBlank { "unknown" }
+        val bodyPart = safeBody.ifBlank { "asset" }
+
+        val joined = "${ownerPart}_${repoPart}_$bodyPart$safeExt"
+        return MULTI_UNDERSCORE.replace(joined, "_")
+    }
+
+    /**
+     * True when [fileName] is in the scoped format produced by [scoped].
+     * Used by the orchestrator to detect "is this already namespaced"
+     * so callers can pass either form during the migration window.
+     */
+    fun isScoped(
+        fileName: String,
+        owner: String,
+        repo: String,
+    ): Boolean {
+        val expectedPrefix = "${sanitizeComponent(owner).take(MAX_COMPONENT_LEN)}_" +
+            "${sanitizeComponent(repo).take(MAX_COMPONENT_LEN)}_"
+        return fileName.lowercase().startsWith(expectedPrefix)
+    }
+
+    private fun sanitizeComponent(input: String): String {
+        if (input.isBlank()) return ""
+        val lowered = input.lowercase()
+        // Replace path separators *first* so they always become a
+        // single `_` rather than getting eaten by FORBIDDEN's
+        // greedy collapse.
+        val withoutSeparators =
+            lowered.replace('/', '_').replace('\\', '_')
+        // Strip path-traversal sequences before letter sanitization;
+        // a leading `..` would otherwise survive as `..` and the
+        // OS would interpret it.
+        val noDots = withoutSeparators.replace("..", "_")
+        return FORBIDDEN.replace(noDots, "_")
+    }
+
+    private fun sanitizeExtension(ext: String): String {
+        if (ext.isEmpty()) return ""
+        // Extensions are short and character-restricted by convention.
+        // We allow `.apk`, `.exe`, `.dmg`, `.deb`, `.rpm`, `.msi`,
+        // `.pkg`, `.zip` and similar — anything weirder gets the
+        // generic sanitizer applied.
+        val cleaned = FORBIDDEN.replace(ext, "")
+        // Re-prepend the dot if the regex stripped it.
+        return if (cleaned.startsWith('.')) cleaned else ".$cleaned"
+    }
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetFileName.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetFileName.kt
@@ -106,8 +106,9 @@ object AssetFileName {
         owner: String,
         repo: String,
     ): Boolean {
-        val expectedPrefix = "${sanitizeComponent(owner).take(MAX_COMPONENT_LEN)}_" +
-            "${sanitizeComponent(repo).take(MAX_COMPONENT_LEN)}_"
+        val ownerPart = sanitizeComponent(owner).take(MAX_COMPONENT_LEN).ifBlank { "unknown" }
+        val repoPart = sanitizeComponent(repo).take(MAX_COMPONENT_LEN).ifBlank { "unknown" }
+        val expectedPrefix = MULTI_UNDERSCORE.replace("${ownerPart}_${repoPart}_", "_")
         return fileName.lowercase().startsWith(expectedPrefix)
     }
 

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -681,4 +681,7 @@
     <string name="variant_first_pin_toast_generic">سوف تفضل التحديثات المستقبلية هذا النوع. غيّر هذا في أي وقت من إعدادات التطبيق.</string>
     <string name="variant_unpinned_toast">تم إلغاء تثبيت النوع. ستستخدم التحديثات المنتقي التلقائي.</string>
     <string name="advanced_filter_variant_relation">يحدد المرشّح الملفات التي يتم النظر فيها. يحدد تثبيت النوع أيها سيتم تثبيته.</string>
+    <string name="install">تثبيت</string>
+    <string name="ready_to_install">جاهز للتثبيت</string>
+    <string name="install_ready">تثبيت (جاهز)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -680,4 +680,7 @@
     <string name="variant_first_pin_toast_generic">ভবিষ্যতের আপডেটগুলি এই ভ্যারিয়েন্ট পছন্দ করবে। অ্যাপ সেটিংস থেকে যেকোনো সময় পরিবর্তন করুন।</string>
     <string name="variant_unpinned_toast">ভ্যারিয়েন্ট আনপিন করা হয়েছে। আপডেটগুলি স্বয়ংক্রিয় নির্বাচক ব্যবহার করবে।</string>
     <string name="advanced_filter_variant_relation">ফিল্টার নির্ধারণ করে কোন অ্যাসেটগুলি বিবেচনা করা হবে। ভ্যারিয়েন্ট পিন নির্ধারণ করে সেগুলির কোনটি ইনস্টল হবে।</string>
+    <string name="install">ইনস্টল</string>
+    <string name="ready_to_install">ইনস্টলের জন্য প্রস্তুত</string>
+    <string name="install_ready">ইনস্টল (প্রস্তুত)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -641,4 +641,7 @@
     <string name="variant_first_pin_toast_generic">Las próximas actualizaciones preferirán esta variante. Cámbialo cuando quieras desde los ajustes de la app.</string>
     <string name="variant_unpinned_toast">Variante desfijada. Las actualizaciones usarán el selector automático.</string>
     <string name="advanced_filter_variant_relation">El filtro decide qué archivos se consideran. La variante fijada decide cuál de ellos se instala.</string>
+    <string name="install">Instalar</string>
+    <string name="ready_to_install">Listo para instalar</string>
+    <string name="install_ready">Instalar (listo)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -642,4 +642,7 @@
     <string name="variant_first_pin_toast_generic">Les futures mises à jour préféreront cette variante. Modifiable à tout moment dans les paramètres de l\'application.</string>
     <string name="variant_unpinned_toast">Variante désépinglée. Les mises à jour utiliseront le sélecteur automatique.</string>
     <string name="advanced_filter_variant_relation">Le filtre décide quels fichiers sont pris en compte. L\'épingle de variante décide lequel sera installé.</string>
+    <string name="install">Installer</string>
+    <string name="ready_to_install">Prêt à installer</string>
+    <string name="install_ready">Installer (prêt)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -679,4 +679,7 @@
     <string name="variant_first_pin_toast_generic">भविष्य के अपडेट इस वेरिएंट को प्राथमिकता देंगे। ऐप सेटिंग्स में किसी भी समय बदलें।</string>
     <string name="variant_unpinned_toast">वेरिएंट अनपिन किया गया। अपडेट स्वचालित चयनकर्ता का उपयोग करेंगे।</string>
     <string name="advanced_filter_variant_relation">फ़िल्टर तय करता है कि कौन सी एसेट्स पर विचार किया जाए। वेरिएंट पिन तय करता है कि उनमें से कौन इंस्टॉल हो।</string>
+    <string name="install">इंस्टॉल</string>
+    <string name="ready_to_install">इंस्टॉल के लिए तैयार</string>
+    <string name="install_ready">इंस्टॉल (तैयार)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -680,4 +680,7 @@
     <string name="variant_first_pin_toast_generic">I prossimi aggiornamenti preferiranno questa variante. Puoi modificarlo in qualsiasi momento dalle impostazioni dell\'app.</string>
     <string name="variant_unpinned_toast">Variante sbloccata. Gli aggiornamenti useranno il selettore automatico.</string>
     <string name="advanced_filter_variant_relation">Il filtro decide quali file vengono considerati. Il blocco della variante decide quale di essi viene installato.</string>
+    <string name="install">Installa</string>
+    <string name="ready_to_install">Pronto per l\'installazione</string>
+    <string name="install_ready">Installa (pronto)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -641,4 +641,7 @@
     <string name="variant_first_pin_toast_generic">今後のアップデートではこのバリアントが優先されます。アプリ設定からいつでも変更できます。</string>
     <string name="variant_unpinned_toast">バリアントの固定を解除しました。アップデートは自動選択を使用します。</string>
     <string name="advanced_filter_variant_relation">フィルターはどのアセットを考慮するかを決めます。バリアントの固定はそのうちどれをインストールするかを決めます。</string>
+    <string name="install">インストール</string>
+    <string name="ready_to_install">インストール準備完了</string>
+    <string name="install_ready">インストール（準備完了）</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -676,4 +676,7 @@
     <string name="variant_first_pin_toast_generic">앞으로의 업데이트는 이 변형을 우선 사용합니다. 앱 설정에서 언제든지 변경할 수 있습니다.</string>
     <string name="variant_unpinned_toast">변형 고정이 해제되었습니다. 업데이트는 자동 선택을 사용합니다.</string>
     <string name="advanced_filter_variant_relation">필터는 어떤 에셋을 고려할지 결정합니다. 변형 고정은 그중 무엇이 설치될지 결정합니다.</string>
+    <string name="install">설치</string>
+    <string name="ready_to_install">설치 준비 완료</string>
+    <string name="install_ready">설치 (준비됨)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -648,4 +648,7 @@
     <string name="variant_first_pin_toast_generic">Przyszłe aktualizacje będą preferować ten wariant. Możesz to zmienić w dowolnym momencie w ustawieniach aplikacji.</string>
     <string name="variant_unpinned_toast">Wariant odpięty. Aktualizacje będą używać automatycznego selektora.</string>
     <string name="advanced_filter_variant_relation">Filtr decyduje, które pliki są brane pod uwagę. Przypięty wariant decyduje, który z nich zostanie zainstalowany.</string>
+    <string name="install">Zainstaluj</string>
+    <string name="ready_to_install">Gotowe do instalacji</string>
+    <string name="install_ready">Zainstaluj (gotowe)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -648,4 +648,7 @@
     <string name="variant_first_pin_toast_generic">Будущие обновления будут предпочитать этот вариант. Изменить это можно в любое время в настройках приложения.</string>
     <string name="variant_unpinned_toast">Вариант откреплён. Обновления будут использовать автоматический выбор.</string>
     <string name="advanced_filter_variant_relation">Фильтр определяет, какие файлы рассматриваются. Закреплённый вариант определяет, какой из них будет установлен.</string>
+    <string name="install">Установить</string>
+    <string name="ready_to_install">Готово к установке</string>
+    <string name="install_ready">Установить (готово)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -678,4 +678,7 @@
     <string name="variant_first_pin_toast_generic">Sonraki güncellemeler bu varyantı tercih edecek. Bunu uygulama ayarlarından istediğiniz zaman değiştirebilirsiniz.</string>
     <string name="variant_unpinned_toast">Varyant sabitlemesi kaldırıldı. Güncellemeler otomatik seçiciyi kullanacak.</string>
     <string name="advanced_filter_variant_relation">Filtre hangi dosyaların dikkate alınacağına karar verir. Varyant sabitlemesi bunlardan hangisinin yükleneceğine karar verir.</string>
+    <string name="install">Yükle</string>
+    <string name="ready_to_install">Yüklemeye hazır</string>
+    <string name="install_ready">Yükle (hazır)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -642,4 +642,7 @@
     <string name="variant_first_pin_toast_generic">将来的更新将优先使用此变体。可以随时在应用设置中更改。</string>
     <string name="variant_unpinned_toast">变体固定已取消。更新将使用自动选择器。</string>
     <string name="advanced_filter_variant_relation">筛选器决定考虑哪些资源。变体固定决定其中哪一个被安装。</string>
+    <string name="install">安装</string>
+    <string name="ready_to_install">准备安装</string>
+    <string name="install_ready">安装（已就绪）</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -689,4 +689,8 @@
     <string name="variant_first_pin_toast_generic">Future updates will prefer this variant. Change this anytime in app settings.</string>
     <string name="variant_unpinned_toast">Variant unpinned. Updates will use the automatic picker.</string>
     <string name="advanced_filter_variant_relation">The filter decides which assets are considered. The variant pin decides which of those assets gets installed.</string>
+    <!-- Pending install (deferred download) -->
+    <string name="install">Install</string>
+    <string name="ready_to_install">Ready to install</string>
+    <string name="install_ready">Install (ready)</string>
 </resources>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -90,4 +90,14 @@ sealed interface AppsAction {
     // Export/Import
     data object OnExportApps : AppsAction
     data object OnImportApps : AppsAction
+
+    /**
+     * User tapped the "Install" affordance on a row whose download
+     * was previously deferred (the user navigated away from Details
+     * mid-download). The orchestrator parked the file; this action
+     * picks it up and runs the installer.
+     */
+    data class OnInstallPendingApp(
+        val app: InstalledAppUi,
+    ) : AppsAction
 }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -105,6 +105,8 @@ import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.add_by_link
 import zed.rainxch.githubstore.core.presentation.res.advanced_settings_open
+import zed.rainxch.githubstore.core.presentation.res.install
+import zed.rainxch.githubstore.core.presentation.res.ready_to_install
 import zed.rainxch.githubstore.core.presentation.res.variant_label_inline
 import zed.rainxch.githubstore.core.presentation.res.variant_picker_open
 import zed.rainxch.githubstore.core.presentation.res.variant_stale_hint
@@ -542,6 +544,9 @@ fun AppsScreen(
                                                 ),
                                             )
                                         },
+                                        onInstallPendingClick = {
+                                            onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
+                                        },
                                         modifier =
                                             Modifier
                                                 .then(
@@ -635,6 +640,7 @@ fun AppItemCard(
     onTogglePreReleases: (Boolean) -> Unit,
     onAdvancedSettingsClick: () -> Unit,
     onPickVariantClick: () -> Unit,
+    onInstallPendingClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val app = appItem.installedApp
@@ -703,6 +709,18 @@ fun AppItemCard(
                     }
 
                     when {
+                        // Highest priority: a download finished while
+                        // the user wasn't watching, the file is on disk
+                        // and ready to be installed with one tap.
+                        app.pendingInstallFilePath != null -> {
+                            Text(
+                                text = stringResource(Res.string.ready_to_install),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+
                         app.isPendingInstall -> {
                             Text(
                                 text = stringResource(Res.string.pending_install),
@@ -1000,7 +1018,26 @@ fun AppItemCard(
                     }
 
                     else -> {
-                        if (app.isUpdateAvailable && !app.isPendingInstall) {
+                        if (app.pendingInstallFilePath != null) {
+                            // One-tap install for a deferred download.
+                            // Bypasses the download phase entirely —
+                            // the file is already on disk.
+                            Button(
+                                onClick = onInstallPendingClick,
+                                modifier = Modifier.weight(1f),
+                                enabled = !isBusy,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Update,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text = stringResource(Res.string.install),
+                                )
+                            }
+                        } else if (app.isUpdateAvailable && !app.isPendingInstall) {
                             Button(
                                 onClick = onUpdateClick,
                                 modifier = Modifier.weight(1f),

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -29,12 +29,19 @@ import zed.rainxch.apps.presentation.model.UpdateAllProgress
 import zed.rainxch.apps.presentation.model.UpdateState
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.InstalledApp
+import zed.rainxch.core.domain.model.InstallerType
 import zed.rainxch.core.domain.model.RateLimitException
 import zed.rainxch.core.domain.network.Downloader
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
 import zed.rainxch.core.domain.repository.TweaksRepository
+import zed.rainxch.core.domain.system.DownloadOrchestrator
+import zed.rainxch.core.domain.system.DownloadSpec
+import zed.rainxch.core.domain.system.DownloadStage as OrchestratorStage
+import zed.rainxch.core.domain.system.InstallPolicy
 import zed.rainxch.core.domain.system.Installer
 import zed.rainxch.core.domain.use_cases.SyncInstalledAppsUseCase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
 import zed.rainxch.core.domain.util.AssetFilter
 import zed.rainxch.core.domain.util.AssetVariant
 import zed.rainxch.core.domain.utils.ShareManager
@@ -50,6 +57,7 @@ class AppsViewModel(
     private val logger: GitHubStoreLogger,
     private val shareManager: ShareManager,
     private val tweaksRepository: TweaksRepository,
+    private val downloadOrchestrator: DownloadOrchestrator,
 ) : ViewModel() {
     companion object {
         private const val UPDATE_CHECK_COOLDOWN_MS = 30 * 60 * 1000L
@@ -223,6 +231,10 @@ class AppsViewModel(
                 } else {
                     updateSingleApp(action.app)
                 }
+            }
+
+            is AppsAction.OnInstallPendingApp -> {
+                installPendingApp(action.app)
             }
 
             is AppsAction.OnCancelUpdate -> {
@@ -912,13 +924,51 @@ class AppsViewModel(
 
                     updateAppState(app.packageName, UpdateState.Downloading)
 
-                    downloader.download(latestAssetUrl, latestAssetName).collect { progress ->
-                        updateAppProgress(app.packageName, progress.percent)
-                    }
+                    // Route the download through the orchestrator so
+                    // it survives this VM being torn down (user
+                    // navigating away from the apps tab). Shizuku
+                    // gets AlwaysInstall (silent install regardless
+                    // of foreground state); regular installer gets
+                    // InstallWhileForeground so the existing dialog/
+                    // installer dispatch below stays in charge.
+                    val installerType =
+                        try {
+                            tweaksRepository.getInstallerType().first()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            InstallerType.DEFAULT
+                        }
+                    val policy =
+                        when (installerType) {
+                            InstallerType.SHIZUKU -> InstallPolicy.AlwaysInstall
+                            InstallerType.DEFAULT -> InstallPolicy.InstallWhileForeground
+                        }
+
+                    downloadOrchestrator.enqueue(
+                        DownloadSpec(
+                            packageName = app.packageName,
+                            repoOwner = app.repoOwner,
+                            repoName = app.repoName,
+                            asset = primaryAsset,
+                            displayAppName = app.appName,
+                            installPolicy = policy,
+                            releaseTag = latestRelease.tagName,
+                        ),
+                    )
 
                     val filePath =
-                        downloader.getDownloadedFilePath(latestAssetName)
-                            ?: throw IllegalStateException("Downloaded file not found")
+                        waitForOrchestratorReady(app.packageName) { progress ->
+                            updateAppProgress(app.packageName, progress)
+                        }
+                    if (filePath == null) {
+                        // Either the orchestrator already installed
+                        // (Shizuku/AlwaysInstall completed) or the
+                        // download failed/cancelled. Either way, the
+                        // local install path below has nothing to do.
+                        updateAppState(app.packageName, UpdateState.Idle)
+                        return@launch
+                    }
 
                     val apkInfo =
                         installer.getApkInfoExtractor().extractPackageInfo(filePath)
@@ -947,6 +997,19 @@ class AppsViewModel(
                     } catch (e: Exception) {
                         installedAppsRepository.updatePendingStatus(app.packageName, false)
                         throw e
+                    }
+
+                    // Successful install — release the orchestrator
+                    // entry so the apps row stops showing the
+                    // download/install state. The DB sync continues
+                    // via PackageEventReceiver.
+                    downloadOrchestrator.dismiss(app.packageName)
+                    try {
+                        installedAppsRepository.setPendingInstallFilePath(app.packageName, null)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (clearEx: Exception) {
+                        logger.error("Failed to clear pending install file path: ${clearEx.message}")
                     }
 
                     updateAppState(app.packageName, UpdateState.Idle)
@@ -1173,6 +1236,83 @@ class AppsViewModel(
     private suspend fun markPendingUpdate(app: InstalledApp) {
         installedAppsRepository.updatePendingStatus(app.packageName, true)
         logger.debug("Marked ${app.packageName} as pending install")
+    }
+
+    /**
+     * Subscribes to the orchestrator's entry for [packageName] and
+     * suspends until it reaches a terminal stage. Mirrors progress
+     * via [onProgress] while downloading.
+     *
+     * Returns:
+     *  - The file path when the orchestrator parks the file at
+     *    [OrchestratorStage.AwaitingInstall] (regular installer path)
+     *  - `null` when the orchestrator finishes its own install
+     *    ([OrchestratorStage.Completed], the Shizuku/AlwaysInstall
+     *    path) — the caller has nothing more to do
+     *  - `null` when the entry is cancelled or fails — the caller
+     *    treats this as "abort the local install logic"
+     *
+     * Implementation: forwards progress side-effects via a
+     * `transform` step, then `first { predicate }` finds the first
+     * emission whose stage is terminal. Avoids needing to throw out
+     * of `collect`.
+     */
+    private suspend fun waitForOrchestratorReady(
+        packageName: String,
+        onProgress: (Int) -> Unit,
+    ): String? {
+        val terminal =
+            downloadOrchestrator
+                .observe(packageName)
+                .onEach { entry ->
+                    if (entry != null) {
+                        entry.progressPercent?.let(onProgress)
+                    }
+                }
+                .first { entry ->
+                    entry == null ||
+                        entry.stage == OrchestratorStage.AwaitingInstall ||
+                        entry.stage == OrchestratorStage.Completed ||
+                        entry.stage == OrchestratorStage.Cancelled ||
+                        entry.stage == OrchestratorStage.Failed
+                }
+        return when {
+            terminal == null -> null
+            terminal.stage == OrchestratorStage.AwaitingInstall -> terminal.filePath
+            else -> null
+        }
+    }
+
+    /**
+     * Triggers an install for an app whose download was previously
+     * deferred (the orchestrator parked the file in `AwaitingInstall`
+     * mode after the user navigated away mid-download). Used by the
+     * apps row "Install" button when [InstalledAppUi.pendingInstallFilePath]
+     * is non-null.
+     *
+     * Delegates to [DownloadOrchestrator.installPending] which
+     * handles validation-free install + DB cleanup.
+     */
+    private fun installPendingApp(app: InstalledAppUi) {
+        if (activeUpdates.containsKey(app.packageName)) {
+            logger.debug("Install already in progress for ${app.packageName}")
+            return
+        }
+        viewModelScope.launch {
+            try {
+                updateAppState(app.packageName, UpdateState.Installing)
+                downloadOrchestrator.installPending(app.packageName)
+                updateAppState(app.packageName, UpdateState.Idle)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                logger.error("Failed to install pending app ${app.packageName}: ${t.message}")
+                updateAppState(
+                    app.packageName,
+                    UpdateState.Error(t.message ?: "Install failed"),
+                )
+            }
+        }
     }
 
     private suspend fun cleanupUpdate(
@@ -1714,17 +1854,21 @@ class AppsViewModel(
     override fun onCleared() {
         super.onCleared()
 
+        // Cancel local OBSERVERS only — the orchestrator entries
+        // keep running in the application scope. Each in-flight
+        // download is downgraded to DeferUntilUserAction so the
+        // user gets a notification when it's ready, instead of
+        // losing the work.
         updateAllJob?.cancel()
+        val packageNames = activeUpdates.keys.toList()
         activeUpdates.values.forEach { it.cancel() }
 
-        viewModelScope.launch {
-            _state.value.apps.forEach { appItem ->
-                if (appItem.updateState != UpdateState.Idle &&
-                    appItem.updateState != UpdateState.Success
-                ) {
-                    appItem.installedApp.latestAssetName?.let { assetName ->
-                        downloader.cancelDownload(assetName)
-                    }
+        viewModelScope.launch(kotlinx.coroutines.NonCancellable) {
+            for (packageName in packageNames) {
+                try {
+                    downloadOrchestrator.downgradeToDeferred(packageName)
+                } catch (t: Throwable) {
+                    logger.error("Failed to downgrade orchestrator for $packageName: ${t.message}")
                 }
             }
         }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -957,22 +957,31 @@ class AppsViewModel(
                         ),
                     )
 
-                    val filePath =
+                    val orchestratorResult =
                         waitForOrchestratorReady(app.packageName) { progress ->
                             updateAppProgress(app.packageName, progress)
                         }
-                    if (filePath == null) {
-                        // Either the orchestrator already installed
-                        // (Shizuku/AlwaysInstall completed) or the
-                        // download failed/cancelled. Either way, the
-                        // local install path below has nothing to do.
-                        updateAppState(app.packageName, UpdateState.Idle)
-                        return@launch
+                    val filePath = when (orchestratorResult) {
+                        is OrchestratorResult.Ready -> orchestratorResult.filePath
+                        is OrchestratorResult.AlreadyInstalled -> {
+                            updateAppState(app.packageName, UpdateState.Idle)
+                            return@launch
+                        }
+                        is OrchestratorResult.Cancelled -> {
+                            updateAppState(app.packageName, UpdateState.Idle)
+                            return@launch
+                        }
+                        is OrchestratorResult.Failed -> {
+                            updateAppState(
+                                app.packageName,
+                                UpdateState.Error(orchestratorResult.message ?: "Download failed"),
+                            )
+                            return@launch
+                        }
                     }
 
                     val apkInfo =
                         installer.getApkInfoExtractor().extractPackageInfo(filePath)
-                            ?: throw IllegalStateException("Failed to extract APK info")
 
                     val currentApp = installedAppsRepository.getAppByPackage(app.packageName)
                     if (currentApp != null) {
@@ -982,8 +991,8 @@ class AppsViewModel(
                                 latestVersion = latestVersion,
                                 latestAssetName = latestAssetName,
                                 latestAssetUrl = latestAssetUrl,
-                                latestVersionName = apkInfo.versionName,
-                                latestVersionCode = apkInfo.versionCode,
+                                latestVersionName = apkInfo?.versionName ?: latestVersion,
+                                latestVersionCode = apkInfo?.versionCode ?: 0L,
                             ),
                         )
                     } else {
@@ -1257,10 +1266,22 @@ class AppsViewModel(
      * emission whose stage is terminal. Avoids needing to throw out
      * of `collect`.
      */
+    /**
+     * Result type for [waitForOrchestratorReady] so callers can
+     * distinguish "file is ready" from "orchestrator already installed"
+     * from "download failed".
+     */
+    private sealed interface OrchestratorResult {
+        data class Ready(val filePath: String) : OrchestratorResult
+        data object AlreadyInstalled : OrchestratorResult
+        data object Cancelled : OrchestratorResult
+        data class Failed(val message: String?) : OrchestratorResult
+    }
+
     private suspend fun waitForOrchestratorReady(
         packageName: String,
         onProgress: (Int) -> Unit,
-    ): String? {
+    ): OrchestratorResult {
         val terminal =
             downloadOrchestrator
                 .observe(packageName)
@@ -1277,9 +1298,13 @@ class AppsViewModel(
                         entry.stage == OrchestratorStage.Failed
                 }
         return when {
-            terminal == null -> null
-            terminal.stage == OrchestratorStage.AwaitingInstall -> terminal.filePath
-            else -> null
+            terminal == null -> OrchestratorResult.Cancelled
+            terminal.stage == OrchestratorStage.AwaitingInstall ->
+                terminal.filePath?.let { OrchestratorResult.Ready(it) }
+                    ?: OrchestratorResult.Failed("Downloaded file path missing")
+            terminal.stage == OrchestratorStage.Completed -> OrchestratorResult.AlreadyInstalled
+            terminal.stage == OrchestratorStage.Failed -> OrchestratorResult.Failed(terminal.errorMessage)
+            else -> OrchestratorResult.Cancelled
         }
     }
 

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/mappers/InstalledAppMapper.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/mappers/InstalledAppMapper.kt
@@ -46,6 +46,9 @@ fun InstalledApp.toUi(): InstalledAppUi =
         assetGlobPattern = assetGlobPattern,
         pickedAssetIndex = pickedAssetIndex,
         pickedAssetSiblingCount = pickedAssetSiblingCount,
+        pendingInstallFilePath = pendingInstallFilePath,
+        pendingInstallVersion = pendingInstallVersion,
+        pendingInstallAssetName = pendingInstallAssetName,
     )
 
 fun InstalledAppUi.toDomain(): InstalledApp =
@@ -91,4 +94,7 @@ fun InstalledAppUi.toDomain(): InstalledApp =
         assetGlobPattern = assetGlobPattern,
         pickedAssetIndex = pickedAssetIndex,
         pickedAssetSiblingCount = pickedAssetSiblingCount,
+        pendingInstallFilePath = pendingInstallFilePath,
+        pendingInstallVersion = pendingInstallVersion,
+        pendingInstallAssetName = pendingInstallAssetName,
     )

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/model/InstalledAppUi.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/model/InstalledAppUi.kt
@@ -44,4 +44,7 @@ data class InstalledAppUi(
     val assetGlobPattern: String? = null,
     val pickedAssetIndex: Int? = null,
     val pickedAssetSiblingCount: Int? = null,
+    val pendingInstallFilePath: String? = null,
+    val pendingInstallVersion: String? = null,
+    val pendingInstallAssetName: String? = null,
 )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -75,4 +75,24 @@ data class DetailsState(
                 ReleaseCategory.PRE_RELEASE -> allReleases.filter { it.isPrerelease }
                 ReleaseCategory.ALL -> allReleases
             }
+
+    /**
+     * True when the currently-tracked app has a *parked* install file
+     * that matches the user's current selection (release tag + asset
+     * name). The install button can short-circuit the download phase
+     * and dispatch the dialog/install flow on the parked file directly.
+     *
+     * This is the data-layer match — the VM also re-checks the file
+     * exists on disk before actually using it (in [parkedFilePathIfMatches]).
+     */
+    val isPendingInstallReady: Boolean
+        get() {
+            val app = installedApp ?: return false
+            val parkedVersion = app.pendingInstallVersion ?: return false
+            val parkedAsset = app.pendingInstallAssetName ?: return false
+            if (app.pendingInstallFilePath.isNullOrBlank()) return false
+            val tag = selectedRelease?.tagName ?: return false
+            val assetName = primaryAsset?.name ?: return false
+            return parkedVersion == tag && parkedAsset == assetName
+        }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -34,8 +34,13 @@ import zed.rainxch.core.domain.repository.InstalledAppsRepository
 import zed.rainxch.core.domain.repository.SeenReposRepository
 import zed.rainxch.core.domain.repository.StarredRepository
 import zed.rainxch.core.domain.repository.TweaksRepository
+import zed.rainxch.core.domain.system.DownloadOrchestrator
+import zed.rainxch.core.domain.system.DownloadSpec
+import zed.rainxch.core.domain.system.DownloadStage as OrchestratorStage
 import zed.rainxch.core.domain.system.InstallOutcome
+import zed.rainxch.core.domain.system.InstallPolicy
 import zed.rainxch.core.domain.system.Installer
+import zed.rainxch.core.domain.model.InstallerType
 import zed.rainxch.core.domain.system.PackageMonitor
 import zed.rainxch.core.domain.use_cases.SyncInstalledAppsUseCase
 import zed.rainxch.core.domain.util.AssetVariant
@@ -103,14 +108,13 @@ class DetailsViewModel(
     private val seenReposRepository: SeenReposRepository,
     private val installationManager: InstallationManager,
     private val attestationVerifier: AttestationVerifier,
+    private val downloadOrchestrator: DownloadOrchestrator,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentDownloadJob: Job? = null
     private var currentAssetName: String? = null
     private var aboutTranslationJob: Job? = null
     private var whatsNewTranslationJob: Job? = null
-
-    private var cachedDownloadAssetName: String? = null
 
     private val _state = MutableStateFlow(DetailsState())
     val state =
@@ -900,9 +904,19 @@ class DetailsViewModel(
         currentDownloadJob?.cancel()
         currentDownloadJob = null
 
+        val packageKey = orchestratorKey()
+        viewModelScope.launch {
+            try {
+                downloadOrchestrator.cancel(packageKey)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                logger.error("Failed to cancel orchestrator download: ${t.message}")
+            }
+        }
+
         val assetName = currentAssetName
         if (assetName != null) {
-            cachedDownloadAssetName = assetName
             val releaseTag = _state.value.selectedRelease?.tagName ?: ""
             val totalSize = _state.value.totalBytes ?: _state.value.downloadedBytes
             appendLog(
@@ -911,7 +925,7 @@ class DetailsViewModel(
                 size = totalSize,
                 result = LogResult.Cancelled,
             )
-            logger.debug("Download cancelled – keeping file for potential reuse: $assetName")
+            logger.debug("Download cancelled via orchestrator: $assetName")
         }
 
         currentAssetName = null
@@ -1034,6 +1048,29 @@ class DetailsViewModel(
         }
     }
 
+    /**
+     * Entry point for "download + install" from the install button.
+     *
+     * Hands the actual download off to [downloadOrchestrator] (so it
+     * survives this screen being destroyed) and then observes the
+     * orchestrator's state to mirror progress into [DetailsState] and
+     * to dispatch the install dialog flow when bytes are on disk.
+     *
+     * Install policy is decided by installer type:
+     *  - **Shizuku**: [InstallPolicy.AlwaysInstall] — orchestrator
+     *    runs the install in its own scope. The user gets a silent
+     *    install whether they stay on this screen or not. The
+     *    PackageEventReceiver picks up `PACKAGE_REPLACED` and the
+     *    installed-apps DB syncs without further work from the VM.
+     *  - **Regular installer**: [InstallPolicy.InstallWhileForeground]
+     *    — orchestrator parks the file at `AwaitingInstall` and the
+     *    foreground VM (this one) runs the existing dialog flow
+     *    (validation → fingerprint check → installer.install → DB
+     *    save). If the screen leaves before bytes are done, the
+     *    VM's `onCleared` calls [DownloadOrchestrator.downgradeToDeferred],
+     *    the orchestrator notifies the user, and the apps row picks
+     *    up the deferred install.
+     */
     private fun installAsset(
         downloadUrl: String,
         assetName: String,
@@ -1041,26 +1078,132 @@ class DetailsViewModel(
         releaseTag: String,
         isUpdate: Boolean = false,
     ) {
+        // Cancel the existing observation job (if any) — but not the
+        // orchestrator entry itself. A user re-tapping install for a
+        // different asset should preempt the *previous* observer, not
+        // the in-flight download (the orchestrator dedupes by
+        // package name).
         currentDownloadJob?.cancel()
+        val packageKey = orchestratorKey()
+        val asset = _state.value.primaryAsset
+        val repository = _state.value.repository
+        if (asset == null || repository == null) {
+            logger.warn("installAsset called with missing primaryAsset/repository")
+            return
+        }
+        currentAssetName = assetName
+
+        // ────────────────────────────────────────────────────────
+        // SHORT-CIRCUIT: parked file matches what the user picked
+        // ────────────────────────────────────────────────────────
+        // If the user already deferred a download for this exact
+        // (releaseTag, assetName) pair (e.g. they navigated away
+        // from Details mid-download, the file got parked, and now
+        // they're back), skip the orchestrator entirely and
+        // dispatch the existing install dialog flow on the parked
+        // file directly. Saves the network round-trip and the
+        // disk space of a duplicate download.
+        val parkedFilePath = parkedFilePathIfMatches(releaseTag, assetName)
+        if (parkedFilePath != null) {
+            logger.debug("Reusing parked file for $releaseTag / $assetName")
+            currentDownloadJob =
+                viewModelScope.launch {
+                    try {
+                        appendLog(
+                            assetName = assetName,
+                            size = sizeBytes,
+                            tag = releaseTag,
+                            result = LogResult.Downloaded,
+                        )
+                        installAsset(
+                            isUpdate = isUpdate,
+                            filePath = parkedFilePath,
+                            assetName = assetName,
+                            downloadUrl = downloadUrl,
+                            sizeBytes = sizeBytes,
+                            releaseTag = releaseTag,
+                        )
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (t: Throwable) {
+                        logger.error("Install of parked file failed: ${t.message}")
+                        _state.value =
+                            _state.value.copy(
+                                downloadStage = DownloadStage.IDLE,
+                                installError = t.message,
+                            )
+                        currentAssetName = null
+                        appendLog(
+                            assetName = assetName,
+                            size = sizeBytes,
+                            tag = releaseTag,
+                            result = Error(t.message),
+                        )
+                    }
+                }
+            return
+        }
+
+        appendLog(
+            assetName = assetName,
+            size = sizeBytes,
+            tag = releaseTag,
+            result =
+                if (isUpdate) {
+                    LogResult.UpdateStarted
+                } else {
+                    LogResult.DownloadStarted
+                },
+        )
+
         currentDownloadJob =
             viewModelScope.launch {
                 try {
-                    val filePath: String =
-                        downloadAsset(
-                            assetName = assetName,
-                            sizeBytes = sizeBytes,
-                            releaseTag = releaseTag,
-                            isUpdate = isUpdate,
-                            downloadUrl = downloadUrl,
-                        ) ?: return@launch
+                    val installerType =
+                        try {
+                            tweaksRepository.getInstallerType().first()
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            InstallerType.DEFAULT
+                        }
 
-                    installAsset(
-                        isUpdate = isUpdate,
-                        filePath = filePath,
-                        assetName = assetName,
+                    val policy =
+                        when (installerType) {
+                            InstallerType.SHIZUKU -> InstallPolicy.AlwaysInstall
+                            InstallerType.DEFAULT -> InstallPolicy.InstallWhileForeground
+                        }
+
+                    downloadOrchestrator.enqueue(
+                        DownloadSpec(
+                            packageName = packageKey,
+                            repoOwner = repository.owner.login,
+                            repoName = repository.name,
+                            asset = asset,
+                            displayAppName = repository.name,
+                            installPolicy = policy,
+                            releaseTag = releaseTag,
+                        ),
+                    )
+
+                    _state.value =
+                        _state.value.copy(
+                            downloadError = null,
+                            installError = null,
+                            downloadProgressPercent = null,
+                            downloadStage = DownloadStage.DOWNLOADING,
+                            downloadedBytes = 0L,
+                            totalBytes = sizeBytes,
+                            attestationStatus = AttestationStatus.UNCHECKED,
+                        )
+
+                    observeOrchestratorEntry(
+                        packageKey = packageKey,
                         downloadUrl = downloadUrl,
+                        assetName = assetName,
                         sizeBytes = sizeBytes,
                         releaseTag = releaseTag,
+                        isUpdate = isUpdate,
                     )
                 } catch (e: kotlinx.coroutines.CancellationException) {
                     throw e
@@ -1081,6 +1224,235 @@ class DetailsViewModel(
                     )
                 }
             }
+    }
+
+    /**
+     * Returns the path of a parked install file iff the currently-tracked
+     * app has one AND it represents *this exact* (releaseTag, assetName)
+     * pair AND the file still exists on disk.
+     *
+     * Used as the short-circuit gate in [installAsset] to skip the
+     * orchestrator round-trip when the bytes are already on disk.
+     * Returns `null` (= "do a fresh download") in any of these cases:
+     *  - app not tracked
+     *  - no parked file
+     *  - parked file represents a different version or asset
+     *  - parked file no longer exists (manually deleted, etc.)
+     */
+    private fun parkedFilePathIfMatches(
+        releaseTag: String,
+        assetName: String,
+    ): String? {
+        val installedApp = _state.value.installedApp ?: return null
+        val parkedPath = installedApp.pendingInstallFilePath ?: return null
+        val parkedVersion = installedApp.pendingInstallVersion ?: return null
+        val parkedAsset = installedApp.pendingInstallAssetName ?: return null
+        if (parkedVersion != releaseTag) return null
+        if (parkedAsset != assetName) return null
+        // Verify the file still exists. If a user manually cleared
+        // their downloads dir between parking and re-opening Details,
+        // the column points at a stale path and we'd hand the
+        // installer a missing file.
+        return try {
+            val file = File(parkedPath)
+            if (file.exists() && file.length() > 0) parkedPath else null
+        } catch (t: Throwable) {
+            logger.warn("Failed to stat parked install file: ${t.message}")
+            null
+        }
+    }
+
+    /**
+     * Stable orchestrator key for the currently-displayed app.
+     *
+     * Tracked apps key by `packageName` so the apps list and the
+     * details screen point at the same orchestrator entry. Untracked
+     * apps (fresh installs) key by `owner/repo` synthetic — real
+     * package names never contain `/`, so there's no collision risk.
+     *
+     * After a fresh install completes, the InstalledApp row is created
+     * with the real package name; subsequent updates use the real
+     * key. The synthetic key is one-shot and short-lived.
+     */
+    private fun orchestratorKey(): String {
+        val packageName = _state.value.installedApp?.packageName
+        if (packageName != null) return packageName
+        val owner = _state.value.repository?.owner?.login ?: return "unknown"
+        val name = _state.value.repository?.name ?: return "unknown"
+        return "$owner/$name"
+    }
+
+    /**
+     * Subscribes to the orchestrator's entry for [packageKey] and
+     * mirrors its state into [DetailsState]. When the entry reaches
+     * [OrchestratorStage.AwaitingInstall] *and* the install policy is
+     * [InstallPolicy.InstallWhileForeground] (i.e. not the Shizuku
+     * silent path), kicks off the existing install dialog flow on
+     * the file path.
+     *
+     * Suspends until the entry reaches a terminal state (`Completed`,
+     * `Cancelled`, `Failed`, or removed from the map). Cancellation
+     * of the *observer* doesn't cancel the orchestrator — that's the
+     * whole point.
+     */
+    private suspend fun observeOrchestratorEntry(
+        packageKey: String,
+        downloadUrl: String,
+        assetName: String,
+        sizeBytes: Long,
+        releaseTag: String,
+        isUpdate: Boolean,
+    ) {
+        var installFired = false
+        downloadOrchestrator.observe(packageKey).collect { entry ->
+            if (entry == null) {
+                // Orchestrator dropped the entry (cancelled or
+                // dismissed elsewhere). Tear down our local UI state
+                // and exit the observer.
+                if (_state.value.downloadStage != DownloadStage.IDLE) {
+                    _state.value =
+                        _state.value.copy(
+                            downloadStage = DownloadStage.IDLE,
+                            downloadProgressPercent = null,
+                        )
+                }
+                currentAssetName = null
+                return@collect
+            }
+
+            // Mirror progress into local state for the UI. Update
+            // bytes too — the live byte counter is what users see
+            // when content-length is small enough that the percent
+            // doesn't tick smoothly. The orchestrator emits both on
+            // every chunk so the UI gets a continuous update.
+            _state.value =
+                _state.value.copy(
+                    downloadProgressPercent = entry.progressPercent,
+                    downloadedBytes = entry.bytesDownloaded,
+                    totalBytes = entry.totalBytes ?: sizeBytes,
+                )
+
+            when (entry.stage) {
+                OrchestratorStage.Queued -> {
+                    // Nothing UI-visible — same as DOWNLOADING placeholder
+                    _state.value = _state.value.copy(downloadStage = DownloadStage.DOWNLOADING)
+                }
+
+                OrchestratorStage.Downloading -> {
+                    _state.value = _state.value.copy(downloadStage = DownloadStage.DOWNLOADING)
+                }
+
+                OrchestratorStage.Installing -> {
+                    // Either the orchestrator's bare-install path
+                    // (Shizuku) or our own install fired below. Either
+                    // way, surface the INSTALLING stage.
+                    _state.value = _state.value.copy(downloadStage = DownloadStage.INSTALLING)
+                }
+
+                OrchestratorStage.AwaitingInstall -> {
+                    // Bytes are on disk. For the foreground path
+                    // (regular installer), this is our cue to run
+                    // the existing dialog/validation/install flow.
+                    // For the Shizuku path the orchestrator already
+                    // moved past Installing → Completed before we
+                    // ever see AwaitingInstall (it doesn't park).
+                    if (installFired) return@collect
+                    installFired = true
+                    val filePath = entry.filePath ?: return@collect
+                    _state.value =
+                        _state.value.copy(downloadStage = DownloadStage.VERIFYING)
+                    appendLog(
+                        assetName = assetName,
+                        size = sizeBytes,
+                        tag = releaseTag,
+                        result = LogResult.Downloaded,
+                    )
+                    // Run the existing install dialog flow on the
+                    // downloaded file. This is the unchanged
+                    // validation + fingerprint + installer + DB save
+                    // path that the VM has always owned.
+                    try {
+                        installAsset(
+                            isUpdate = isUpdate,
+                            filePath = filePath,
+                            assetName = assetName,
+                            downloadUrl = downloadUrl,
+                            sizeBytes = sizeBytes,
+                            releaseTag = releaseTag,
+                        )
+                        // Successful install — release the entry
+                        // from the orchestrator so the apps row
+                        // doesn't keep showing "ready to install".
+                        downloadOrchestrator.dismiss(packageKey)
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (t: Throwable) {
+                        logger.error("Foreground install failed: ${t.message}")
+                        _state.value =
+                            _state.value.copy(
+                                downloadStage = DownloadStage.IDLE,
+                                installError = t.message,
+                            )
+                        appendLog(
+                            assetName = assetName,
+                            size = sizeBytes,
+                            tag = releaseTag,
+                            result = Error(t.message),
+                        )
+                    }
+                }
+
+                OrchestratorStage.Completed -> {
+                    // Shizuku/AlwaysInstall path: orchestrator
+                    // installed silently. Surface success and clean
+                    // up. The DB sync happens via PackageEventReceiver
+                    // when Android fires PACKAGE_REPLACED.
+                    _state.value = _state.value.copy(downloadStage = DownloadStage.IDLE)
+                    currentAssetName = null
+                    appendLog(
+                        assetName = assetName,
+                        size = sizeBytes,
+                        tag = releaseTag,
+                        result = if (isUpdate) LogResult.Updated else LogResult.Installed,
+                    )
+                    downloadOrchestrator.dismiss(packageKey)
+                    return@collect
+                }
+
+                OrchestratorStage.Cancelled -> {
+                    _state.value =
+                        _state.value.copy(
+                            downloadStage = DownloadStage.IDLE,
+                            downloadProgressPercent = null,
+                        )
+                    currentAssetName = null
+                    appendLog(
+                        assetName = assetName,
+                        size = sizeBytes,
+                        tag = releaseTag,
+                        result = LogResult.Cancelled,
+                    )
+                    return@collect
+                }
+
+                OrchestratorStage.Failed -> {
+                    _state.value =
+                        _state.value.copy(
+                            downloadStage = DownloadStage.IDLE,
+                            downloadError = entry.errorMessage,
+                        )
+                    currentAssetName = null
+                    appendLog(
+                        assetName = assetName,
+                        size = sizeBytes,
+                        tag = releaseTag,
+                        result = Error(entry.errorMessage),
+                    )
+                    downloadOrchestrator.dismiss(packageKey)
+                    return@collect
+                }
+            }
+        }
     }
 
     private suspend fun installAsset(
@@ -1199,7 +1571,6 @@ class DetailsViewModel(
                 installOutcome = installOutcome,
             )
         } else if (platform != Platform.ANDROID) {
-            cachedDownloadAssetName = null
             viewModelScope.launch {
                 _events.send(DetailsEvent.OnMessage(getString(Res.string.installer_saved_downloads)))
             }
@@ -1241,109 +1612,6 @@ class DetailsViewModel(
         }
     }
 
-    private suspend fun downloadAsset(
-        assetName: String,
-        sizeBytes: Long,
-        releaseTag: String,
-        isUpdate: Boolean,
-        downloadUrl: String,
-    ): String? {
-        currentAssetName = assetName
-
-        appendLog(
-            assetName = assetName,
-            size = sizeBytes,
-            tag = releaseTag,
-            result =
-                if (isUpdate) {
-                    LogResult.UpdateStarted
-                } else {
-                    LogResult.DownloadStarted
-                },
-        )
-        _state.value =
-            _state.value.copy(
-                downloadError = null,
-                installError = null,
-                downloadProgressPercent = null,
-                attestationStatus = AttestationStatus.UNCHECKED,
-            )
-
-        val existingPath = downloader.getDownloadedFilePath(assetName)
-        val filePath: String
-
-        val existingFile = existingPath?.let { File(it) }
-        if (existingFile != null && existingFile.exists() && existingFile.length() == sizeBytes) {
-            logger.debug("Reusing already downloaded file: $assetName")
-            filePath = existingPath
-            _state.value =
-                _state.value.copy(
-                    downloadProgressPercent = 100,
-                    downloadedBytes = sizeBytes,
-                    totalBytes = sizeBytes,
-                    downloadStage = DownloadStage.VERIFYING,
-                )
-        } else {
-            _state.value =
-                _state.value.copy(
-                    downloadStage = DownloadStage.DOWNLOADING,
-                    downloadedBytes = 0L,
-                    totalBytes = sizeBytes,
-                )
-            downloader.download(downloadUrl, assetName).collect { p ->
-                _state.value =
-                    _state.value.copy(
-                        downloadProgressPercent = p.percent,
-                        downloadedBytes = p.bytesDownloaded,
-                        totalBytes = p.totalBytes ?: sizeBytes,
-                    )
-                if (p.percent == 100) {
-                    _state.value =
-                        _state.value.copy(downloadStage = DownloadStage.VERIFYING)
-                }
-            }
-
-            filePath = downloader.getDownloadedFilePath(assetName)
-                ?: throw IllegalStateException("Downloaded file not found")
-
-            cachedDownloadAssetName = assetName
-        }
-
-        appendLog(
-            assetName = assetName,
-            size = sizeBytes,
-            tag = releaseTag,
-            result = LogResult.Downloaded,
-        )
-        val ext = assetName.substringAfterLast('.', "").lowercase()
-
-        if (!installer.isSupported(ext)) {
-            throw IllegalStateException("Asset type .$ext not supported")
-        }
-
-        try {
-            installer.ensurePermissionsOrThrow(extOrMime = ext)
-        } catch (e: IllegalStateException) {
-            logger.warn("Install permission blocked: ${e.message}")
-            _state.value =
-                _state.value.copy(
-                    downloadStage = DownloadStage.IDLE,
-                    showExternalInstallerPrompt = true,
-                    pendingInstallFilePath = filePath,
-                )
-            currentAssetName = null
-            appendLog(
-                assetName = assetName,
-                size = sizeBytes,
-                tag = releaseTag,
-                result = LogResult.PermissionBlocked,
-            )
-            return null
-        }
-
-        return filePath
-    }
-
     private suspend fun saveInstalledAppToDatabase(
         apkInfo: ApkPackageInfo,
         assetName: String,
@@ -1383,6 +1651,14 @@ class DetailsViewModel(
         }
     }
 
+    /**
+     * "Download only" entry point — used by the action that
+     * downloads an asset without auto-installing it (e.g. for users
+     * who want to side-load via a different installer). Routes
+     * through the orchestrator with [InstallPolicy.DeferUntilUserAction]
+     * so the file is parked at AwaitingInstall and the user can pick
+     * it up from the apps row whenever they're ready.
+     */
     private fun downloadAsset(
         downloadUrl: String,
         assetName: String,
@@ -1390,37 +1666,50 @@ class DetailsViewModel(
         releaseTag: String,
     ) {
         currentDownloadJob?.cancel()
+        val packageKey = orchestratorKey()
+        val asset = _state.value.primaryAsset
+        val repository = _state.value.repository
+        if (asset == null || repository == null) return
+        currentAssetName = assetName
+
+        appendLog(
+            assetName = assetName,
+            size = sizeBytes,
+            tag = releaseTag,
+            result = LogResult.DownloadStarted,
+        )
+        _state.value =
+            _state.value.copy(
+                isDownloading = true,
+                downloadError = null,
+                installError = null,
+                downloadProgressPercent = null,
+            )
+
         currentDownloadJob =
             viewModelScope.launch {
                 try {
-                    currentAssetName = assetName
-
-                    appendLog(
-                        assetName = assetName,
-                        size = sizeBytes,
-                        tag = releaseTag,
-                        result = LogResult.DownloadStarted,
+                    downloadOrchestrator.enqueue(
+                        DownloadSpec(
+                            packageName = packageKey,
+                            repoOwner = repository.owner.login,
+                            repoName = repository.name,
+                            asset = asset,
+                            displayAppName = repository.name,
+                            installPolicy = InstallPolicy.DeferUntilUserAction,
+                            releaseTag = releaseTag,
+                        ),
                     )
-                    _state.value =
-                        _state.value.copy(
-                            isDownloading = true,
-                            downloadError = null,
-                            installError = null,
-                            downloadProgressPercent = null,
-                        )
-
-                    downloader.download(downloadUrl, assetName).collect { p ->
-                        _state.value = _state.value.copy(downloadProgressPercent = p.percent)
-                    }
-
-                    _state.value = _state.value.copy(isDownloading = false)
-                    currentAssetName = null
-                    appendLog(
+                    observeOrchestratorEntry(
+                        packageKey = packageKey,
+                        downloadUrl = downloadUrl,
                         assetName = assetName,
-                        size = sizeBytes,
-                        tag = releaseTag,
-                        result = LogResult.Downloaded,
+                        sizeBytes = sizeBytes,
+                        releaseTag = releaseTag,
+                        isUpdate = false,
                     )
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
                 } catch (t: Throwable) {
                     _state.value =
                         _state.value.copy(
@@ -1480,19 +1769,26 @@ class DetailsViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        // Cancel the orchestrator OBSERVER (not the orchestrator
+        // entry itself). The download keeps running in the
+        // application-scoped orchestrator scope.
         currentDownloadJob?.cancel()
 
-        val assetsToClean = listOfNotNull(currentAssetName, cachedDownloadAssetName).distinct()
-        if (assetsToClean.isNotEmpty()) {
-            viewModelScope.launch(NonCancellable) {
-                for (asset in assetsToClean) {
-                    try {
-                        downloader.cancelDownload(asset)
-                        logger.debug("Cleaned up download on screen leave: $asset")
-                    } catch (t: Throwable) {
-                        logger.error("Failed to clean download on leave: ${t.message}")
-                    }
-                }
+        // Tell the orchestrator that the foreground watcher is gone:
+        // any in-flight download with policy InstallWhileForeground
+        // should switch to DeferUntilUserAction so the file gets
+        // parked + the user gets a notification when bytes are done.
+        // Race-safe — the orchestrator handles "already past park
+        // time" by retroactively notifying.
+        //
+        // NonCancellable so the call runs to completion even though
+        // viewModelScope is being torn down around us.
+        val packageKey = orchestratorKey()
+        viewModelScope.launch(NonCancellable) {
+            try {
+                downloadOrchestrator.downgradeToDeferred(packageKey)
+            } catch (t: Throwable) {
+                logger.error("Failed to downgrade orchestrator on screen leave: ${t.message}")
             }
         }
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -1479,20 +1479,13 @@ class DetailsViewModel(
 
             when (validationResult) {
                 is ApkValidationResult.ExtractionFailed -> {
-                    logger.error("Failed to extract APK info for $assetName")
-                    _state.value =
-                        _state.value.copy(
-                            downloadStage = DownloadStage.IDLE,
-                            installError = "Failed to verify APK package info",
-                        )
-                    currentAssetName = null
-                    appendLog(
-                        assetName = assetName,
-                        size = sizeBytes,
-                        tag = releaseTag,
-                        result = Error("Failed to extract APK info"),
+                    // Don't block installation — proceed without
+                    // validation (same as the Shizuku path).
+                    // PackageEventReceiver will sync the DB post-install.
+                    logger.warn(
+                        "Could not extract APK info for $assetName, " +
+                            "proceeding with unvalidated install",
                     )
-                    return
                 }
 
                 is ApkValidationResult.PackageMismatch -> {
@@ -1667,9 +1660,12 @@ class DetailsViewModel(
     ) {
         currentDownloadJob?.cancel()
         val packageKey = orchestratorKey()
-        val asset = _state.value.primaryAsset
-        val repository = _state.value.repository
-        if (asset == null || repository == null) return
+        val repository = _state.value.repository ?: return
+        // Use the exact asset the user tapped, not the auto-picked primary.
+        val asset = _state.value.selectedRelease?.assets
+            ?.find { it.downloadUrl == downloadUrl }
+            ?: _state.value.primaryAsset
+            ?: return
         currentAssetName = assetName
 
         appendLog(

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -61,6 +61,7 @@ import zed.rainxch.githubstore.core.presentation.res.cancel_download
 import zed.rainxch.githubstore.core.presentation.res.checking_attestation
 import zed.rainxch.githubstore.core.presentation.res.downloading
 import zed.rainxch.githubstore.core.presentation.res.install_latest
+import zed.rainxch.githubstore.core.presentation.res.install_ready
 import zed.rainxch.githubstore.core.presentation.res.install_version
 import zed.rainxch.githubstore.core.presentation.res.installing
 import zed.rainxch.githubstore.core.presentation.res.not_available
@@ -234,6 +235,15 @@ fun SmartInstallButton(
         when {
             !enabled && primaryAsset == null -> {
                 stringResource(Res.string.not_available)
+            }
+
+            // Highest priority: a previously-deferred download is
+            // already on disk and matches the current selection.
+            // Tell the user they can install in one tap, no
+            // re-download. The actual short-circuit lives in
+            // DetailsViewModel.installAsset.
+            state.isPendingInstallReady -> {
+                stringResource(Res.string.install_ready)
             }
 
             isUpdateAvailable -> {


### PR DESCRIPTION
…ation system. Key changes include:

- **Download Orchestration**: Introduced `DownloadOrchestrator` and `DefaultDownloadOrchestrator` to manage downloads and installs in an application-scoped `CoroutineScope`. This ensures downloads survive screen navigation and ViewModel destruction.
- **Install Policies**: Added `InstallPolicy` (`AlwaysInstall`, `InstallWhileForeground`, `DeferUntilUserAction`) to control post-download behavior, allowing for Shizuku silent installs or parking files for manual user confirmation.
- **Pending Install Notifications**: Implemented `PendingInstallNotifier` (Android-specific) to notify users when a background download is ready for installation, including deep-link support to the apps tab.
- **Database Schema Updates**: Incremented database version to 14. Added `pendingInstallFilePath`, `pendingInstallVersion`, and `pendingInstallAssetName` to the `installed_apps` table to persist metadata for "parked" downloads.
- **Asset Namespacing**: Introduced `AssetFileName.scoped` to prevent collisions by renaming downloaded files to an `owner_repo_filename.ext` format.
- **UI & Presentation**:
    - Updated `DetailsViewModel` and `AppsViewModel` to observe the orchestrator instead of managing downloads directly.
    - Added "Ready to install" indicators and one-tap install buttons to the Apps list and Details screens for previously deferred downloads.
    - Added localized strings for "Install", "Ready to install", and "Install (ready)" across multiple languages.
- **Deep Linking**: Added a new `githubstore://apps` deep-link destination to route users to the apps tab from notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep link to the Apps tab (githubstore://apps)
  * App-scoped download orchestrator with deferred-download workflows and per-app install actions
  * UI: "Ready to Install" state and one-tap install for parked downloads
  * Android: notifications for pending installs; desktop no-op notifier
  * Localized install-related strings across many languages

* **Bug Fixes / Reliability**
  * More tolerant APK parsing and signing extraction
  * Downloads now prefer app-specific storage with an internal fallback

* **Chores**
  * Database schema and migrations added to persist pending-install metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->