### PR TITLE
BackendApiClient: Include GitHub token in search and explore requests

### DIFF
--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/MainActivity.kt
@@ -49,11 +49,6 @@ class MainActivity : ComponentActivity() {
         // cheap and we only block once per Activity creation (including
         // the post-language-swap recreate() path below). Without this,
         // recreate() would briefly flash the old locale before settling.
-        //
-        // The 2s timeout + catch-all is defence against a stalled or
-        // corrupted DataStore: we'd rather boot in system language than
-        // leave the Activity stuck before super.onCreate(), which would
-        // hang the whole app with no visible error.
         runBlocking {
             val tag =
                 try {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -51,10 +51,6 @@ fun main(args: Array<String>) {
     // language swaps surface as a "restart required" snackbar from the
     // Tweaks screen; this block just covers the cold-start path so
     // users see their chosen language immediately on next launch.
-    //
-    // Timeout guards against a stalled DataStore read blocking window
-    // creation and deep-link dispatch — we fall back to system language
-    // rather than hang the launch.
     runBlocking {
         val koin = GlobalContext.get()
         val tweaksRepo = koin.get<TweaksRepository>()

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -155,6 +155,7 @@ val coreModule =
             get<ProxyManagerSeeding>()
             BackendApiClient(
                 proxyConfigFlow = ProxyManager.configFlow(ProxyScope.DISCOVERY),
+                tokenStore = get(),
             )
         }
         // NOTE: the reviewer asked for a Koin onClose hook to call

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import zed.rainxch.core.data.data_source.TokenStore
 import zed.rainxch.core.data.dto.BackendExploreResponse
 import zed.rainxch.core.data.dto.BackendRepoResponse
 import zed.rainxch.core.data.dto.BackendSearchResponse
@@ -42,6 +44,7 @@ import kotlin.coroutines.cancellation.CancellationException
  */
 class BackendApiClient(
     proxyConfigFlow: StateFlow<ProxyConfig>,
+    private val tokenStore: TokenStore,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val mutex = Mutex()
@@ -110,12 +113,14 @@ class BackendApiClient(
         offset: Int = 0,
     ): Result<BackendSearchResponse> =
         safeCall {
+            val token = currentUserGithubToken()
             val response = httpClient.get("search") {
                 parameter("q", query)
                 if (platform != null) parameter("platform", platform)
                 if (sort != null) parameter("sort", sort)
                 parameter("limit", limit)
                 parameter("offset", offset)
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
             }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
@@ -130,11 +135,13 @@ class BackendApiClient(
         page: Int = 1,
     ): Result<BackendExploreResponse> =
         safeCall {
+            val token = currentUserGithubToken()
             val response = httpClient.get("search/explore") {
                 parameter("q", query)
                 if (platform != null) parameter("platform", platform)
                 parameter("page", page)
                 timeout { requestTimeoutMillis = 20_000 }
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
             }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
@@ -142,6 +149,11 @@ class BackendApiClient(
                 Result.failure(BackendException("HTTP ${response.status.value}"))
             }
         }
+
+    private suspend fun currentUserGithubToken(): String? =
+        runCatching { tokenStore.currentToken()?.accessToken?.trim() }
+            .getOrNull()
+            ?.takeIf { it.isNotEmpty() }
 
     suspend fun getRepo(owner: String, name: String): Result<BackendRepoResponse> =
         safeCall {
@@ -180,6 +192,7 @@ class BackendApiClient(
 
     companion object {
         private const val BASE_URL = "https://api.github-store.org/v1/"
+        private const val X_GITHUB_TOKEN_HEADER = "X-GitHub-Token"
     }
 }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -151,10 +151,13 @@ class BackendApiClient(
         }
 
     private suspend fun currentUserGithubToken(): String? =
-        runCatching { tokenStore.currentToken()?.accessToken?.trim() }
-            .getOrNull()
-            ?.takeIf { it.isNotEmpty() }
-
+        try {
+            tokenStore.currentToken()?.accessToken?.trim()?.takeIf { it.isNotEmpty() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
     suspend fun getRepo(owner: String, name: String): Result<BackendRepoResponse> =
         safeCall {
             val response = httpClient.get("repo/$owner/$name")

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -214,10 +214,6 @@ class TweaksRepositoryImpl(
 
     override fun getAppLanguage(): Flow<String?> =
         preferences.data.map { prefs ->
-            // Treat blank *or* unknown tags as "unset" — guards against
-            // stale writes from older builds that shipped a language
-            // we no longer bundle resources for, which would otherwise
-            // pin the UI to an unresolvable locale.
             prefs[APP_LANGUAGE_KEY]
                 ?.trim()
                 ?.takeIf { it.isNotEmpty() && AppLanguages.containsTag(it) }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -752,22 +752,9 @@ class TweaksViewModel(
             }
 
             is TweaksAction.OnAppLanguageSelected -> {
-                // Skip the write + restart prompt when the user re-picks
-                // the language that's already active — tapping the
-                // current option shouldn't look like a change on
-                // Desktop (would fire a spurious "restart to apply"
-                // snackbar) or churn DataStore on Android.
                 if (action.tag == _state.value.selectedAppLanguage) return
                 viewModelScope.launch {
                     tweaksRepository.setAppLanguage(action.tag)
-                    // Android: `MainActivity` is subscribed to the
-                    // same preference flow and calls `recreate()` on
-                    // change — no extra nudging needed. Desktop has
-                    // no recreate-equivalent, so we surface a
-                    // "restart to apply" prompt; the user's choice is
-                    // already persisted and will take effect on the
-                    // next launch (or they can restart now via the
-                    // snackbar action).
                     if (getPlatform() != Platform.ANDROID) {
                         _events.send(TweaksEvent.OnAppLanguageChangeRequiresRestart)
                     }


### PR DESCRIPTION
- Inject `TokenStore` into `BackendApiClient`.
- Implement `currentUserGithubToken()` to retrieve and trim the access token from `TokenStore`.
- Add `X-GitHub-Token` header to `search` and `search/explore` requests if a token is available.
- Update `SharedModule` to provide the `TokenStore` dependency to `BackendApiClient`.
- Cleanup: Remove several detailed internal comments regarding language selection logic and DataStore timeouts in `TweaksViewModel`, `TweaksRepositoryImpl`, `DesktopApp`, and `MainActivity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub authentication tokens in search requests to improve API rate limits and access to repositories.

* **Documentation**
  * Removed internal comments from startup and preference initialization code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->