### PR TITLE
Integrate BackendApiClient for optimized repository discovery and search

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "Bash(./gradlew build *)",
       "Bash(./gradlew compileKotlinJvm compileDebugKotlinAndroid)",
       "Bash(./gradlew :core:data:compileKotlinJvm :feature:home:data:compileKotlinJvm :feature:search:data:compileKotlinJvm --rerun-tasks)",
-      "Bash(./gradlew :core:data:compileDebugKotlinAndroid :feature:home:data:compileDebugKotlinAndroid :feature:search:data:compileDebugKotlinAndroid --rerun-tasks)"
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid :feature:home:data:compileDebugKotlinAndroid :feature:search:data:compileDebugKotlinAndroid --rerun-tasks)",
+      "Bash(./gradlew :core:data:compileKotlinJvm :feature:home:data:compileKotlinJvm :feature:search:data:compileKotlinJvm :core:data:compileDebugKotlinAndroid :feature:home:data:compileDebugKotlinAndroid :feature:search:data:compileDebugKotlinAndroid --rerun-tasks)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,11 @@
       "Bash(./gradlew :feature:apps:presentation:compileDebugKotlinAndroid)",
       "Bash(./gradlew :core:data:compileDebugKotlinAndroid)",
       "Bash(./gradlew :core:data:compileDebugKotlinAndroid :feature:details:presentation:compileDebugKotlinAndroid :feature:apps:presentation:compileDebugKotlinAndroid)",
-      "Bash(./gradlew :composeApp:compileDebugKotlinAndroid :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid :feature:details:presentation:compileDebugKotlinAndroid :feature:apps:presentation:compileDebugKotlinAndroid)"
+      "Bash(./gradlew :composeApp:compileDebugKotlinAndroid :core:data:compileDebugKotlinAndroid :core:domain:compileDebugKotlinAndroid :feature:details:presentation:compileDebugKotlinAndroid :feature:apps:presentation:compileDebugKotlinAndroid)",
+      "Bash(./gradlew build *)",
+      "Bash(./gradlew compileKotlinJvm compileDebugKotlinAndroid)",
+      "Bash(./gradlew :core:data:compileKotlinJvm :feature:home:data:compileKotlinJvm :feature:search:data:compileKotlinJvm --rerun-tasks)",
+      "Bash(./gradlew :core:data:compileDebugKotlinAndroid :feature:home:data:compileDebugKotlinAndroid :feature:search:data:compileDebugKotlinAndroid --rerun-tasks)"
     ]
   }
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -21,6 +21,7 @@ import zed.rainxch.core.data.local.db.dao.SeenRepoDao
 import zed.rainxch.core.data.local.db.dao.StarredRepoDao
 import zed.rainxch.core.data.local.db.dao.UpdateHistoryDao
 import zed.rainxch.core.data.logging.KermitLogger
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.GitHubClientProvider
 import zed.rainxch.core.data.network.ProxyManager
 import zed.rainxch.core.data.network.ProxyTesterImpl
@@ -136,6 +137,10 @@ val coreModule =
 
         single<CacheManager> {
             CacheManager(cacheDao = get())
+        }
+
+        single<BackendApiClient> {
+            BackendApiClient()
         }
 
         // Application-scoped download / install orchestrator. Lives

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendRepoResponse.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendRepoResponse.kt
@@ -1,0 +1,37 @@
+package zed.rainxch.core.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackendRepoResponse(
+    val id: Long,
+    val name: String,
+    val fullName: String,
+    val owner: BackendRepoOwner,
+    val description: String? = null,
+    val defaultBranch: String? = null,
+    val htmlUrl: String,
+    val stargazersCount: Int,
+    val forksCount: Int,
+    val language: String? = null,
+    val topics: List<String> = emptyList(),
+    val releasesUrl: String? = null,
+    val updatedAt: String? = null,
+    val createdAt: String? = null,
+    val latestReleaseDate: String? = null,
+    val latestReleaseTag: String? = null,
+    val releaseRecency: Int? = null,
+    val releaseRecencyText: String? = null,
+    val trendingScore: Double? = null,
+    val popularityScore: Double? = null,
+    val hasInstallersAndroid: Boolean = false,
+    val hasInstallersWindows: Boolean = false,
+    val hasInstallersMacos: Boolean = false,
+    val hasInstallersLinux: Boolean = false,
+)
+
+@Serializable
+data class BackendRepoOwner(
+    val login: String,
+    val avatarUrl: String? = null,
+)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendSearchResponse.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendSearchResponse.kt
@@ -1,0 +1,11 @@
+package zed.rainxch.core.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackendSearchResponse(
+    val items: List<BackendRepoResponse>,
+    val totalHits: Int,
+    val processingTimeMs: Int,
+    val source: String? = null,
+)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/BackendRepoMapper.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/BackendRepoMapper.kt
@@ -1,0 +1,37 @@
+package zed.rainxch.core.data.mappers
+
+import zed.rainxch.core.data.dto.BackendRepoResponse
+import zed.rainxch.core.domain.model.DiscoveryPlatform
+import zed.rainxch.core.domain.model.GithubRepoSummary
+import zed.rainxch.core.domain.model.GithubUser
+
+fun BackendRepoResponse.toSummary(): GithubRepoSummary =
+    GithubRepoSummary(
+        id = id,
+        name = name,
+        fullName = fullName,
+        owner = GithubUser(
+            id = 0,
+            login = owner.login,
+            avatarUrl = owner.avatarUrl ?: "",
+            htmlUrl = "https://github.com/${owner.login}",
+        ),
+        description = description,
+        defaultBranch = defaultBranch ?: "main",
+        htmlUrl = htmlUrl,
+        stargazersCount = stargazersCount,
+        forksCount = forksCount,
+        language = language,
+        topics = topics.ifEmpty { null },
+        releasesUrl = releasesUrl ?: "https://api.github.com/repos/$fullName/releases{/id}",
+        updatedAt = latestReleaseDate ?: updatedAt ?: "",
+        availablePlatforms = buildAvailablePlatforms(),
+    )
+
+private fun BackendRepoResponse.buildAvailablePlatforms(): List<DiscoveryPlatform> =
+    buildList {
+        if (hasInstallersAndroid) add(DiscoveryPlatform.Android)
+        if (hasInstallersWindows) add(DiscoveryPlatform.Windows)
+        if (hasInstallersMacos) add(DiscoveryPlatform.Macos)
+        if (hasInstallersLinux) add(DiscoveryPlatform.Linux)
+    }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -1,0 +1,90 @@
+package zed.rainxch.core.data.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import zed.rainxch.core.data.dto.BackendRepoResponse
+import zed.rainxch.core.data.dto.BackendSearchResponse
+import kotlin.coroutines.cancellation.CancellationException
+
+class BackendApiClient {
+
+    private val httpClient = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+            connectTimeoutMillis = 3_000
+            socketTimeoutMillis = 5_000
+        }
+        defaultRequest {
+            url(BASE_URL)
+        }
+        expectSuccess = false
+    }
+
+    suspend fun getCategory(category: String, platform: String): Result<List<BackendRepoResponse>> =
+        safeCall {
+            val response = httpClient.get("categories/$category/$platform")
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException("HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun getTopic(bucket: String, platform: String): Result<List<BackendRepoResponse>> =
+        safeCall {
+            val response = httpClient.get("topics/$bucket/$platform")
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException("HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun search(
+        query: String,
+        platform: String? = null,
+        sort: String? = null,
+        limit: Int = 20,
+        offset: Int = 0,
+    ): Result<BackendSearchResponse> =
+        safeCall {
+            val response = httpClient.get("search") {
+                parameter("q", query)
+                if (platform != null) parameter("platform", platform)
+                if (sort != null) parameter("sort", sort)
+                parameter("limit", limit)
+                parameter("offset", offset)
+            }
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException("HTTP ${response.status.value}"))
+            }
+        }
+
+    private inline fun <T> safeCall(block: () -> Result<T>): Result<T> =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    companion object {
+        private const val BASE_URL = "https://api.github-store.org/v1/"
+    }
+}
+
+class BackendException(message: String) : Exception(message)

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
@@ -185,7 +185,8 @@ class CachedRepositoriesDataSourceImpl(
             }.awaitAll().filterNotNull()
         }
 
