### PR TITLE
feat(search): add "Explore from GitHub" functionality

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendExploreResponse.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/BackendExploreResponse.kt
@@ -1,0 +1,10 @@
+package zed.rainxch.core.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackendExploreResponse(
+    val items: List<BackendRepoResponse>,
+    val page: Int,
+    val hasMore: Boolean,
+)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -10,6 +10,8 @@ import io.ktor.client.request.parameter
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import io.ktor.client.plugins.timeout
+import zed.rainxch.core.data.dto.BackendExploreResponse
 import zed.rainxch.core.data.dto.BackendRepoResponse
 import zed.rainxch.core.data.dto.BackendSearchResponse
 import kotlin.coroutines.cancellation.CancellationException
@@ -65,6 +67,25 @@ class BackendApiClient {
                 if (sort != null) parameter("sort", sort)
                 parameter("limit", limit)
                 parameter("offset", offset)
+            }
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException("HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun searchExplore(
+        query: String,
+        platform: String? = null,
+        page: Int = 1,
+    ): Result<BackendExploreResponse> =
+        safeCall {
+            val response = httpClient.get("search/explore") {
+                parameter("q", query)
+                if (platform != null) parameter("platform", platform)
+                parameter("page", page)
+                timeout { requestTimeoutMillis = 20_000 }
             }
             if (response.status.isSuccess()) {
                 Result.success(response.body())

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -235,6 +235,10 @@
     <string name="downloads">التنزيلات</string>
     <string name="license">الترخيص</string>
     <string name="license_none">لا يوجد</string>
+    <string name="fetch_more_from_github">جلب المزيد من GitHub</string>
+    <string name="fetching_from_github">جارٍ الجلب من GitHub…</string>
+    <string name="no_more_github_results">لا توجد نتائج أخرى على GitHub</string>
+    <string name="explore_error">فشل الجلب من GitHub. حاول مرة أخرى.</string>
 
     <!-- Misc -->
     <string name="by_author">بواسطة %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -194,6 +194,10 @@
     <string name="downloads">ডাউনলোড</string>
     <string name="license">লাইসেন্স</string>
     <string name="license_none">নেই</string>
+    <string name="fetch_more_from_github">GitHub থেকে আরও আনুন</string>
+    <string name="fetching_from_github">GitHub থেকে আনা হচ্ছে…</string>
+    <string name="no_more_github_results">GitHub-এ আর ফলাফল নেই</string>
+    <string name="explore_error">GitHub থেকে আনতে ব্যর্থ। আবার চেষ্টা করুন।</string>
 
     <!-- Misc -->
     <string name="by_author">%1$s দ্বারা</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -144,6 +144,10 @@
     <string name="downloads">Descargas</string>
     <string name="license">Licencia</string>
     <string name="license_none">Ninguna</string>
+    <string name="fetch_more_from_github">Buscar más en GitHub</string>
+    <string name="fetching_from_github">Buscando en GitHub…</string>
+    <string name="no_more_github_results">No hay más resultados en GitHub</string>
+    <string name="explore_error">Error al buscar en GitHub. Inténtalo de nuevo.</string>
 
     <string name="by_author">por %1$s</string>
     <string name="installed_version">• Instalado: %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -144,6 +144,10 @@
     <string name="downloads">Téléchargements</string>
     <string name="license">Licence</string>
     <string name="license_none">Aucune</string>
+    <string name="fetch_more_from_github">Chercher plus sur GitHub</string>
+    <string name="fetching_from_github">Recherche sur GitHub…</string>
+    <string name="no_more_github_results">Plus de résultats sur GitHub</string>
+    <string name="explore_error">Échec de la recherche GitHub. Réessayez.</string>
 
     <string name="by_author">par %1$s</string>
     <string name="installed_version">• Installé : %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -194,6 +194,10 @@
     <string name="downloads">डाउनलोड</string>
     <string name="license">लाइसेंस</string>
     <string name="license_none">कोई नहीं</string>
+    <string name="fetch_more_from_github">GitHub से और लाएं</string>
+    <string name="fetching_from_github">GitHub से ला रहे हैं…</string>
+    <string name="no_more_github_results">GitHub पर और परिणाम नहीं हैं</string>
+    <string name="explore_error">GitHub से लाने में विफल। पुनः प्रयास करें।</string>
 
     <!-- Misc -->
     <string name="by_author">द्वारा %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -194,6 +194,10 @@
     <string name="downloads">Download</string>
     <string name="license">Licenza</string>
     <string name="license_none">Nessuna</string>
+    <string name="fetch_more_from_github">Cerca altri su GitHub</string>
+    <string name="fetching_from_github">Ricerca su GitHub…</string>
+    <string name="no_more_github_results">Nessun altro risultato su GitHub</string>
+    <string name="explore_error">Ricerca GitHub fallita. Riprova.</string>
 
     <!-- Misc -->
     <string name="by_author">per %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -145,6 +145,10 @@
     <string name="downloads">ダウンロード</string>
     <string name="license">ライセンス</string>
     <string name="license_none">なし</string>
+    <string name="fetch_more_from_github">GitHubからさらに取得</string>
+    <string name="fetching_from_github">GitHubから取得中…</string>
+    <string name="no_more_github_results">GitHubにこれ以上の結果はありません</string>
+    <string name="explore_error">GitHubからの取得に失敗しました。再試行してください。</string>
 
     <string name="by_author">%1$s 作</string>
     <string name="installed_version">• インストール済み: %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -192,6 +192,10 @@
     <string name="downloads">다운로드</string>
     <string name="license">라이선스</string>
     <string name="license_none">없음</string>
+    <string name="fetch_more_from_github">GitHub에서 더 가져오기</string>
+    <string name="fetching_from_github">GitHub에서 가져오는 중…</string>
+    <string name="no_more_github_results">GitHub에 더 이상 결과가 없습니다</string>
+    <string name="explore_error">GitHub에서 가져오기 실패. 다시 시도하세요.</string>
 
     <!-- Misc -->
     <string name="by_author">%1$s 작성</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -163,6 +163,10 @@
     <string name="downloads">Pobrania</string>
     <string name="license">Licencja</string>
     <string name="license_none">Brak</string>
+    <string name="fetch_more_from_github">Pobierz więcej z GitHub</string>
+    <string name="fetching_from_github">Pobieranie z GitHub…</string>
+    <string name="no_more_github_results">Brak więcej wyników na GitHub</string>
+    <string name="explore_error">Nie udało się pobrać z GitHub. Spróbuj ponownie.</string>
 
     <string name="by_author">autor: %1$s</string>
     <string name="installed_version">• Zainstalowana: %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -159,6 +159,10 @@
     <string name="downloads">Загрузки</string>
     <string name="license">Лицензия</string>
     <string name="license_none">Нет</string>
+    <string name="fetch_more_from_github">Найти ещё на GitHub</string>
+    <string name="fetching_from_github">Поиск на GitHub…</string>
+    <string name="no_more_github_results">Больше результатов на GitHub нет</string>
+    <string name="explore_error">Не удалось загрузить с GitHub. Попробуйте снова.</string>
 
     <string name="by_author">от %1$s</string>
     <string name="installed_version">• Установлено: %1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -193,6 +193,10 @@
     <string name="downloads">İndirmeler</string>
     <string name="license">Lisans</string>
     <string name="license_none">Yok</string>
+    <string name="fetch_more_from_github">GitHub\'tan daha fazla getir</string>
+    <string name="fetching_from_github">GitHub\'tan getiriliyor…</string>
+    <string name="no_more_github_results">GitHub\'ta başka sonuç yok</string>
+    <string name="explore_error">GitHub\'tan getirilemedi. Tekrar deneyin.</string>
 
     <!-- Misc -->
     <string name="by_author">%1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -146,6 +146,10 @@
     <string name="downloads">下载量</string>
     <string name="license">许可证</string>
     <string name="license_none">无</string>
+    <string name="fetch_more_from_github">从 GitHub 获取更多</string>
+    <string name="fetching_from_github">正在从 GitHub 获取…</string>
+    <string name="no_more_github_results">GitHub 上没有更多结果</string>
+    <string name="explore_error">从 GitHub 获取失败，请重试。</string>
 
     <string name="by_author">由 %1$s</string>
     <string name="installed_version">• 已安装：%1$s</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -244,6 +244,12 @@
     <string name="license">License</string>
     <string name="license_none">None</string>
 
+    <!-- Explore -->
+    <string name="fetch_more_from_github">Fetch more from GitHub</string>
+    <string name="fetching_from_github">Fetching from GitHub…</string>
+    <string name="no_more_github_results">No more results on GitHub</string>
+    <string name="explore_error">Failed to fetch from GitHub. Try again.</string>
+
     <!-- Misc -->
     <string name="by_author">by %1$s</string>
     <string name="installed_version">• Installed: %1$s</string>

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -29,6 +29,7 @@ import zed.rainxch.core.domain.model.DiscoveryPlatform
 import zed.rainxch.core.domain.model.GithubRepoSummary
 import zed.rainxch.core.domain.model.PaginatedDiscoveryRepositories
 import zed.rainxch.core.domain.model.RateLimitException
+import zed.rainxch.domain.model.ExploreResult
 import zed.rainxch.domain.model.ProgrammingLanguage
 import zed.rainxch.domain.model.SortBy
 import zed.rainxch.domain.model.SortOrder
@@ -425,5 +426,31 @@ class SearchRepositoryImpl(
             releaseCheckCache.put(key, result)
         }
         return result
+    }
+
+    override suspend fun exploreFromGithub(
+        query: String,
+        platform: DiscoveryPlatform,
+        page: Int,
+    ): ExploreResult {
+        val platformSlug = when (platform) {
+            DiscoveryPlatform.Android -> "android"
+            DiscoveryPlatform.Windows -> "windows"
+            DiscoveryPlatform.Macos -> "macos"
+            DiscoveryPlatform.Linux -> "linux"
+            DiscoveryPlatform.All -> null
+        }
+
+        val response = backendApiClient.searchExplore(
+            query = query,
+            platform = platformSlug,
+            page = page,
+        ).getOrThrow()
+
+        return ExploreResult(
+            repos = response.items.map { it.toSummary() },
+            page = response.page,
+            hasMore = response.hasMore,
+        )
     }
 }

