### PR TITLE
make GitHub release author and asset uploader fields nullable

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/AssetNetwork.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/AssetNetwork.kt
@@ -10,6 +10,6 @@ data class AssetNetwork(
     @SerialName("content_type") val contentType: String,
     @SerialName("size") val size: Long,
     @SerialName("browser_download_url") val downloadUrl: String,
-    @SerialName("uploader") val uploader: OwnerNetwork,
+    @SerialName("uploader") val uploader: OwnerNetwork? = null,
     @SerialName("download_count") val downloadCount: Long = 0,
 )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubReadmeResponseDto.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubReadmeResponseDto.kt
@@ -1,0 +1,12 @@
+package zed.rainxch.core.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GithubReadmeResponseDto(
+    @SerialName("name") val name: String? = null,
+    @SerialName("path") val path: String? = null,
+    @SerialName("content") val content: String,
+    @SerialName("encoding") val encoding: String? = null,
+)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/ReleaseNetwork.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/ReleaseNetwork.kt
@@ -10,7 +10,7 @@ data class ReleaseNetwork(
     @SerialName("name") val name: String? = null,
     @SerialName("draft") val draft: Boolean? = null,
     @SerialName("prerelease") val prerelease: Boolean? = null,
-    @SerialName("author") val author: OwnerNetwork,
+    @SerialName("author") val author: OwnerNetwork? = null,
     @SerialName("published_at") val publishedAt: String? = null,
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("body") val body: String? = null,

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/AssetNetwork.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/AssetNetwork.kt
@@ -12,11 +12,13 @@ fun AssetNetwork.toDomain(): GithubAsset =
         size = size,
         downloadUrl = downloadUrl,
         uploader =
-            GithubUser(
-                id = uploader.id,
-                login = uploader.login,
-                avatarUrl = uploader.avatarUrl,
-                htmlUrl = uploader.htmlUrl,
-            ),
+            uploader?.let {
+                GithubUser(
+                    id = it.id,
+                    login = it.login,
+                    avatarUrl = it.avatarUrl,
+                    htmlUrl = it.htmlUrl,
+                )
+            },
         downloadCount = downloadCount,
     )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/ReleaseNetwork.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mappers/ReleaseNetwork.kt
@@ -10,12 +10,14 @@ fun ReleaseNetwork.toDomain(): GithubRelease =
         tagName = tagName,
         name = name,
         author =
-            GithubUser(
-                id = author.id,
-                login = author.login,
-                avatarUrl = author.avatarUrl,
-                htmlUrl = author.htmlUrl,
-            ),
+            author?.let {
+                GithubUser(
+                    id = it.id,
+                    login = it.login,
+                    avatarUrl = it.avatarUrl,
+                    htmlUrl = it.htmlUrl,
+                )
+            },
         publishedAt = publishedAt ?: createdAt ?: "",
         description = body,
         assets = assets.map { it.toDomain() },

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -33,6 +33,9 @@ import zed.rainxch.core.data.dto.BackendExploreResponse
 import zed.rainxch.core.data.dto.BackendRepoResponse
 import zed.rainxch.core.data.dto.BackendSearchResponse
 import zed.rainxch.core.data.dto.EventRequest
