### PR TITLE
core: refresh Shizuku status before checking installation eligibility

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuInstallerWrapper.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuInstallerWrapper.kt
@@ -176,7 +176,31 @@ class ShizukuInstallerWrapper(
         androidInstaller.uninstall(packageName)
     }
 
-    private suspend fun shouldUseShizuku(): Boolean = isShizukuEnabled() && shizukuServiceManager.status.value == ShizukuStatus.READY
+    /**
+     * Whether this install attempt should be routed through Shizuku.
+     *
+     * Refreshes status first so we don't act on a stale cache. The
+     * status flow is only updated reactively by Shizuku's
+     * binder-received / binder-dead / permission-result listeners,
+     * plus a one-shot `initialize()` at DI time. If the app has been
+     * backgrounded long enough for the binder to die and revive
+     * without our listener catching the transition (e.g. days between
+     * the user opening the app), the cached value lags reality and
+     * we'd wrongly fall through to the unknown-sources prompt — the
+     * concrete symptom in issue #419. [AutoUpdateWorker] already does
+     * this before its own gate; this mirrors that pattern for every
+     * install path.
+     *
+     * Both gates are required: the user's explicit
+     * [InstallerType.SHIZUKU] preference AND a live/granted Shizuku.
+     * We deliberately don't override the preference — DEFAULT means
+     * "use the system installer," even when Shizuku happens to be
+     * granted for another purpose.
+     */
+    private fun shouldUseShizuku(): Boolean {
+        shizukuServiceManager.refreshStatus()
+        return isShizukuEnabled() && shizukuServiceManager.status.value == ShizukuStatus.READY
+    }
 
     private fun isShizukuEnabled(): Boolean = cachedInstallerType == InstallerType.SHIZUKU
 }


### PR DESCRIPTION
- Update `shouldUseShizuku` to call `shizukuServiceManager.refreshStatus()` before checking the current status value.
- Ensures the installer does not rely on a stale binder status cache when routing installation attempts.
- Maintains the requirement that both the user preference must be set to `InstallerType.SHIZUKU` and the service status must be `READY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Shizuku-based installation by refreshing system status before permission checks and installation operations, ensuring up-to-date status information is used instead of cached values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->