--- a/feature/search/domain/src/commonMain/kotlin/zed/rainxch/domain/model/ExploreResult.kt
+++ b/feature/search/domain/src/commonMain/kotlin/zed/rainxch/domain/model/ExploreResult.kt
@@ -1,0 +1,9 @@
+package zed.rainxch.domain.model
+
+import zed.rainxch.core.domain.model.GithubRepoSummary
+
+data class ExploreResult(
+    val repos: List<GithubRepoSummary>,
+    val page: Int,
+    val hasMore: Boolean,
+)

--- a/feature/search/domain/src/commonMain/kotlin/zed/rainxch/domain/repository/SearchRepository.kt
+++ b/feature/search/domain/src/commonMain/kotlin/zed/rainxch/domain/repository/SearchRepository.kt
@@ -3,6 +3,7 @@ package zed.rainxch.domain.repository
 import kotlinx.coroutines.flow.Flow
 import zed.rainxch.core.domain.model.DiscoveryPlatform
 import zed.rainxch.core.domain.model.PaginatedDiscoveryRepositories
+import zed.rainxch.domain.model.ExploreResult
 import zed.rainxch.domain.model.ProgrammingLanguage
 import zed.rainxch.domain.model.SortBy
 import zed.rainxch.domain.model.SortOrder
