### PR TITLE
Adjust content padding for Home and Search screens to account for bot…

### DIFF
--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -364,6 +364,7 @@ private fun MainState(
     bottomNavLiquidState: LiquidState,
     homeTopBarLiquidState: LiquidState,
 ) {
+    val bottomNavHeight = LocalBottomNavigationHeight.current
     val visibleRepos by remember(state.repos, state.isHideSeenEnabled, state.seenRepoIds) {
         derivedStateOf {
             if (state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()) {
@@ -386,7 +387,13 @@ private fun MainState(
             columns = StaggeredGridCells.Adaptive(350.dp),
             verticalItemSpacing = 12.dp,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+            contentPadding =
+                PaddingValues(
+                    start = 8.dp,
+                    end = 8.dp,
+                    top = 12.dp,
+                    bottom = bottomNavHeight + 32.dp,
+                ),
             modifier = Modifier.fillMaxSize(),
         ) {
             items(

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -553,7 +553,16 @@ fun SearchScreen(
                             columns = StaggeredGridCells.Adaptive(350.dp),
                             verticalItemSpacing = 12.dp,
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+                            // Bottom clearance = nav pill + FAB (~56dp standard M3
+                            // FAB, positioned at bottomNavHeight + 16.dp) + breathing
+                            // room so the last card scrolls fully above both.
+                            contentPadding =
+                                PaddingValues(
+                                    start = 8.dp,
+                                    end = 8.dp,
+                                    top = 12.dp,
+                                    bottom = bottomNavHeight + 88.dp,
+                                ),
                             modifier =
                                 Modifier
                                     .fillMaxSize()


### PR DESCRIPTION
…tom navigation

- In `HomeRoot.kt`, update the `LazyVerticalStaggeredGrid` bottom padding to include `bottomNavHeight` plus additional spacing to ensure the last item is not obscured.
- In `SearchRoot.kt`, increase the bottom `contentPadding` to provide clearance for both the bottom navigation pill and the Floating Action Button (FAB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content spacing and padding calculations in grid layouts to ensure proper alignment with bottom navigation elements.
  * Enhanced scrolling behavior to prevent content from overlapping with navigation UI components at the bottom of the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->