-        if (responses.isEmpty()) return@withContext null
+        // Only use backend result if all 4 platforms succeeded (mirrors fallback behavior)
+        if (responses.isEmpty() || responses.size < platforms.size) return@withContext null
 
         val merged = responses
             .asSequence()
@@ -266,7 +267,8 @@ class CachedRepositoriesDataSourceImpl(
             }.awaitAll().filterNotNull()
         }
 
-        if (responses.isEmpty()) return@withContext null
+        // Only use backend result if all 4 platforms succeeded (mirrors fallback behavior)
+        if (responses.isEmpty() || responses.size < platforms.size) return@withContext null
 
         val merged = responses
             .asSequence()

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
@@ -15,11 +15,13 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.DiscoveryPlatform
 import zed.rainxch.home.data.data_source.CachedRepositoriesDataSource
 import zed.rainxch.home.data.dto.CachedGithubRepoSummary
 import zed.rainxch.home.data.dto.CachedRepoResponse
+import zed.rainxch.home.data.mappers.toCachedGithubRepoSummary
 import zed.rainxch.home.domain.model.HomeCategory
 import zed.rainxch.home.domain.model.TopicCategory
 import kotlin.coroutines.cancellation.CancellationException
@@ -30,6 +32,7 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalTime::class)
 class CachedRepositoriesDataSourceImpl(
+    private val backendApiClient: BackendApiClient,
     private val logger: GitHubStoreLogger,
 ) : CachedRepositoriesDataSource {
     private val json =
@@ -38,7 +41,7 @@ class CachedRepositoriesDataSourceImpl(
             isLenient = true
         }
 
-    private val httpClient =
+    private val fallbackHttpClient =
         HttpClient {
             install(HttpTimeout) {
                 requestTimeoutMillis = 10_000
@@ -70,14 +73,6 @@ class CachedRepositoriesDataSourceImpl(
         topic: TopicCategory,
         platform: DiscoveryPlatform,
     ): CachedRepoResponse? {
-        val topicFolder = when (topic) {
-            TopicCategory.PRIVACY -> "privacy"
-            TopicCategory.MEDIA -> "media"
-            TopicCategory.PRODUCTIVITY -> "productivity"
-            TopicCategory.NETWORKING -> "networking"
-            TopicCategory.DEV_TOOLS -> "dev-tools"
-        }
-
         val topicCacheKey = TopicCacheKey(topic, platform)
         val cached = cacheMutex.withLock { topicMemoryCache[topicCacheKey] }
         if (cached != null) {
@@ -88,99 +83,19 @@ class CachedRepositoriesDataSourceImpl(
             }
         }
 
-        return withContext(Dispatchers.IO) {
-            val paths = listOf(
-                "cached-data/topics/$topicFolder/android.json",
-                "cached-data/topics/$topicFolder/windows.json",
-                "cached-data/topics/$topicFolder/macos.json",
-                "cached-data/topics/$topicFolder/linux.json",
-            )
-
-            val responses = coroutineScope {
-                paths.map { path ->
-                    async {
-                        val url = "https://raw.githubusercontent.com/OpenHub-Store/api/main/$path"
-                        val filePlatform = when {
-                            path.contains("/android") -> DiscoveryPlatform.Android
-                            path.contains("/windows") -> DiscoveryPlatform.Windows
-                            path.contains("/macos") -> DiscoveryPlatform.Macos
-                            path.contains("/linux") -> DiscoveryPlatform.Linux
-                            else -> error("Unknown platform in path: $path")
-                        }
-                        try {
-                            logger.debug("Fetching topic cache: $url")
-                            val response: HttpResponse = httpClient.get(url)
-                            if (response.status.isSuccess()) {
-                                json.decodeFromString<CachedRepoResponse>(response.bodyAsText())
-                                    .let { repoResponse ->
-                                        repoResponse.copy(
-                                            repositories = repoResponse.repositories.map {
-                                                it.copy(availablePlatforms = listOf(filePlatform))
-                                            },
-                                        )
-                                    }
-                            } else {
-                                logger.error("HTTP ${response.status.value} from $url")
-                                null
-                            }
-                        } catch (e: SerializationException) {
-                            logger.error("Parse error from $url: ${e.message}")
-                            null
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            logger.error("Error with $url: ${e.message}")
-                            null
-                        }
-                    }
-                }.awaitAll().filterNotNull()
+        // Try backend first
+        val backendResult = fetchTopicFromBackend(topic, platform)
+        if (backendResult != null) {
+            cacheMutex.withLock {
+                topicMemoryCache[topicCacheKey] =
+                    CacheEntry(data = backendResult, fetchedAt = Clock.System.now())
             }
-
-            if (responses.isEmpty()) {
-                logger.error("All topic mirrors failed for $topicCacheKey")
-                return@withContext null
-            }
-
-            val allMergedRepos = responses
-                .asSequence()
-                .flatMap { it.repositories.asSequence() }
-                .groupBy { it.id }
-                .values
-                .map { duplicates ->
-                    duplicates.reduce { acc, repo ->
-                        acc.copy(
-                            availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
-                            latestReleaseDate = listOfNotNull(
-                                acc.latestReleaseDate,
-                                repo.latestReleaseDate,
-                            ).maxOrNull(),
-                        )
-                    }
-                }
-                .sortedByDescending { it.stargazersCount }
-
-            val filteredRepos = when (platform) {
-                DiscoveryPlatform.All -> allMergedRepos
-                else -> allMergedRepos.filter { platform in it.availablePlatforms }
-            }.toList()
-
-            val merged = CachedRepoResponse(
-                category = "topic",
-                platform = platform.name.lowercase(),
-                lastUpdated = responses.maxOf { it.lastUpdated },
-                totalCount = filteredRepos.size,
-                repositories = filteredRepos,
-            )
-
-            if (responses.size == paths.size) {
-                cacheMutex.withLock {
-                    topicMemoryCache[topicCacheKey] =
-                        CacheEntry(data = merged, fetchedAt = Clock.System.now())
-                }
-            }
-
-            merged
+            return backendResult
         }
+
+        // Fallback to raw GitHub JSON
+        logger.debug("Backend failed for topic $topicCacheKey, falling back to GitHub raw JSON")
+        return fetchTopicFromFallback(topic, platform, topicCacheKey)
     }
 
     private suspend fun fetchCachedReposForCategory(
@@ -200,145 +115,387 @@ class CachedRepositoriesDataSourceImpl(
             }
         }
 
-        return withContext(Dispatchers.IO) {
-            val paths =
-                when (category) {
-                    HomeCategory.TRENDING -> {
-                        listOf(
-                            "cached-data/trending/android.json",
-                            "cached-data/trending/windows.json",
-                            "cached-data/trending/macos.json",
-                            "cached-data/trending/linux.json",
-                        )
-                    }
-
-                    HomeCategory.HOT_RELEASE -> {
-                        listOf(
-                            "cached-data/new-releases/android.json",
-                            "cached-data/new-releases/windows.json",
-                            "cached-data/new-releases/macos.json",
-                            "cached-data/new-releases/linux.json",
-                        )
-                    }
-
-                    HomeCategory.MOST_POPULAR -> {
-                        listOf(
-                            "cached-data/most-popular/android.json",
-                            "cached-data/most-popular/windows.json",
-                            "cached-data/most-popular/macos.json",
-                            "cached-data/most-popular/linux.json",
-                        )
-                    }
-                }
-
-            val responses =
-                coroutineScope {
-                    paths
-                        .map { path ->
-                            async {
-                                val url = "https://raw.githubusercontent.com/OpenHub-Store/api/main/$path"
-                                val filePlatform =
-                                    when {
-                                        path.contains("/android") -> DiscoveryPlatform.Android
-                                        path.contains("/windows") -> DiscoveryPlatform.Windows
-                                        path.contains("/macos") -> DiscoveryPlatform.Macos
-                                        path.contains("/linux") -> DiscoveryPlatform.Linux
-                                        else -> error("Unknown platform in path: $path")
-                                    }
-                                try {
-                                    logger.debug("Fetching from: $url")
-                                    val response: HttpResponse = httpClient.get(url)
-                                    if (response.status.isSuccess()) {
-                                        json
-                                            .decodeFromString<CachedRepoResponse>(response.bodyAsText())
-                                            .let { repoResponse ->
-                                                repoResponse.copy(
-                                                    repositories =
-                                                        repoResponse.repositories.map {
-                                                            it.copy(availablePlatforms = listOf(filePlatform))
-                                                        },
-                                                )
-                                            }
-                                    } else {
-                                        logger.error("HTTP ${response.status.value} from $url")
-                                        null
-                                    }
-                                } catch (e: SerializationException) {
-                                    logger.error("Parse error from $url: ${e.message}")
-                                    null
-                                } catch (e: CancellationException) {
-                                    throw e
-                                } catch (e: Exception) {
-                                    logger.error("Error with $url: ${e.message}")
-                                    null
-                                }
-                            }
-                        }.awaitAll()
-                        .filterNotNull()
-                }
-
-            if (responses.isEmpty()) {
-                logger.error("All mirrors failed for $cacheKey")
-                return@withContext null
+        // Try backend first
+        val backendResult = fetchCategoryFromBackend(category, platform)
+        if (backendResult != null) {
+            cacheMutex.withLock {
+                memoryCache[cacheKey] =
+                    CacheEntry(data = backendResult, fetchedAt = Clock.System.now())
             }
-
-            val allMergedRepos =
-                responses
-                    .asSequence()
-                    .flatMap { it.repositories.asSequence() }
-                    .groupBy { it.id }
-                    .values
-                    .map { duplicates ->
-                        duplicates.reduce { acc, repo ->
-                            acc.copy(
-                                availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
-                                trendingScore =
-                                    listOfNotNull(
-                                        acc.trendingScore,
-                                        repo.trendingScore,
-                                    ).maxOrNull(),
-                                popularityScore =
-                                    listOfNotNull(
-                                        acc.popularityScore,
-                                        repo.popularityScore,
-                                    ).maxOrNull(),
-                                latestReleaseDate =
-                                    listOfNotNull(
-                                        acc.latestReleaseDate,
-                                        repo.latestReleaseDate,
-                                    ).maxOrNull(),
-                            )
-                        }
-                    }.sortedWith(
-                        compareByDescending<CachedGithubRepoSummary> { it.trendingScore }
-                            .thenByDescending { it.popularityScore }
-                            .thenByDescending { it.latestReleaseDate },
-                    )
-
-            val filteredRepos =
-                when (platform) {
-                    DiscoveryPlatform.All -> allMergedRepos
-                    else -> allMergedRepos.filter { platform in it.availablePlatforms }
-                }.toList()
-
-            val merged =
-                CachedRepoResponse(
-                    category = responses.first().category,
-                    platform = platform.name.lowercase(),
-                    lastUpdated = responses.maxOf { it.lastUpdated },
-                    totalCount = filteredRepos.size,
-                    repositories = filteredRepos,
-                )
-
-            if (responses.size == paths.size) {
-                cacheMutex.withLock {
-                    memoryCache[cacheKey] =
-                        CacheEntry(data = merged, fetchedAt = Clock.System.now())
-                }
-            }
-
-            merged
+            return backendResult
         }
+
+        // Fallback to raw GitHub JSON
+        logger.debug("Backend failed for $cacheKey, falling back to GitHub raw JSON")
+        return fetchCategoryFromFallback(category, platform, cacheKey)
+    }
+
+    // ── Backend fetchers ──────────────────────────────────────────────
+
+    private suspend fun fetchCategoryFromBackend(
+        category: HomeCategory,
+        platform: DiscoveryPlatform,
+    ): CachedRepoResponse? {
+        val categorySlug = when (category) {
+            HomeCategory.TRENDING -> "trending"
+            HomeCategory.HOT_RELEASE -> "new-releases"
+            HomeCategory.MOST_POPULAR -> "most-popular"
+        }
+
+        if (platform == DiscoveryPlatform.All) {
+            return fetchAllPlatformsFromBackend(categorySlug, category)
+        }
+
+        val platformSlug = platform.toApiSlug() ?: return null
+        val result = backendApiClient.getCategory(categorySlug, platformSlug)
+        return result.getOrNull()?.let { repos ->
+            if (repos.isEmpty()) return null
+            logger.debug("Backend returned ${repos.size} repos for $categorySlug/$platformSlug")
+            CachedRepoResponse(
+                category = categorySlug,
+                platform = platformSlug,
+                lastUpdated = "",
+                totalCount = repos.size,
+                repositories = repos.map { it.toCachedGithubRepoSummary() },
+            )
+        }
+    }
+
+    private suspend fun fetchAllPlatformsFromBackend(
+        categorySlug: String,
+        category: HomeCategory,
+    ): CachedRepoResponse? = withContext(Dispatchers.IO) {
+        val platforms = listOf("android", "windows", "macos", "linux")
+        val responses = coroutineScope {
+            platforms.map { plat ->
+                async {
+                    val r = backendApiClient.getCategory(categorySlug, plat)
+                    val discoveryPlatform = when (plat) {
+                        "android" -> DiscoveryPlatform.Android
+                        "windows" -> DiscoveryPlatform.Windows
+                        "macos" -> DiscoveryPlatform.Macos
+                        "linux" -> DiscoveryPlatform.Linux
+                        else -> return@async null
+                    }
+                    r.getOrNull()?.map {
+                        it.toCachedGithubRepoSummary()
+                            .copy(availablePlatforms = listOf(discoveryPlatform))
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        if (responses.isEmpty()) return@withContext null
+
+        val merged = responses
+            .asSequence()
+            .flatten()
+            .groupBy { it.id }
+            .values
+            .map { duplicates ->
+                duplicates.reduce { acc, repo ->
+                    acc.copy(
+                        availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
+                        trendingScore = listOfNotNull(acc.trendingScore, repo.trendingScore).maxOrNull(),
+                        popularityScore = listOfNotNull(acc.popularityScore, repo.popularityScore).maxOrNull(),
+                        latestReleaseDate = listOfNotNull(acc.latestReleaseDate, repo.latestReleaseDate).maxOrNull(),
+                    )
+                }
+            }
+            .sortedWith(
+                compareByDescending<CachedGithubRepoSummary> { it.trendingScore }
+                    .thenByDescending { it.popularityScore }
+                    .thenByDescending { it.latestReleaseDate },
+            )
+            .toList()
+
+        logger.debug("Backend returned ${merged.size} merged repos for $categorySlug/all")
+        CachedRepoResponse(
+            category = categorySlug,
+            platform = "all",
+            lastUpdated = "",
+            totalCount = merged.size,
+            repositories = merged,
+        )
+    }
+
+    private suspend fun fetchTopicFromBackend(
+        topic: TopicCategory,
+        platform: DiscoveryPlatform,
+    ): CachedRepoResponse? {
+        val topicSlug = topic.toApiSlug()
+
+        if (platform == DiscoveryPlatform.All) {
+            return fetchAllPlatformsTopicFromBackend(topicSlug)
+        }
+
+        val platformSlug = platform.toApiSlug() ?: return null
+        val result = backendApiClient.getTopic(topicSlug, platformSlug)
+        return result.getOrNull()?.let { repos ->
+            if (repos.isEmpty()) return null
+            logger.debug("Backend returned ${repos.size} repos for topic $topicSlug/$platformSlug")
+            CachedRepoResponse(
+                category = "topic",
+                platform = platformSlug,
+                lastUpdated = "",
+                totalCount = repos.size,
+                repositories = repos.map { it.toCachedGithubRepoSummary() },
+            )
+        }
+    }
+
+    private suspend fun fetchAllPlatformsTopicFromBackend(
+        topicSlug: String,
+    ): CachedRepoResponse? = withContext(Dispatchers.IO) {
+        val platforms = listOf("android", "windows", "macos", "linux")
+        val responses = coroutineScope {
+            platforms.map { plat ->
+                async {
+                    val discoveryPlatform = when (plat) {
+                        "android" -> DiscoveryPlatform.Android
+                        "windows" -> DiscoveryPlatform.Windows
+                        "macos" -> DiscoveryPlatform.Macos
+                        "linux" -> DiscoveryPlatform.Linux
+                        else -> return@async null
+                    }
+                    backendApiClient.getTopic(topicSlug, plat).getOrNull()?.map {
+                        it.toCachedGithubRepoSummary()
+                            .copy(availablePlatforms = listOf(discoveryPlatform))
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        if (responses.isEmpty()) return@withContext null
+
+        val merged = responses
+            .asSequence()
+            .flatten()
+            .groupBy { it.id }
+            .values
+            .map { duplicates ->
+                duplicates.reduce { acc, repo ->
+                    acc.copy(
+                        availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
+                        latestReleaseDate = listOfNotNull(acc.latestReleaseDate, repo.latestReleaseDate).maxOrNull(),
+                    )
+                }
+            }
+            .sortedByDescending { it.stargazersCount }
+            .toList()
+
+        logger.debug("Backend returned ${merged.size} merged repos for topic $topicSlug/all")
+        CachedRepoResponse(
+            category = "topic",
+            platform = "all",
+            lastUpdated = "",
+            totalCount = merged.size,
+            repositories = merged,
+        )
+    }
+
+    // ── Fallback fetchers (existing raw GitHub JSON) ──────────────────
+
+    private suspend fun fetchCategoryFromFallback(
+        category: HomeCategory,
+        platform: DiscoveryPlatform,
+        cacheKey: CacheKey,
+    ): CachedRepoResponse? = withContext(Dispatchers.IO) {
+        val paths = when (category) {
+            HomeCategory.TRENDING -> listOf(
+                "cached-data/trending/android.json",
+                "cached-data/trending/windows.json",
+                "cached-data/trending/macos.json",
+                "cached-data/trending/linux.json",
+            )
+            HomeCategory.HOT_RELEASE -> listOf(
+                "cached-data/new-releases/android.json",
+                "cached-data/new-releases/windows.json",
+                "cached-data/new-releases/macos.json",
+                "cached-data/new-releases/linux.json",
+            )
+            HomeCategory.MOST_POPULAR -> listOf(
+                "cached-data/most-popular/android.json",
+                "cached-data/most-popular/windows.json",
+                "cached-data/most-popular/macos.json",
+                "cached-data/most-popular/linux.json",
+            )
+        }
+
+        val responses = coroutineScope {
+            paths.map { path ->
+                async {
+                    fetchFallbackFile(path)
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        if (responses.isEmpty()) {
+            logger.error("All fallback mirrors failed for $cacheKey")
+            return@withContext null
+        }
+
+        val allMergedRepos = responses
+            .asSequence()
+            .flatMap { it.repositories.asSequence() }
+            .groupBy { it.id }
+            .values
+            .map { duplicates ->
+                duplicates.reduce { acc, repo ->
+                    acc.copy(
+                        availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
+                        trendingScore = listOfNotNull(acc.trendingScore, repo.trendingScore).maxOrNull(),
+                        popularityScore = listOfNotNull(acc.popularityScore, repo.popularityScore).maxOrNull(),
+                        latestReleaseDate = listOfNotNull(acc.latestReleaseDate, repo.latestReleaseDate).maxOrNull(),
+                    )
+                }
+            }
+            .sortedWith(
+                compareByDescending<CachedGithubRepoSummary> { it.trendingScore }
+                    .thenByDescending { it.popularityScore }
+                    .thenByDescending { it.latestReleaseDate },
+            )
+
+        val filteredRepos = when (platform) {
+            DiscoveryPlatform.All -> allMergedRepos
+            else -> allMergedRepos.filter { platform in it.availablePlatforms }
+        }.toList()
+
+        val merged = CachedRepoResponse(
+            category = responses.first().category,
+            platform = platform.name.lowercase(),
+            lastUpdated = responses.maxOf { it.lastUpdated },
+            totalCount = filteredRepos.size,
+            repositories = filteredRepos,
+        )
+
+        if (responses.size == paths.size) {
+            cacheMutex.withLock {
+                memoryCache[cacheKey] =
+                    CacheEntry(data = merged, fetchedAt = Clock.System.now())
+            }
+        }
+
+        merged
+    }
+
+    private suspend fun fetchTopicFromFallback(
+        topic: TopicCategory,
+        platform: DiscoveryPlatform,
+        topicCacheKey: TopicCacheKey,
+    ): CachedRepoResponse? = withContext(Dispatchers.IO) {
+        val topicFolder = topic.toApiSlug()
+
+        val paths = listOf(
+            "cached-data/topics/$topicFolder/android.json",
+            "cached-data/topics/$topicFolder/windows.json",
+            "cached-data/topics/$topicFolder/macos.json",
+            "cached-data/topics/$topicFolder/linux.json",
+        )
+
+        val responses = coroutineScope {
+            paths.map { path ->
+                async {
+                    fetchFallbackFile(path)
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        if (responses.isEmpty()) {
+            logger.error("All fallback topic mirrors failed for $topicCacheKey")
+            return@withContext null
+        }
+
+        val allMergedRepos = responses
+            .asSequence()
+            .flatMap { it.repositories.asSequence() }
+            .groupBy { it.id }
+            .values
+            .map { duplicates ->
+                duplicates.reduce { acc, repo ->
+                    acc.copy(
+                        availablePlatforms = (acc.availablePlatforms + repo.availablePlatforms).distinct(),
+                        latestReleaseDate = listOfNotNull(acc.latestReleaseDate, repo.latestReleaseDate).maxOrNull(),
+                    )
+                }
+            }
+            .sortedByDescending { it.stargazersCount }
+
+        val filteredRepos = when (platform) {
+            DiscoveryPlatform.All -> allMergedRepos
+            else -> allMergedRepos.filter { platform in it.availablePlatforms }
+        }.toList()
+
+        val merged = CachedRepoResponse(
+            category = "topic",
+            platform = platform.name.lowercase(),
+            lastUpdated = responses.maxOf { it.lastUpdated },
+            totalCount = filteredRepos.size,
+            repositories = filteredRepos,
+        )
+
+        if (responses.size == paths.size) {
+            cacheMutex.withLock {
+                topicMemoryCache[topicCacheKey] =
+                    CacheEntry(data = merged, fetchedAt = Clock.System.now())
+            }
+        }
+
+        merged
+    }
+
+    private suspend fun fetchFallbackFile(path: String): CachedRepoResponse? {
+        val url = "https://raw.githubusercontent.com/OpenHub-Store/api/main/$path"
+        val filePlatform = when {
+            path.contains("/android") -> DiscoveryPlatform.Android
+            path.contains("/windows") -> DiscoveryPlatform.Windows
+            path.contains("/macos") -> DiscoveryPlatform.Macos
+            path.contains("/linux") -> DiscoveryPlatform.Linux
+            else -> error("Unknown platform in path: $path")
+        }
+        return try {
+            logger.debug("Fetching fallback: $url")
+            val response: HttpResponse = fallbackHttpClient.get(url)
+            if (response.status.isSuccess()) {
+                json.decodeFromString<CachedRepoResponse>(response.bodyAsText())
+                    .let { repoResponse ->
+                        repoResponse.copy(
+                            repositories = repoResponse.repositories.map {
+                                it.copy(availablePlatforms = listOf(filePlatform))
+                            },
+                        )
+                    }
+            } else {
+                logger.error("HTTP ${response.status.value} from $url")
+                null
+            }
+        } catch (e: SerializationException) {
+            logger.error("Parse error from $url: ${e.message}")
+            null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Error with $url: ${e.message}")
+            null
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private fun DiscoveryPlatform.toApiSlug(): String? = when (this) {
+        DiscoveryPlatform.Android -> "android"
+        DiscoveryPlatform.Windows -> "windows"
+        DiscoveryPlatform.Macos -> "macos"
+        DiscoveryPlatform.Linux -> "linux"
+        DiscoveryPlatform.All -> null
+    }
+
+    private fun TopicCategory.toApiSlug(): String = when (this) {
+        TopicCategory.PRIVACY -> "privacy"
+        TopicCategory.MEDIA -> "media"
+        TopicCategory.PRODUCTIVITY -> "productivity"
+        TopicCategory.NETWORKING -> "networking"
+        TopicCategory.DEV_TOOLS -> "dev-tools"
     }
 
     private companion object {

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/di/SharedModule.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/di/SharedModule.kt
@@ -1,6 +1,7 @@
 package zed.rainxch.home.data.di
 
 import org.koin.dsl.module
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.home.data.data_source.CachedRepositoriesDataSource
 import zed.rainxch.home.data.data_source.impl.CachedRepositoriesDataSourceImpl
 import zed.rainxch.home.data.repository.HomeRepositoryImpl
@@ -20,6 +21,7 @@ val homeModule =
 
         single<CachedRepositoriesDataSource> {
             CachedRepositoriesDataSourceImpl(
+                backendApiClient = get(),
                 logger = get(),
             )
         }

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/mappers/BackendToCachedMapper.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/mappers/BackendToCachedMapper.kt
@@ -1,0 +1,35 @@
+package zed.rainxch.home.data.mappers
+
+import zed.rainxch.core.data.dto.BackendRepoResponse
+import zed.rainxch.core.domain.model.DiscoveryPlatform
+import zed.rainxch.home.data.dto.CachedGithubOwner
+import zed.rainxch.home.data.dto.CachedGithubRepoSummary
+
+fun BackendRepoResponse.toCachedGithubRepoSummary(): CachedGithubRepoSummary =
+    CachedGithubRepoSummary(
+        id = id,
+        name = name,
+        fullName = fullName,
+        owner = CachedGithubOwner(
+            login = owner.login,
+            avatarUrl = owner.avatarUrl ?: "",
+        ),
+        description = description,
+        defaultBranch = defaultBranch ?: "main",
+        htmlUrl = htmlUrl,
+        stargazersCount = stargazersCount,
+        forksCount = forksCount,
+        language = language,
+        topics = topics.ifEmpty { null },
+        releasesUrl = releasesUrl ?: "https://api.github.com/repos/$fullName/releases{/id}",
+        updatedAt = updatedAt ?: "",
+        latestReleaseDate = latestReleaseDate,
+        trendingScore = trendingScore,
+        popularityScore = popularityScore?.toInt(),
+        availablePlatforms = buildList {
+            if (hasInstallersAndroid) add(DiscoveryPlatform.Android)
+            if (hasInstallersWindows) add(DiscoveryPlatform.Windows)
+            if (hasInstallersMacos) add(DiscoveryPlatform.Macos)
+            if (hasInstallersLinux) add(DiscoveryPlatform.Linux)
+        },
+    )

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/di/SharedModule.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/di/SharedModule.kt
@@ -1,6 +1,7 @@
 package zed.rainxch.search.data.di
 
 import org.koin.dsl.module
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.domain.repository.SearchRepository
 import zed.rainxch.search.data.repository.SearchRepositoryImpl
 
@@ -9,6 +10,7 @@ val searchModule =
         single<SearchRepository> {
             SearchRepositoryImpl(
                 httpClient = get(),
+                backendApiClient = get(),
                 cacheManager = get(),
             )
         }

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -109,6 +109,9 @@ class SearchRepositoryImpl(
     ): PaginatedDiscoveryRepositories? {
         if (query.isBlank()) return null
 
+        // Backend doesn't support forks sorting — fall through to GitHub REST
+        if (sortBy == SortBy.MostForks) return null
+
         val platformSlug = when (platform) {
             DiscoveryPlatform.Android -> "android"
             DiscoveryPlatform.Windows -> "windows"
@@ -119,8 +122,8 @@ class SearchRepositoryImpl(
 
         val sort = when (sortBy) {
             SortBy.MostStars -> "stars"
-            SortBy.MostForks -> null
             SortBy.BestMatch -> "relevance"
+            SortBy.MostForks -> null // unreachable, guarded above
         }
 
         val offset = (page - 1) * BACKEND_PAGE_SIZE
@@ -240,6 +243,14 @@ class SearchRepositoryImpl(
             throw e
         } catch (e: CancellationException) {
             throw e
+        } catch (_: Exception) {
+            send(
+                PaginatedDiscoveryRepositories(
+                    repos = emptyList(),
+                    hasMore = false,
+                    nextPageIndex = page,
+                ),
+            )
         }
     }
 

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -23,6 +23,7 @@ import zed.rainxch.core.data.cache.CacheManager.CacheTtl.SEARCH_RESULTS
 import zed.rainxch.core.data.dto.GithubRepoNetworkModel
 import zed.rainxch.core.data.dto.GithubRepoSearchResponse
 import zed.rainxch.core.data.mappers.toSummary
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.executeRequest
 import zed.rainxch.core.domain.model.DiscoveryPlatform
 import zed.rainxch.core.domain.model.GithubRepoSummary
@@ -37,6 +38,7 @@ import zed.rainxch.search.data.utils.LruCache
 
 class SearchRepositoryImpl(
     private val httpClient: HttpClient,
+    private val backendApiClient: BackendApiClient,
     private val cacheManager: CacheManager,
 ) : SearchRepository {
     private val releaseCheckCache = LruCache<String, GithubRepoSummary>(maxSize = 500)
@@ -47,6 +49,7 @@ class SearchRepositoryImpl(
         private const val VERIFY_CONCURRENCY = 15
         private const val PER_CHECK_TIMEOUT_MS = 2000L
         private const val MAX_AUTO_SKIP_PAGES = 3
+        private const val BACKEND_PAGE_SIZE = 20
     }
 
     private fun searchCacheKey(
@@ -84,92 +87,161 @@ class SearchRepositoryImpl(
                 return@channelFlow
             }
 
-            val searchQuery = buildSearchQuery(query, language)
-            val sort = sortBy.toGithubSortParam()
-            val order = sortOrder.toGithubParam()
+            // Try backend search first
+            val backendResult = tryBackendSearch(query, platform, sortBy, page)
+            if (backendResult != null) {
+                cacheManager.put(cacheKey, backendResult, SEARCH_RESULTS)
+                send(backendResult)
+                return@channelFlow
+            }
 
-            try {
-                var currentPage = page
-                var pagesSkipped = 0
+            // Fallback to GitHub REST search
+            fallbackGithubSearch(query, platform, language, sortBy, sortOrder, page, cacheKey)
+        }.flowOn(Dispatchers.IO)
 
-                while (pagesSkipped <= MAX_AUTO_SKIP_PAGES) {
-                    currentCoroutineContext().ensureActive()
+    // ── Backend search ────────────────────────────────────────────────
 
-                    val response =
-                        httpClient
-                            .executeRequest<GithubRepoSearchResponse> {
-                                get("/search/repositories") {
-                                    parameter("q", searchQuery)
-                                    parameter("per_page", PER_PAGE)
-                                    parameter("page", currentPage)
-                                    if (sort != null) {
-                                        parameter("sort", sort)
-                                        parameter("order", order)
-                                    }
+    private suspend fun tryBackendSearch(
+        query: String,
+        platform: DiscoveryPlatform,
+        sortBy: SortBy,
+        page: Int,
+    ): PaginatedDiscoveryRepositories? {
+        if (query.isBlank()) return null
+
+        val platformSlug = when (platform) {
+            DiscoveryPlatform.Android -> "android"
+            DiscoveryPlatform.Windows -> "windows"
+            DiscoveryPlatform.Macos -> "macos"
+            DiscoveryPlatform.Linux -> "linux"
+            DiscoveryPlatform.All -> null
+        }
+
+        val sort = when (sortBy) {
+            SortBy.MostStars -> "stars"
+            SortBy.MostForks -> null
+            SortBy.BestMatch -> "relevance"
+        }
+
+        val offset = (page - 1) * BACKEND_PAGE_SIZE
+        val result = backendApiClient.search(
+            query = query,
+            platform = platformSlug,
+            sort = sort,
+            limit = BACKEND_PAGE_SIZE,
+            offset = offset,
+        )
+
+        return result.getOrNull()?.let { searchResponse ->
+            val repos = searchResponse.items.map { it.toSummary() }
+
+            val hasMore = offset + repos.size < searchResponse.totalHits
+            PaginatedDiscoveryRepositories(
+                repos = repos,
+                hasMore = hasMore,
+                nextPageIndex = page + 1,
+                totalCount = searchResponse.totalHits,
+            )
+        }
+    }
+
+    // ── Fallback GitHub REST search ───────────────────────────────────
+
+    private suspend fun kotlinx.coroutines.channels.ProducerScope<PaginatedDiscoveryRepositories>.fallbackGithubSearch(
+        query: String,
+        platform: DiscoveryPlatform,
+        language: ProgrammingLanguage,
+        sortBy: SortBy,
+        sortOrder: SortOrder,
+        page: Int,
+        cacheKey: String,
+    ) {
+        val searchQuery = buildSearchQuery(query, language)
+        val sort = sortBy.toGithubSortParam()
+        val order = sortOrder.toGithubParam()
+
+        try {
+            var currentPage = page
+            var pagesSkipped = 0
+
+            while (pagesSkipped <= MAX_AUTO_SKIP_PAGES) {
+                currentCoroutineContext().ensureActive()
+
+                val response =
+                    httpClient
+                        .executeRequest<GithubRepoSearchResponse> {
+                            get("/search/repositories") {
+                                parameter("q", searchQuery)
+                                parameter("per_page", PER_PAGE)
+                                parameter("page", currentPage)
+                                if (sort != null) {
+                                    parameter("sort", sort)
+                                    parameter("order", order)
                                 }
-                            }.getOrThrow()
+                            }
+                        }.getOrThrow()
 
-                    val total = response.totalCount
-                    val baseHasMore =
-                        (currentPage * PER_PAGE) < total && response.items.isNotEmpty()
+                val total = response.totalCount
+                val baseHasMore =
+                    (currentPage * PER_PAGE) < total && response.items.isNotEmpty()
 
-                    if (response.items.isEmpty()) {
-                        send(
-                            PaginatedDiscoveryRepositories(
-                                repos = emptyList(),
-                                hasMore = false,
-                                nextPageIndex = currentPage + 1,
-                                totalCount = total,
-                            ),
-                        )
-                        return@channelFlow
-                    }
-
-                    val verified = verifyBatch(response.items, platform)
-
-                    if (verified.isNotEmpty()) {
-                        val result =
-                            PaginatedDiscoveryRepositories(
-                                repos = verified,
-                                hasMore = baseHasMore,
-                                nextPageIndex = currentPage + 1,
-                                totalCount = total,
-                            )
-                        cacheManager.put(cacheKey, result, SEARCH_RESULTS)
-                        send(result)
-                        return@channelFlow
-                    }
-
-                    if (!baseHasMore) {
-                        send(
-                            PaginatedDiscoveryRepositories(
-                                repos = emptyList(),
-                                hasMore = false,
-                                nextPageIndex = currentPage + 1,
-                                totalCount = total,
-                            ),
-                        )
-                        return@channelFlow
-                    }
-
-                    currentPage++
-                    pagesSkipped++
+                if (response.items.isEmpty()) {
+                    send(
+                        PaginatedDiscoveryRepositories(
+                            repos = emptyList(),
+                            hasMore = false,
+                            nextPageIndex = currentPage + 1,
+                            totalCount = total,
+                        ),
+                    )
+                    return
                 }
 
-                send(
-                    PaginatedDiscoveryRepositories(
-                        repos = emptyList(),
-                        hasMore = true,
-                        nextPageIndex = currentPage + 1,
-                        totalCount = null,
-                    ),
-                )
-            } catch (e: RateLimitException) {
-                throw e
-            } catch (e: CancellationException) {
-                throw e
+                val verified = verifyBatch(response.items, platform)
+
+                if (verified.isNotEmpty()) {
+                    val result =
+                        PaginatedDiscoveryRepositories(
+                            repos = verified,
+                            hasMore = baseHasMore,
+                            nextPageIndex = currentPage + 1,
+                            totalCount = total,
+                        )
+                    cacheManager.put(cacheKey, result, SEARCH_RESULTS)
+                    send(result)
+                    return
+                }
+
+                if (!baseHasMore) {
+                    send(
+                        PaginatedDiscoveryRepositories(
+                            repos = emptyList(),
+                            hasMore = false,
+                            nextPageIndex = currentPage + 1,
+                            totalCount = total,
+                        ),
+                    )
+                    return
+                }
+
+                currentPage++
+                pagesSkipped++
             }
-        }.flowOn(Dispatchers.IO)
+
+            send(
+                PaginatedDiscoveryRepositories(
+                    repos = emptyList(),
+                    hasMore = true,
+                    nextPageIndex = currentPage + 1,
+                    totalCount = null,
+                ),
+            )
+        } catch (e: RateLimitException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        }
+    }
 
     private suspend fun verifyBatch(
         items: List<GithubRepoNetworkModel>,


### PR DESCRIPTION
- Introduce `BackendApiClient` to interface with the centralized GitHub Store API, featuring dedicated endpoints for categories, topics, and search.
- Update `CachedRepositoriesDataSourceImpl` to prioritize backend fetching for home categories and topics, with a fallback to raw GitHub JSON files if the backend is unavailable.
- Implement `SearchRepositoryImpl` logic to attempt backend searches first, providing faster results and native platform filtering, before falling back to manual GitHub REST API search and verification.
- Add DTOs and mappers (`BackendRepoResponse`, `BackendSearchResponse`, `BackendRepoMapper`) to handle backend data structures and convert them to domain/cached models.
- Configure dependency injection for `BackendApiClient` across core, home, and search modules.
- Refactor `CachedRepositoriesDataSourceImpl` to simplify platform and category slug handling via helper methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend API integrated as a primary source for repository discovery, topics, categories, and search with automatic fallback to GitHub.
* **Improvements**
  * Search now uses a backend-first paginated flow with graceful GitHub fallback.
  * Cached results and merged "all platforms" responses provide richer repo metadata and platform/installer availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->