@@ -16,4 +17,10 @@ interface SearchRepository {
         sortOrder: SortOrder,
         page: Int,
     ): Flow<PaginatedDiscoveryRepositories>
+
+    suspend fun exploreFromGithub(
+        query: String,
+        platform: DiscoveryPlatform,
+        page: Int,
+    ): ExploreResult
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
@@ -71,4 +71,6 @@ sealed interface SearchAction {
     ) : SearchAction
 
     data object OnClearAllHistory : SearchAction
+
+    data object ExploreFromGithub : SearchAction
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
@@ -39,6 +40,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.TravelExplore
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -46,6 +48,7 @@ import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -211,7 +214,7 @@ fun SearchScreen(
 
             val hasEmptySpaceAtBottom =
                 lastVisibleItem.index == totalItems - 1 &&
-                    lastVisibleItem.offset.y + lastVisibleItem.size.height < viewportEndOffset
+                        lastVisibleItem.offset.y + lastVisibleItem.size.height < viewportEndOffset
 
             val threshold = (totalItems * 0.8f).toInt()
             val isNearEnd = lastVisibleItem.index >= threshold
@@ -241,7 +244,7 @@ fun SearchScreen(
         ) {
             val hasEmptySpace =
                 lastVisible.index == layoutInfo.totalItemsCount - 1 &&
-                    lastVisible.offset.y + lastVisible.size.height < layoutInfo.viewportEndOffset
+                        lastVisible.offset.y + lastVisible.size.height < layoutInfo.viewportEndOffset
 
             if (hasEmptySpace) {
                 delay(100)
@@ -506,16 +509,6 @@ fun SearchScreen(
                 )
             }
 
-            val visibleRepos by remember(state.repositories, state.isHideSeenEnabled, state.seenRepoIds) {
-                derivedStateOf {
-                    if (state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()) {
-                        state.repositories.filter { it.repository.id !in state.seenRepoIds }
-                    } else {
-                        state.repositories
-                    }
-                }
-            }
-
             Box(Modifier.fillMaxSize()) {
                 if (state.isLoading && state.repositories.isEmpty()) {
                     Box(
@@ -548,75 +541,85 @@ fun SearchScreen(
                     }
                 }
 
-                if (visibleRepos.isNotEmpty()) {
+                if (state.visibleRepos.isNotEmpty()) {
                     val isScrollbarEnabled = LocalScrollbarEnabled.current
                     ScrollbarContainer(
                         gridState = listState,
                         enabled = isScrollbarEnabled,
                         modifier = Modifier.fillMaxSize(),
                     ) {
-                    LazyVerticalStaggeredGrid(
-                        state = listState,
-                        columns = StaggeredGridCells.Adaptive(350.dp),
-                        verticalItemSpacing = 12.dp,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .then(
-                                    if (state.isLiquidGlassEnabled) {
-                                        Modifier.liquefiable(liquidState)
-                                    } else {
-                                        Modifier
+                        LazyVerticalStaggeredGrid(
+                            state = listState,
+                            columns = StaggeredGridCells.Adaptive(350.dp),
+                            verticalItemSpacing = 12.dp,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .then(
+                                        if (state.isLiquidGlassEnabled) {
+                                            Modifier.liquefiable(liquidState)
+                                        } else {
+                                            Modifier
+                                        },
+                                    ),
+                        ) {
+                            items(
+                                items = state.visibleRepos,
+                                key = { it.repository.id },
+                            ) { discoveryRepository ->
+                                RepositoryCard(
+                                    discoveryRepositoryUi = discoveryRepository,
+                                    onClick = {
+                                        onAction(SearchAction.OnRepositoryClick(discoveryRepository.repository))
                                     },
-                                ),
-                    ) {
-                        items(
-                            items = visibleRepos,
-                            key = { it.repository.id },
-                        ) { discoveryRepository ->
-                            RepositoryCard(
-                                discoveryRepositoryUi = discoveryRepository,
-                                onClick = {
-                                    onAction(SearchAction.OnRepositoryClick(discoveryRepository.repository))
-                                },
-                                onDeveloperClick = { username ->
-                                    onAction(SearchAction.OnRepositoryDeveloperClick(username))
-                                },
-                                onShareClick = {
-                                    onAction(SearchAction.OnShareClick(discoveryRepository.repository))
-                                },
-                                modifier =
-                                    Modifier
-                                        .animateItem()
-                                        .then(
-                                            if (state.isLiquidGlassEnabled) {
-                                                Modifier.liquefiable(liquidState)
-                                            } else {
-                                                Modifier
-                                            },
-                                        ),
-                            )
-                        }
-
-                        item {
-                            if (state.isLoadingMore) {
-                                Box(
+                                    onDeveloperClick = { username ->
+                                        onAction(SearchAction.OnRepositoryDeveloperClick(username))
+                                    },
+                                    onShareClick = {
+                                        onAction(SearchAction.OnShareClick(discoveryRepository.repository))
+                                    },
                                     modifier =
                                         Modifier
-                                            .fillMaxWidth()
-                                            .padding(16.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
+                                            .animateItem()
+                                            .then(
+                                                if (state.isLiquidGlassEnabled) {
+                                                    Modifier.liquefiable(liquidState)
+                                                } else {
+                                                    Modifier
+                                                },
+                                            ),
+                                )
+                            }
+
+                            item {
+                                if (state.isLoadingMore) {
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                        )
+                                    }
+                                }
+                            }
+
+                            // "Fetch more from GitHub" explore button
+                            if (!state.isLoading && !state.isLoadingMore && state.query.isNotBlank()) {
+                                item {
+                                    ExploreFromGithubButton(
+                                        status = state.exploreStatus,
+                                        onExplore = { onAction(SearchAction.ExploreFromGithub) },
                                     )
                                 }
                             }
                         }
                     }
-                    } // ScrollbarContainer
                 }
             }
         }
@@ -854,6 +857,52 @@ private fun SearchTopbar(
                     .weight(1f)
                     .focusRequester(focusRequester),
         )
+    }
+}
+
+@Composable
+private fun ExploreFromGithubButton(
+    status: SearchState.ExploreStatus,
+    onExplore: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        when (status) {
+            SearchState.ExploreStatus.IDLE -> {
+                OutlinedButton(onClick = onExplore) {
+                    Icon(
+                        imageVector = Icons.Outlined.TravelExplore,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = stringResource(Res.string.fetch_more_from_github))
+                }
+            }
+
+            SearchState.ExploreStatus.LOADING -> {
+                OutlinedButton(onClick = {}, enabled = false) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = stringResource(Res.string.fetching_from_github))
+                }
+            }
+
+            SearchState.ExploreStatus.EXHAUSTED -> {
+                Text(
+                    text = stringResource(Res.string.no_more_github_results),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
     }
 }
 

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchState.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchState.kt
@@ -12,6 +12,7 @@ import zed.rainxch.search.presentation.model.SortOrderUi
 data class SearchState(
     val query: String = "",
     val repositories: ImmutableList<DiscoveryRepositoryUi> = persistentListOf(),
+    val visibleRepos: ImmutableList<DiscoveryRepositoryUi> = persistentListOf(),
     val selectedSearchPlatform: SearchPlatformUi = SearchPlatformUi.All,
     val selectedSortBy: SortByUi = SortByUi.BestMatch,
     val selectedSortOrder: SortOrderUi = SortOrderUi.Descending,
@@ -31,4 +32,11 @@ data class SearchState(
     val isClipboardBannerVisible: Boolean = false,
     val autoDetectClipboardEnabled: Boolean = true,
     val recentSearches: ImmutableList<String> = persistentListOf(),
-)
+    val exploreStatus: ExploreStatus = ExploreStatus.IDLE,
+) {
+    enum class ExploreStatus {
+        IDLE,
+        LOADING,
+        EXHAUSTED,
+    }
+}

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -2,6 +2,7 @@ package zed.rainxch.search.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
@@ -10,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -35,6 +37,7 @@ import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_share_link
 import zed.rainxch.githubstore.core.presentation.res.link_copied_to_clipboard
 import zed.rainxch.githubstore.core.presentation.res.no_github_link_in_clipboard
+import zed.rainxch.githubstore.core.presentation.res.explore_error
 import zed.rainxch.githubstore.core.presentation.res.no_repositories_found
 import zed.rainxch.githubstore.core.presentation.res.search_failed
 import zed.rainxch.search.presentation.mappers.toDomain
@@ -58,6 +61,8 @@ class SearchViewModel(
     private var hasLoadedInitialData = false
     private var currentSearchJob: Job? = null
     private var currentPage = 1
+    private var explorePage = 1
+    private var lastExploreQuery = ""
 
     companion object {
         private const val MIN_QUERY_LENGTH = 3
@@ -82,11 +87,20 @@ class SearchViewModel(
 
                     hasLoadedInitialData = true
                 }
-            }.stateIn(
+            }
+            .map { it.copy(visibleRepos = computeVisibleRepos(it)) }
+            .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000L),
                 initialValue = SearchState(),
             )
+
+    private fun computeVisibleRepos(state: SearchState): ImmutableList<DiscoveryRepositoryUi> =
+        if (state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()) {
+            state.repositories.filter { it.repository.id !in state.seenRepoIds }.toImmutableList()
+        } else {
+            state.repositories
+        }
 
     private fun observeLiquidGlassEnabled() {
         viewModelScope.launch {
@@ -277,6 +291,9 @@ class SearchViewModel(
         if (isInitial) {
             currentSearchJob?.cancel()
             currentPage = 1
+            explorePage = 1
+            lastExploreQuery = query
+            _state.update { it.copy(exploreStatus = SearchState.ExploreStatus.IDLE) }
         }
 
         currentSearchJob =
@@ -645,6 +662,82 @@ class SearchViewModel(
                 viewModelScope.launch {
                     searchHistoryRepository.clearAll()
                 }
+            }
+
+            SearchAction.ExploreFromGithub -> {
+                performExplore()
+            }
+        }
+    }
+
+    private fun performExplore() {
+        val query = _state.value.query.trim()
+        if (query.isBlank() || _state.value.exploreStatus == SearchState.ExploreStatus.LOADING) return
+
+        // Reset page if query changed
+        if (query != lastExploreQuery) {
+            explorePage = 1
+            lastExploreQuery = query
+        }
+
+        viewModelScope.launch {
+            _state.update { it.copy(exploreStatus = SearchState.ExploreStatus.LOADING) }
+
+            try {
+                val exploreResult = searchRepository.exploreFromGithub(
+                    query = query,
+                    platform = _state.value.selectedSearchPlatform.toDomain(),
+                    page = explorePage,
+                )
+
+                if (exploreResult.repos.isEmpty() || !exploreResult.hasMore) {
+                    if (exploreResult.repos.isNotEmpty()) {
+                        appendExploreResults(exploreResult.repos)
+                    }
+                    _state.update { it.copy(exploreStatus = SearchState.ExploreStatus.EXHAUSTED) }
+                } else {
+                    appendExploreResults(exploreResult.repos)
+                    explorePage++
+                    _state.update { it.copy(exploreStatus = SearchState.ExploreStatus.IDLE) }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error("Explore failed: ${e.message}")
+                _state.update { it.copy(exploreStatus = SearchState.ExploreStatus.IDLE) }
+                _events.send(SearchEvent.OnMessage(getString(Res.string.explore_error)))
+            }
+        }
+    }
+
+    private suspend fun appendExploreResults(
+        newRepos: List<zed.rainxch.core.domain.model.GithubRepoSummary>,
+    ) {
+        val installedMap = installedAppsRepository.getAllInstalledApps().first().associateBy { it.repoId }
+        val favoritesMap = favouritesRepository.getAllFavorites().first().associateBy { it.repoId }
+        val starredMap = starredRepository.getAllStarred().first().associateBy { it.repoId }
+        val seenIds = _state.value.seenRepoIds
+
+        val existingIds = _state.value.repositories.map { it.repository.id }.toSet()
+
+        val deduped = newRepos
+            .filter { it.id !in existingIds }
+            .map { repo ->
+                DiscoveryRepositoryUi(
+                    isInstalled = installedMap[repo.id] != null,
+                    isFavourite = favoritesMap[repo.id] != null,
+                    isStarred = starredMap[repo.id] != null,
+                    isSeen = repo.id in seenIds,
+                    isUpdateAvailable = installedMap[repo.id]?.isUpdateAvailable ?: false,
+                    repository = repo.toUi(),
+                )
+            }
+
+        if (deduped.isNotEmpty()) {
+            _state.update { current ->
+                current.copy(
+                    repositories = (current.repositories + deduped).toImmutableList(),
+                )
             }
         }
     }


### PR DESCRIPTION
- Introduce `BackendExploreResponse` DTO and `ExploreResult` domain model to handle paginated results from the backend's explore endpoint.
- Extend `SearchRepository` and its implementation to support fetching additional repositories directly from GitHub via the backend.
- Update `SearchViewModel` to manage explore state, including pagination, loading status, and deduplication of results against existing search items.
- Enhance the search UI with an `ExploreFromGithubButton` and integrated loading/exhausted states.
- Add localized strings for the new explore features in English, Arabic, Bengali, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Russian, Turkish, and Simplified Chinese.
- Refactor `SearchState` to include `visibleRepos` as a managed property and introduce an `ExploreStatus` enum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub repository exploration with pagination support, enabling users to fetch and browse additional results directly from GitHub.
  * Implemented "Fetch more from GitHub" button with loading and exhausted states.
  * Added multi-language support with new UI strings across 12 languages for exploration, loading, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->