+import zed.rainxch.core.data.dto.GithubReadmeResponseDto
+import zed.rainxch.core.data.dto.ReleaseNetwork
+import zed.rainxch.core.data.dto.UserProfileNetwork
 import zed.rainxch.core.domain.model.ProxyConfig
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -91,7 +94,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException("HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -101,7 +104,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException("HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -125,7 +128,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException("HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -151,7 +154,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException("HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -165,11 +168,72 @@ class BackendApiClient(
         }
     suspend fun getRepo(owner: String, name: String): Result<BackendRepoResponse> =
         safeCall {
-            val response = httpClient.get("repo/$owner/$name")
+            val token = currentUserGithubToken()
+            val response = httpClient.get("repo/$owner/$name") {
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+            }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException("HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun getReleases(
+        owner: String,
+        name: String,
+        page: Int = 1,
+        perPage: Int = 100,
+    ): Result<List<ReleaseNetwork>> =
+        safeCall {
+            val token = currentUserGithubToken()
+            val response = httpClient.get("releases/$owner/$name") {
+                parameter("page", page)
+                parameter("per_page", perPage)
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+                // Cold path: backend goes to GitHub + paginates. 15s covers p99.
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    socketTimeoutMillis = 15_000
+                }
+            }
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun getReadme(
+        owner: String,
+        name: String,
+    ): Result<GithubReadmeResponseDto> =
+        safeCall {
+            val token = currentUserGithubToken()
+            val response = httpClient.get("readme/$owner/$name") {
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    socketTimeoutMillis = 15_000
+                }
+            }
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+            }
+        }
+
+    suspend fun getUser(username: String): Result<UserProfileNetwork> =
+        safeCall {
+            val token = currentUserGithubToken()
+            val response = httpClient.get("user/$username") {
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+            }
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else {
+                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -185,7 +249,7 @@ class BackendApiClient(
                 response.status == HttpStatusCode.TooManyRequests ->
                     Result.failure(RateLimitedException())
                 else ->
-                    Result.failure(BackendException("HTTP ${response.status.value}"))
+                    Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
             }
         }
 
@@ -204,6 +268,9 @@ class BackendApiClient(
     }
 }
 
-class BackendException(message: String) : Exception(message)
+class BackendException(
+    val statusCode: Int,
+    message: String,
+) : Exception(message)
 
 class RateLimitedException : Exception("Rate limited by backend (429)")

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -94,7 +94,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -104,7 +104,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -128,7 +128,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -154,7 +154,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -175,7 +175,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -200,7 +200,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -220,7 +220,7 @@ class BackendApiClient(
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -229,11 +229,15 @@ class BackendApiClient(
             val token = currentUserGithubToken()
             val response = httpClient.get("user/$username") {
                 if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    socketTimeoutMillis = 15_000
+                }
             }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else {
-                Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -249,7 +253,7 @@ class BackendApiClient(
                 response.status == HttpStatusCode.TooManyRequests ->
                     Result.failure(RateLimitedException())
                 else ->
-                    Result.failure(BackendException(response.status.value, "HTTP ${response.status.value}"))
+                    Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -270,7 +274,7 @@ class BackendApiClient(
 
 class BackendException(
     val statusCode: Int,
-    message: String,
+    message: String = "HTTP $statusCode",
 ) : Exception(message)
 
 class RateLimitedException : Exception("Rate limited by backend (429)")

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/GithubAsset.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/GithubAsset.kt
@@ -9,6 +9,6 @@ data class GithubAsset(
     val contentType: String,
     val size: Long,
     val downloadUrl: String,
-    val uploader: GithubUser,
+    val uploader: GithubUser? = null,
     val downloadCount: Long = 0,
 )

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/GithubRelease.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/GithubRelease.kt
@@ -7,7 +7,7 @@ data class GithubRelease(
     val id: Long,
     val tagName: String,
     val name: String?,
-    val author: GithubUser,
+    val author: GithubUser? = null,
     val publishedAt: String,
     val description: String?,
     val assets: List<GithubAsset>,

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -213,6 +213,10 @@
     <string name="installed">Installed</string>
     <string name="update_available">Update available</string>
     <string name="not_available">Not available</string>
+    <string name="releases_load_failed">Couldn\'t load releases</string>
+    <string name="releases_load_failed_description">Check your connection and try again.</string>
+    <string name="no_releases_published">No releases published yet</string>
+    <string name="loading_releases">Loading releases…</string>
     <string name="install_latest">Install latest</string>
     <string name="reinstall">Reinstall</string>
     <string name="update_app">Update app</string>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/mappers/GithubAssetMapper.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/mappers/GithubAssetMapper.kt
@@ -11,11 +11,13 @@ fun GithubAsset.toUi(): GithubAssetUi {
         contentType = contentType,
         size = size,
         downloadUrl = downloadUrl,
-        uploader = GithubUserUi(
-            id = uploader.id,
-            login = uploader.login,
-            avatarUrl = uploader.avatarUrl,
-            htmlUrl = uploader.htmlUrl,
-        ),
+        uploader = uploader?.let {
+            GithubUserUi(
+                id = it.id,
+                login = it.login,
+                avatarUrl = it.avatarUrl,
+                htmlUrl = it.htmlUrl,
+            )
+        },
     )
 }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/model/GithubAssetUi.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/model/GithubAssetUi.kt
@@ -6,5 +6,5 @@ data class GithubAssetUi(
     val contentType: String,
     val size: Long,
     val downloadUrl: String,
-    val uploader: GithubUserUi,
+    val uploader: GithubUserUi? = null,
 )

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -5,6 +5,8 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpHeaders
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import zed.rainxch.core.data.cache.CacheManager
@@ -13,6 +15,7 @@ import zed.rainxch.core.data.cache.CacheManager.CacheTtl.RELEASES
 import zed.rainxch.core.data.cache.CacheManager.CacheTtl.REPO_DETAILS
 import zed.rainxch.core.data.cache.CacheManager.CacheTtl.REPO_STATS
 import zed.rainxch.core.data.cache.CacheManager.CacheTtl.USER_PROFILE
+import zed.rainxch.core.data.dto.GithubReadmeResponseDto
 import zed.rainxch.core.data.dto.ReleaseNetwork
 import zed.rainxch.core.data.dto.RepoByIdNetwork
 import zed.rainxch.core.data.dto.RepoInfoNetwork
@@ -22,6 +25,7 @@ import zed.rainxch.core.data.dto.BackendRepoResponse
 import zed.rainxch.core.data.mappers.toDomain
 import zed.rainxch.core.data.mappers.toSummary
 import zed.rainxch.core.data.network.BackendApiClient
+import zed.rainxch.core.data.network.BackendException
 import zed.rainxch.core.data.network.GitHubClientProvider
 import zed.rainxch.core.data.network.executeRequest
 import zed.rainxch.core.data.services.LocalizationManager
@@ -53,6 +57,21 @@ class DetailsRepositoryImpl(
     )
 
     private val readmeHelper = ReadmeLocalizationHelper(localizationManager)
+
+    /**
+     * Decides whether a backend failure should trigger the direct-to-GitHub
+     * fallback. Only infrastructure errors should — backend 4xx responses
+     * are real answers (cached negative hits, auth failures, etc.) that
+     * GitHub would return equivalently, so retrying via GitHub direct
+     * just adds latency without changing the outcome.
+     */
+    private fun shouldFallbackToGithub(cause: Throwable): Boolean =
+        when (cause) {
+            is CancellationException -> throw cause
+            is BackendException -> cause.statusCode in 500..599
+            // Network/timeout/parse — treated as infra error, retry via GitHub
+            else -> true
+        }
 
     private fun BackendRepoResponse.toBackendSummary(): GithubRepoSummary = toSummary()
 
@@ -118,17 +137,33 @@ class DetailsRepositoryImpl(
             return cached
         }
 
-        // Try backend first
-        backendApiClient.getRepo(owner, name).getOrNull()?.let { backendRepo ->
-            logger.debug("Backend hit for repo $owner/$name")
-            val result = backendRepo.toBackendSummary()
-            cacheManager.put(cacheKey, result, REPO_DETAILS)
-            return result
-        }
+        // Try backend first. Phase 5.1: backend now lazy-caches unknown
+        // repos, so success rate is high even for non-curated repos.
+        val backendResult = backendApiClient.getRepo(owner, name)
+        backendResult.fold(
+            onSuccess = { backendRepo ->
+                logger.debug("Backend hit for repo $owner/$name")
+                val result = backendRepo.toBackendSummary()
+                cacheManager.put(cacheKey, result, REPO_DETAILS)
+                return result
+            },
+            onFailure = { e ->
+                if (!shouldFallbackToGithub(e)) {
+                    // Backend 4xx — GitHub would give the same answer.
+                    // Serve stale if we have it, otherwise propagate the
+                    // error so the VM can show the right state.
+                    cacheManager.getStale<GithubRepoSummary>(cacheKey)?.let { stale ->
+                        logger.debug("Backend 4xx for $owner/$name, serving stale cache")
+                        return stale
+                    }
+                    throw e
+                }
+                logger.debug("Backend infra error for $owner/$name (${e.message}), falling back to GitHub")
+            },
+        )
 
-        // Fallback to GitHub API
+        // Fallback to GitHub API (only reached on backend 5xx / network error)
         return try {
-            logger.debug("Backend miss for $owner/$name, falling back to GitHub API")
             val result =
                 httpClient
                     .executeRequest<RepoByIdNetwork> {
@@ -209,6 +244,36 @@ class DetailsRepositoryImpl(
             }
         }
 
+        // Backend-first. Phase 5.1 routes /v1/releases via the backend cache
+        // + ETag revalidation, China-reachable via Gcore/api-direct.
+        val backendResult = backendApiClient.getReleases(owner, repo)
+        backendResult.fold(
+            onSuccess = { releases ->
+                val result = releases
+                    .filter { it.draft != true }
+                    .map { release ->
+                        release.copy(
+                            body = processReleaseBody(release.body, owner, repo, defaultBranch),
+                        ).toDomain()
+                    }.sortedByDescending { it.publishedAt }
+                if (result.isNotEmpty()) {
+                    cacheManager.put(cacheKey, result, RELEASES)
+                }
+                return result
+            },
+            onFailure = { e ->
+                if (!shouldFallbackToGithub(e)) {
+                    cacheManager.getStale<List<GithubRelease>>(cacheKey)?.let { stale ->
+                        logger.debug("Backend 4xx for releases $owner/$repo, serving stale cache")
+                        return stale
+                    }
+                    throw e
+                }
+                logger.debug("Backend infra error for releases $owner/$repo (${e.message}), falling back to GitHub")
+            },
+        )
+
+        // Fallback to GitHub API directly (only reached on backend 5xx / network error)
         return try {
             val releases =
                 httpClient
@@ -286,6 +351,46 @@ class DetailsRepositoryImpl(
             return Triple(cached.content, cached.languageCode, cached.path)
         }
 
+        // Backend-first. Phase 5.2: /v1/readme proxies GitHub's contents API,
+        // which returns base64-encoded markdown — different shape from the
+        // raw.githubusercontent.com path below, but the post-processing
+        // pipeline is the same.
+        val backendResult = backendApiClient.getReadme(owner, repo)
+        backendResult.fold(
+            onSuccess = { dto ->
+                val processed = processReadmeFromBackend(dto, owner, repo, defaultBranch)
+                if (processed != null) {
+                    cacheManager.put(
+                        cacheKey,
+                        CachedReadme(
+                            content = processed.first,
+                            languageCode = processed.second,
+                            path = processed.third,
+                        ),
+                        README,
+                    )
+                    return processed
+                }
+                // Decode/processing failed — fall through to the raw-URL path
+                logger.debug("Backend readme decode failed for $owner/$repo, falling back to raw URL")
+            },
+            onFailure = { e ->
+                if (!shouldFallbackToGithub(e)) {
+                    cacheManager.getStale<CachedReadme>(cacheKey)?.let { stale ->
+                        logger.debug("Backend 4xx for readme $owner/$repo, serving stale cache")
+                        return Triple(stale.content, stale.languageCode, stale.path)
+                    }
+                    // No stale — no readme exists or user can't access. Treat
+                    // as "no readme" rather than propagating as an error;
+                    // matches how fetchReadmeFromApi returned null.
+                    return null
+                }
+                logger.debug("Backend infra error for readme $owner/$repo (${e.message}), falling back to raw URL")
+            },
+        )
+
+        // Fallback to raw.githubusercontent.com (only reached on backend
+        // infra error or on successful backend response that we couldn't decode)
         val result = fetchReadmeFromApi(owner, repo, defaultBranch)
 
         if (result != null) {
@@ -299,6 +404,29 @@ class DetailsRepositoryImpl(
         }
 
         return result
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun processReadmeFromBackend(
+        dto: GithubReadmeResponseDto,
+        owner: String,
+        repo: String,
+        defaultBranch: String,
+    ): Triple<String, String?, String>? {
+        // GitHub's contents API base64-encodes with embedded newlines.
+        val raw = dto.content.replace("\n", "").replace("\r", "")
+        val decoded = try {
+            Base64.Default.decode(raw).decodeToString()
+        } catch (e: Throwable) {
+            logger.warn("Failed to base64-decode backend readme for $owner/$repo: ${e.message}")
+            return null
+        }
+        val path = dto.path?.takeIf { it.isNotBlank() } ?: "README.md"
+        val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/"
+        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl)
+        val detectedLang = readmeHelper.detectReadmeLanguage(processed)
+        logger.debug("Fetched README via backend (detected language: ${detectedLang ?: "unknown"})")
+        return Triple(processed, detectedLang, path)
     }
 
     private suspend fun fetchReadmeFromApi(
@@ -424,6 +552,28 @@ class DetailsRepositoryImpl(
             return cached
         }
 
+        // Backend-first. Phase 5.3: /v1/user proxies GitHub's users API with
+        // aggressive edge caching (7-day TTL on Gcore).
+        val backendResult = backendApiClient.getUser(username)
+        backendResult.fold(
+            onSuccess = { user ->
+                val result = user.toDomainProfile()
+                cacheManager.put(cacheKey, result, USER_PROFILE)
+                return result
+            },
+            onFailure = { e ->
+                if (!shouldFallbackToGithub(e)) {
+                    cacheManager.getStale<GithubUserProfile>(cacheKey)?.let { stale ->
+                        logger.debug("Backend 4xx for profile $username, serving stale cache")
+                        return stale
+                    }
+                    throw e
+                }
+                logger.debug("Backend infra error for profile $username (${e.message}), falling back to GitHub")
+            },
+        )
+
+        // Fallback to GitHub direct (only reached on backend 5xx / network error)
         return try {
             val user =
                 httpClient
@@ -433,23 +583,7 @@ class DetailsRepositoryImpl(
                         }
                     }.getOrThrow()
 
-            val result =
-                GithubUserProfile(
-                    id = user.id,
-                    login = user.login,
-                    name = user.name,
-                    bio = user.bio,
-                    avatarUrl = user.avatarUrl,
-                    htmlUrl = user.htmlUrl,
-                    followers = user.followers,
-                    following = user.following,
-                    publicRepos = user.publicRepos,
-                    location = user.location,
-                    company = user.company,
-                    blog = user.blog,
-                    twitterUsername = user.twitterUsername,
-                )
-
+            val result = user.toDomainProfile()
             cacheManager.put(cacheKey, result, USER_PROFILE)
             result
         } catch (e: Exception) {
@@ -460,6 +594,23 @@ class DetailsRepositoryImpl(
             throw e
         }
     }
+
+    private fun UserProfileNetwork.toDomainProfile(): GithubUserProfile =
+        GithubUserProfile(
+            id = id,
+            login = login,
+            name = name,
+            bio = bio,
+            avatarUrl = avatarUrl,
+            htmlUrl = htmlUrl,
+            followers = followers,
+            following = following,
+            publicRepos = publicRepos,
+            location = location,
+            company = company,
+            blog = blog,
+            twitterUsername = twitterUsername,
+        )
 
     override suspend fun checkAttestations(
         owner: String,

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -60,16 +60,27 @@ class DetailsRepositoryImpl(
 
     /**
      * Decides whether a backend failure should trigger the direct-to-GitHub
-     * fallback. Only infrastructure errors should — backend 4xx responses
-     * are real answers (cached negative hits, auth failures, etc.) that
-     * GitHub would return equivalently, so retrying via GitHub direct
-     * just adds latency without changing the outcome.
+     * fallback. **Side effect:** rethrows `CancellationException` to preserve
+     * structured concurrency — callers don't need a separate CE check before
+     * invoking this.
+     *
+     * Returns `true` for:
+     *   - Any non-[BackendException] throwable (network errors, timeouts,
+     *     parse failures — all treated as infra)
+     *   - [BackendException] with status in 500..599
+     *
+     * Returns `false` for:
+     *   - [BackendException] with status in 400..499 — backend's answer is
+     *     authoritative (cached 404, 401 auth failure, 429 rate limit, etc.)
+     *     and GitHub-direct would return the same answer. **Note:** this
+     *     includes 429 and 408 — if the backend is rate-limiting us or
+     *     timing out on its own pipeline, retrying via GitHub direct
+     *     doesn't help and only burns more quota.
      */
-    private fun shouldFallbackToGithub(cause: Throwable): Boolean =
+    private fun shouldFallbackToGithubOrRethrow(cause: Throwable): Boolean =
         when (cause) {
             is CancellationException -> throw cause
             is BackendException -> cause.statusCode in 500..599
-            // Network/timeout/parse — treated as infra error, retry via GitHub
             else -> true
         }
 
@@ -148,7 +159,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithub(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e)) {
                     // Backend 4xx — GitHub would give the same answer.
                     // Serve stale if we have it, otherwise propagate the
                     // error so the VM can show the right state.
@@ -262,7 +273,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithub(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e)) {
                     cacheManager.getStale<List<GithubRelease>>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for releases $owner/$repo, serving stale cache")
                         return stale
@@ -375,7 +386,7 @@ class DetailsRepositoryImpl(
                 logger.debug("Backend readme decode failed for $owner/$repo, falling back to raw URL")
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithub(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e)) {
                     cacheManager.getStale<CachedReadme>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for readme $owner/$repo, serving stale cache")
                         return Triple(stale.content, stale.languageCode, stale.path)
@@ -413,11 +424,13 @@ class DetailsRepositoryImpl(
         repo: String,
         defaultBranch: String,
     ): Triple<String, String?, String>? {
-        // GitHub's contents API base64-encodes with embedded newlines.
-        val raw = dto.content.replace("\n", "").replace("\r", "")
+        // GitHub's contents API base64-encodes with embedded newlines; Mime
+        // variant tolerates all whitespace transparently so we don't have
+        // to pre-strip. Narrow catch: only IAE is decode-related, other
+        // throwables (OOM, etc.) propagate.
         val decoded = try {
-            Base64.Default.decode(raw).decodeToString()
-        } catch (e: Throwable) {
+            Base64.Mime.decode(dto.content).decodeToString()
+        } catch (e: IllegalArgumentException) {
             logger.warn("Failed to base64-decode backend readme for $owner/$repo: ${e.message}")
             return null
         }
@@ -474,44 +487,57 @@ class DetailsRepositoryImpl(
         // Backend doesn't have openIssues/license, so supplement with a
         // best-effort GitHub call for those fields. If GitHub is blocked
         // (e.g. for users in China), we still show the backend data.
-        backendApiClient.getRepo(owner, repo).getOrNull()?.let { backendRepo ->
-            logger.debug("Backend hit for repo stats $owner/$repo")
+        val backendResult = backendApiClient.getRepo(owner, repo)
+        backendResult.fold(
+            onSuccess = { backendRepo ->
+                logger.debug("Backend hit for repo stats $owner/$repo")
 
-            // Explicit try/catch (not runCatching) so cancellation
-            // propagates — runCatching would swallow it and break
-            // structured concurrency.
-            val githubInfo =
-                try {
-                    httpClient.executeRequest<RepoInfoNetwork> {
-                        get("/repos/$owner/$repo") {
-                            header(HttpHeaders.Accept, "application/vnd.github+json")
-                        }
-                    }.getOrNull()
-                } catch (e: CancellationException) {
+                // Explicit try/catch (not runCatching) so cancellation
+                // propagates — runCatching would swallow it and break
+                // structured concurrency.
+                val githubInfo =
+                    try {
+                        httpClient.executeRequest<RepoInfoNetwork> {
+                            get("/repos/$owner/$repo") {
+                                header(HttpHeaders.Accept, "application/vnd.github+json")
+                            }
+                        }.getOrNull()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.debug("GitHub enrichment failed for $owner/$repo: ${e.message}")
+                        null
+                    }
+
+                // If the GitHub enrichment didn't land, reuse the stale
+                // cached openIssues/license from a previous successful
+                // resolve. Prevents a transient GitHub failure from
+                // clobbering real values with zeros/nulls.
+                val stale = if (githubInfo == null) cacheManager.getStale<RepoStats>(cacheKey) else null
+
+                val result = RepoStats(
+                    stars = backendRepo.stargazersCount,
+                    forks = backendRepo.forksCount,
+                    openIssues = githubInfo?.openIssues ?: stale?.openIssues ?: 0,
+                    license = githubInfo?.license?.spdxId
+                        ?: githubInfo?.license?.name
+                        ?: stale?.license,
+                    totalDownloads = backendRepo.downloadCount,
+                )
+                cacheManager.put(cacheKey, result, REPO_STATS)
+                return result
+            },
+            onFailure = { e ->
+                if (!shouldFallbackToGithubOrRethrow(e)) {
+                    cacheManager.getStale<RepoStats>(cacheKey)?.let { stale ->
+                        logger.debug("Backend 4xx for stats $owner/$repo, serving stale cache")
+                        return stale
+                    }
                     throw e
-                } catch (e: Exception) {
-                    logger.debug("GitHub enrichment failed for $owner/$repo: ${e.message}")
-                    null
                 }
-
-            // If the GitHub enrichment didn't land, reuse the stale
-            // cached openIssues/license from a previous successful
-            // resolve. Prevents a transient GitHub failure from
-            // clobbering real values with zeros/nulls.
-            val stale = if (githubInfo == null) cacheManager.getStale<RepoStats>(cacheKey) else null
-
-            val result = RepoStats(
-                stars = backendRepo.stargazersCount,
-                forks = backendRepo.forksCount,
-                openIssues = githubInfo?.openIssues ?: stale?.openIssues ?: 0,
-                license = githubInfo?.license?.spdxId
-                    ?: githubInfo?.license?.name
-                    ?: stale?.license,
-                totalDownloads = backendRepo.downloadCount,
-            )
-            cacheManager.put(cacheKey, result, REPO_STATS)
-            return result
-        }
+                logger.debug("Backend infra error for stats $owner/$repo (${e.message}), falling back to GitHub")
+            },
+        )
 
         // Fallback to GitHub API
         return try {
@@ -562,7 +588,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithub(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e)) {
                     cacheManager.getStale<GithubUserProfile>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for profile $username, serving stale cache")
                         return stale

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpHeaders
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import zed.rainxch.core.data.cache.CacheManager
 import zed.rainxch.core.data.cache.CacheManager.CacheTtl.README
 import zed.rainxch.core.data.cache.CacheManager.CacheTtl.RELEASES
@@ -232,6 +233,19 @@ class DetailsRepositoryImpl(
                 cacheManager.put(cacheKey, result, RELEASES)
             }
             result
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: SerializationException) {
+            // Parse failure signals a DTO/API drift — surface loudly so it's
+            // findable in logs and crash reports. Still prefer returning a
+            // stale cache rather than throwing, so the UI can keep rendering
+            // the last known good data while we figure out the new shape.
+            logger.error("Failed to parse releases for $owner/$repo: ${e.message}", e)
+            cacheManager.getStale<List<GithubRelease>>(cacheKey)?.let { stale ->
+                logger.debug("Serving stale cache for releases $owner/$repo after parse failure")
+                return stale
+            }
+            throw e
         } catch (e: Exception) {
             cacheManager.getStale<List<GithubRelease>>(cacheKey)?.let { stale ->
                 logger.debug("Network error, using stale cache for releases $owner/$repo")

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
@@ -9,6 +9,8 @@ import zed.rainxch.details.presentation.model.TranslationTarget
 sealed interface DetailsAction {
     data object Retry : DetailsAction
 
+    data object RetryReleases : DetailsAction
+
     data object InstallPrimary : DetailsAction
 
     data object OnDismissDowngradeWarning : DetailsAction

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -27,6 +27,8 @@ data class DetailsState(
     // state for releases
     val selectedRelease: GithubRelease? = null,
     val allReleases: List<GithubRelease> = emptyList(),
+    val releasesLoadFailed: Boolean = false,
+    val isRetryingReleases: Boolean = false,
     val isReleaseSelectorVisible: Boolean = false,
     val selectedReleaseCategory: ReleaseCategory = ReleaseCategory.STABLE,
     val isVersionPickerVisible: Boolean = false,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -513,6 +513,7 @@ class DetailsViewModel(
         val repo = _state.value.repository ?: return
         if (_state.value.isRetryingReleases) return
         viewModelScope.launch {
+            val prevCategory = _state.value.selectedReleaseCategory
             _state.update { it.copy(isRetryingReleases = true, releasesLoadFailed = false) }
             try {
                 val releases =
@@ -521,8 +522,21 @@ class DetailsViewModel(
                         repo = repo.name,
                         defaultBranch = repo.defaultBranch,
                     )
-                val selected =
-                    releases.firstOrNull { !it.isPrerelease } ?: releases.firstOrNull()
+                // Prefer a release that matches the user's previous category.
+                // Only fall back to the generic "first stable, else first" rule
+                // when no release exists in that category — in which case reset
+                // the category too so the UI doesn't end up with a category
+                // selected but no matching release.
+                val byPrevCategory = when (prevCategory) {
+                    ReleaseCategory.STABLE -> releases.firstOrNull { !it.isPrerelease }
+                    ReleaseCategory.PRE_RELEASE -> releases.firstOrNull { it.isPrerelease }
+                    ReleaseCategory.ALL -> releases.firstOrNull()
+                }
+                val selected = byPrevCategory
+                    ?: releases.firstOrNull { !it.isPrerelease }
+                    ?: releases.firstOrNull()
+                val resolvedCategory =
+                    if (byPrevCategory != null) prevCategory else ReleaseCategory.STABLE
                 val (installable, primary) =
                     recomputeAssetsForRelease(selected, _state.value.installedApp)
                 _state.update {
@@ -531,11 +545,13 @@ class DetailsViewModel(
                         releasesLoadFailed = false,
                         isRetryingReleases = false,
                         selectedRelease = selected,
-                        selectedReleaseCategory = ReleaseCategory.STABLE,
+                        selectedReleaseCategory = resolvedCategory,
                         installableAssets = installable,
                         primaryAsset = primary,
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: RateLimitException) {
                 _state.update {
                     it.copy(isRetryingReleases = false, releasesLoadFailed = true)
@@ -2083,7 +2099,17 @@ class DetailsViewModel(
                 val installedApp = installedAppDeferred.await()
 
                 if (rateLimited.get()) {
-                    _state.value = _state.value.copy(isLoading = false, errorMessage = null)
+                    // Any deferred tripping the rate-limit flag leaves the UI
+                    // in an incomplete state. Flag the releases section as
+                    // failed so it renders its FAILED card with a Retry
+                    // affordance instead of the misleading EMPTY card ("no
+                    // releases published yet") — the default would be EMPTY
+                    // because allReleases stays at its initial empty list.
+                    _state.value = _state.value.copy(
+                        isLoading = false,
+                        errorMessage = null,
+                        releasesLoadFailed = true,
+                    )
                     return@launch
                 }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -167,6 +167,8 @@ class DetailsViewModel(
                 loadInitial()
             }
 
+            DetailsAction.RetryReleases -> retryReleases()
+
             DetailsAction.OnDismissDowngradeWarning -> {
                 dismissDowngradeWarning()
             }
@@ -504,6 +506,46 @@ class DetailsViewModel(
 
     private fun observeLiquidGlassEnabled() {
         viewModelScope.launch {
+        }
+    }
+
+    private fun retryReleases() {
+        val repo = _state.value.repository ?: return
+        if (_state.value.isRetryingReleases) return
+        viewModelScope.launch {
+            _state.update { it.copy(isRetryingReleases = true, releasesLoadFailed = false) }
+            try {
+                val releases =
+                    detailsRepository.getAllReleases(
+                        owner = repo.owner.login,
+                        repo = repo.name,
+                        defaultBranch = repo.defaultBranch,
+                    )
+                val selected =
+                    releases.firstOrNull { !it.isPrerelease } ?: releases.firstOrNull()
+                val (installable, primary) =
+                    recomputeAssetsForRelease(selected, _state.value.installedApp)
+                _state.update {
+                    it.copy(
+                        allReleases = releases,
+                        releasesLoadFailed = false,
+                        isRetryingReleases = false,
+                        selectedRelease = selected,
+                        selectedReleaseCategory = ReleaseCategory.STABLE,
+                        installableAssets = installable,
+                        primaryAsset = primary,
+                    )
+                }
+            } catch (_: RateLimitException) {
+                _state.update {
+                    it.copy(isRetryingReleases = false, releasesLoadFailed = true)
+                }
+            } catch (t: Throwable) {
+                logger.warn("Retry failed to load releases: ${t.message}")
+                _state.update {
+                    it.copy(isRetryingReleases = false, releasesLoadFailed = true)
+                }
+            }
         }
     }
 
@@ -1951,13 +1993,13 @@ class DetailsViewModel(
                                 owner = owner,
                                 repo = name,
                                 defaultBranch = repo.defaultBranch,
-                            )
+                            ) to false
                         } catch (_: RateLimitException) {
                             rateLimited.set(true)
-                            emptyList()
+                            emptyList<GithubRelease>() to true
                         } catch (t: Throwable) {
                             logger.warn("Failed to load releases: ${t.message}")
-                            emptyList()
+                            emptyList<GithubRelease>() to true
                         }
                     }
 
@@ -2034,7 +2076,7 @@ class DetailsViewModel(
                 val isObtainiumEnabled = platform == Platform.ANDROID
                 val isAppManagerEnabled = platform == Platform.ANDROID
 
-                val allReleases = allReleasesDeferred.await()
+                val (allReleases, releasesFailed) = allReleasesDeferred.await()
                 val stats = statsDeferred.await()
                 val readme = readmeDeferred.await()
                 val userProfile = userProfileDeferred.await()
@@ -2064,6 +2106,8 @@ class DetailsViewModel(
                         errorMessage = null,
                         repository = repo,
                         allReleases = allReleases,
+                        releasesLoadFailed = releasesFailed,
+                        isRetryingReleases = false,
                         selectedRelease = selectedRelease,
                         selectedReleaseCategory = ReleaseCategory.STABLE,
                         stats = stats,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleasesStatusCard.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleasesStatusCard.kt
@@ -1,0 +1,114 @@
+package zed.rainxch.details.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.Inventory2
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.presentation.components.GithubStoreButton
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.loading_releases
+import zed.rainxch.githubstore.core.presentation.res.no_releases_published
+import zed.rainxch.githubstore.core.presentation.res.releases_load_failed
+import zed.rainxch.githubstore.core.presentation.res.releases_load_failed_description
+import zed.rainxch.githubstore.core.presentation.res.retry
+
+enum class ReleasesStatus {
+    FAILED,
+    RETRYING,
+    EMPTY,
+}
+
+@Composable
+fun ReleasesStatusCard(
+    status: ReleasesStatus,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            when (status) {
+                ReleasesStatus.FAILED -> {
+                    Icon(
+                        imageVector = Icons.Outlined.CloudOff,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(28.dp),
+                    )
+                    Text(
+                        text = stringResource(Res.string.releases_load_failed),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = stringResource(Res.string.releases_load_failed_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    GithubStoreButton(
+                        text = stringResource(Res.string.retry),
+                        onClick = onRetry,
+                    )
+                }
+
+                ReleasesStatus.RETRYING -> {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                        )
+                        Text(
+                            text = stringResource(Res.string.loading_releases),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                ReleasesStatus.EMPTY -> {
+                    Icon(
+                        imageVector = Icons.Outlined.Inventory2,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(28.dp),
+                    )
+                    Text(
+                        text = stringResource(Res.string.no_releases_published),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -28,6 +28,8 @@ import zed.rainxch.details.presentation.DetailsAction
 import zed.rainxch.details.presentation.DetailsState
 import zed.rainxch.details.presentation.components.AppHeader
 import zed.rainxch.details.presentation.components.ReleaseAssetsPicker
+import zed.rainxch.details.presentation.components.ReleasesStatus
+import zed.rainxch.details.presentation.components.ReleasesStatusCard
 import zed.rainxch.details.presentation.components.SmartInstallButton
 import zed.rainxch.details.presentation.components.VersionPicker
 import zed.rainxch.details.presentation.components.VersionTypePicker
@@ -67,59 +69,82 @@ fun LazyListScope.header(
         }
     }
 
-    // versions type list
-    if (state.allReleases.isNotEmpty()) {
+    // Status card replaces the pickers + install button in three cases:
+    //   1. releases fetch failed — show error + Retry
+    //   2. retry in flight — show spinner
+    //   3. repo truly has no releases — show "no releases published" empty state
+    // Initial page load (isLoading) is intentionally excluded — the top-level
+    // loading spinner covers it, no need to double up.
+    val releasesStatus: ReleasesStatus? =
+        when {
+            state.releasesLoadFailed -> ReleasesStatus.FAILED
+            state.isRetryingReleases -> ReleasesStatus.RETRYING
+            !state.isLoading && state.allReleases.isEmpty() -> ReleasesStatus.EMPTY
+            else -> null
+        }
+
+    if (releasesStatus != null) {
         item {
-            VersionTypePicker(
-                selectedCategory = state.selectedReleaseCategory,
-                onAction = onAction,
-                modifier = Modifier.fillMaxWidth().animateItem(),
+            ReleasesStatusCard(
+                status = releasesStatus,
+                onRetry = { onAction(DetailsAction.RetryReleases) },
+                modifier = Modifier.animateItem(),
             )
         }
-    }
-
-    // version and installable release
-    if (state.allReleases.isNotEmpty() || state.installableAssets.isNotEmpty()) {
-        item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                ReleaseAssetsPicker(
-                    assetsList = state.installableAssets,
-                    selectedAsset = state.primaryAsset,
-                    isPickerVisible = state.isReleaseSelectorVisible,
-                    pinnedVariant = state.installedApp?.preferredAssetVariant,
+    } else {
+        // versions type list
+        if (state.allReleases.isNotEmpty()) {
+            item {
+                VersionTypePicker(
+                    selectedCategory = state.selectedReleaseCategory,
                     onAction = onAction,
-                    modifier = Modifier.weight(.65f),
-                )
-                VersionPicker(
-                    selectedRelease = state.selectedRelease,
-                    filteredReleases = state.filteredReleases,
-                    isPickerVisible = state.isVersionPickerVisible,
-                    onAction = onAction,
-                    modifier = Modifier.weight(.35f),
+                    modifier = Modifier.fillMaxWidth().animateItem(),
                 )
             }
         }
-    }
 
-    item {
-        val liquidState = LocalTopbarLiquidState.current
+        // version and installable release
+        if (state.allReleases.isNotEmpty() || state.installableAssets.isNotEmpty()) {
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ReleaseAssetsPicker(
+                        assetsList = state.installableAssets,
+                        selectedAsset = state.primaryAsset,
+                        isPickerVisible = state.isReleaseSelectorVisible,
+                        pinnedVariant = state.installedApp?.preferredAssetVariant,
+                        onAction = onAction,
+                        modifier = Modifier.weight(.65f),
+                    )
+                    VersionPicker(
+                        selectedRelease = state.selectedRelease,
+                        filteredReleases = state.filteredReleases,
+                        isPickerVisible = state.isVersionPickerVisible,
+                        onAction = onAction,
+                        modifier = Modifier.weight(.35f),
+                    )
+                }
+            }
+        }
 
-        Box(
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            SmartInstallButton(
-                isDownloading = state.isDownloading,
-                isInstalling = state.isInstalling,
-                isLiquidGlassEnabled = state.isLiquidGlassEnabled,
-                progress = state.downloadProgressPercent,
-                primaryAsset = state.primaryAsset,
-                state = state,
-                onAction = onAction,
-            )
+        item {
+            val liquidState = LocalTopbarLiquidState.current
+
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                SmartInstallButton(
+                    isDownloading = state.isDownloading,
+                    isInstalling = state.isInstalling,
+                    isLiquidGlassEnabled = state.isLiquidGlassEnabled,
+                    progress = state.downloadProgressPercent,
+                    primaryAsset = state.primaryAsset,
+                    state = state,
+                    onAction = onAction,
+                )
 
             DropdownMenu(
                 expanded = state.isInstallDropdownExpanded,
@@ -238,5 +263,6 @@ fun LazyListScope.header(
                 )
             }
         }
+    }
     }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -74,9 +74,12 @@ fun LazyListScope.header(
     //   2. retry in flight — show spinner
     //   3. repo truly has no releases — show "no releases published" empty state
     // Initial page load (isLoading) is intentionally excluded — the top-level
-    // loading spinner covers it, no need to double up.
+    // loading spinner covers it, no need to double up. Same for repository
+    // not loaded yet: the release-specific states only make sense once we
+    // know the repo exists (matches the VM's retryReleases() guard).
     val releasesStatus: ReleasesStatus? =
         when {
+            state.repository == null -> null
             state.releasesLoadFailed -> ReleasesStatus.FAILED
             state.isRetryingReleases -> ReleasesStatus.RETRYING
             !state.isLoading && state.allReleases.isEmpty() -> ReleasesStatus.EMPTY


### PR DESCRIPTION
- Update `GithubAsset` and `GithubRelease` domain models to allow null values for `uploader` and `author`.
- Modify `AssetNetwork` and `ReleaseNetwork` DTOs to handle optional `uploader` and `author` fields from API responses.
- Update data and presentation mappers to safely handle null user objects using null-safe calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release loading with pagination and a retry flow
  * Backend-backed readme and user profile fetching

* **Improvements**
  * Clearer release-error handling and retry feedback
  * UI: release status card (loading / empty / failed) with retry action
  * Tolerant handling of missing asset/author/uploader metadata
  * Added user-facing strings for release loading states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->