### PR TITLE
Add support for Arch Linux packages (`.pkg.tar.zst`)

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/StarredRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/StarredRepositoryImpl.kt
@@ -204,9 +204,7 @@ class StarredRepositoryImpl(
 
                         Platform.LINUX -> {
                             name.endsWith(".appimage") || name.endsWith(".deb") ||
-                                name.endsWith(
-                                    ".rpm",
-                                )
+                                name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
                         }
                     }
                 }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/model/LinuxPackageType.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/model/LinuxPackageType.kt
@@ -1,7 +1,8 @@
 package zed.rainxch.core.data.model
 
 enum class LinuxPackageType {
-    DEB, // Debian/Ubuntu/Mint
-    RPM, // Fedora/RHEL/CentOS/openSUSE
+    DEB, // Debian/Ubuntu/Mint/Pop/Elementary
+    RPM, // Fedora/RHEL/CentOS/openSUSE/Rocky/Alma
+    ARCH, // Arch/Manjaro/EndeavourOS/Artix/CachyOS/Garuda
     UNIVERSAL, // Unknown - show AppImage only
 }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopInstaller.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopInstaller.kt
@@ -92,7 +92,10 @@ class DesktopInstaller(
                 }
 
                 Platform.LINUX -> {
-                    name.endsWith(".appimage") || name.endsWith(".deb") || name.endsWith(".rpm")
+                    name.endsWith(".appimage") ||
+                        name.endsWith(".deb") ||
+                        name.endsWith(".rpm") ||
+                        name.endsWith(".pkg.tar.zst")
                 }
             }
 
@@ -119,17 +122,23 @@ class DesktopInstaller(
                 }
 
                 Platform.LINUX -> {
+                    // Flatpak sandbox prefers native packages over AppImage
+                    // because AppImages inside Flatpak require extra permission
+                    // dances. Outside Flatpak we prefer AppImage — portable,
+                    // no sudo needed.
                     if (isRunningInFlatpak) {
                         when (linuxPackageType) {
-                            LinuxPackageType.DEB -> listOf(".deb", ".appimage", ".rpm")
-                            LinuxPackageType.RPM -> listOf(".rpm", ".appimage", ".deb")
-                            LinuxPackageType.UNIVERSAL -> listOf(".appimage", ".deb", ".rpm")
+                            LinuxPackageType.DEB -> listOf(".deb", ".appimage", ".rpm", ".pkg.tar.zst")
+                            LinuxPackageType.RPM -> listOf(".rpm", ".appimage", ".deb", ".pkg.tar.zst")
+                            LinuxPackageType.ARCH -> listOf(".pkg.tar.zst", ".appimage", ".deb", ".rpm")
+                            LinuxPackageType.UNIVERSAL -> listOf(".appimage", ".deb", ".rpm", ".pkg.tar.zst")
                         }
                     } else {
                         when (linuxPackageType) {
-                            LinuxPackageType.DEB -> listOf(".appimage", ".deb", ".rpm")
-                            LinuxPackageType.RPM -> listOf(".appimage", ".rpm", ".deb")
-                            LinuxPackageType.UNIVERSAL -> listOf(".appimage", ".deb", ".rpm")
+                            LinuxPackageType.DEB -> listOf(".appimage", ".deb", ".rpm", ".pkg.tar.zst")
+                            LinuxPackageType.RPM -> listOf(".appimage", ".rpm", ".deb", ".pkg.tar.zst")
+                            LinuxPackageType.ARCH -> listOf(".appimage", ".pkg.tar.zst", ".deb", ".rpm")
+                            LinuxPackageType.UNIVERSAL -> listOf(".appimage", ".deb", ".rpm", ".pkg.tar.zst")
                         }
                     }
                 }
@@ -231,6 +240,23 @@ class DesktopInstaller(
                     Logger.d { "Detected RPM-based distribution: $id" }
                     return LinuxPackageType.RPM
                 }
+
+                if (id in
+                    listOf(
+                        "arch",
+                        "manjaro",
+                        "endeavouros",
+                        "artix",
+                        "cachyos",
+                        "garuda",
+                        "arcolinux",
+                        "parabola",
+                    ) ||
+                    idLike.contains("arch")
+                ) {
+                    Logger.d { "Detected Arch-based distribution: $id" }
+                    return LinuxPackageType.ARCH
+                }
             }
 
             if (commandExists("apt") || commandExists("apt-get")) {
@@ -251,6 +277,11 @@ class DesktopInstaller(
             if (commandExists("zypper")) {
                 Logger.d { "Detected package manager: zypper" }
                 return LinuxPackageType.RPM
+            }
+
+            if (commandExists("pacman")) {
+                Logger.d { "Detected package manager: pacman" }
+                return LinuxPackageType.ARCH
             }
 
             Logger.d { "Could not determine package type, defaulting to UNIVERSAL" }
@@ -292,6 +323,22 @@ class DesktopInstaller(
         ) {
             Logger.d { "Host is RPM-based: $id" }
             return LinuxPackageType.RPM
+        }
+
+        if (id in listOf(
+                "arch",
+                "manjaro",
+                "endeavouros",
+                "artix",
+                "cachyos",
+                "garuda",
+                "arcolinux",
+                "parabola",
+            ) ||
+            idLike.contains("arch")
+        ) {
+            Logger.d { "Host is Arch-based: $id" }
+            return LinuxPackageType.ARCH
         }
 
         Logger.d { "Could not classify host distro, defaulting to UNIVERSAL" }
@@ -374,7 +421,12 @@ class DesktopInstaller(
         return when (platform) {
             Platform.WINDOWS -> ext in listOf("msi", "exe")
             Platform.MACOS -> ext in listOf("dmg", "pkg")
-            Platform.LINUX -> ext in listOf("appimage", "deb", "rpm")
+            // "pkg.tar.zst" keeps the literal double-dotted form the Arch
+            // convention uses. Dispatch below checks the full filename
+            // suffix anyway, but callers that only have the ext token
+            // (e.g. file-extension-only classification paths) would see
+            // "zst" on its own. Accept "pkg.tar.zst" and bare "zst" both.
+            Platform.LINUX -> ext in listOf("appimage", "deb", "rpm", "pkg.tar.zst", "zst")
             else -> false
         }
     }
@@ -688,6 +740,17 @@ class DesktopInstaller(
         file: File,
         ext: String,
     ) {
+        // The `ext` parameter is just the final extension token, but
+        // Arch packages use the double-dotted form `.pkg.tar.zst`. So
+        // look at the full filename when routing to pacman — a bare
+        // `.zst` on a non-pacman-shaped filename is genuinely ambiguous
+        // and we shouldn't hand it to pacman.
+        val nameLower = file.name.lowercase()
+        if (nameLower.endsWith(".pkg.tar.zst")) {
+            installPacmanPackage(file)
+            return
+        }
+
         when (ext) {
             "appimage" -> {
                 installAppImage(file)
@@ -884,6 +947,136 @@ class DesktopInstaller(
         }
 
         throw IOException("Could not install RPM package. Please install it manually.")
+    }
+
+    private fun installPacmanPackage(file: File) {
+        Logger.d { "Installing pacman package: ${file.absolutePath}" }
+
+        // Wrong-distro case: a `.pkg.tar.zst` on a non-Arch system is
+        // effectively impossible to install cleanly (no package manager
+        // knows the format, and conversion tools like `debtap` are
+        // Arch→Debian not the other way, and require user setup to
+        // seed their DB first). Show the user a clear terminal message
+        // instead of silently attempting a path that will fail.
+        if (linuxPackageType != LinuxPackageType.ARCH) {
+            Logger.w { "Pacman package (.pkg.tar.zst) on non-Arch system (type=$linuxPackageType)." }
+            openTerminalForPacmanIncompatible(file.absolutePath)
+            return
+        }
+
+        val installMethods =
+            listOf(
+                listOf("pkexec", "pacman", "-U", "--noconfirm", file.absolutePath),
+                listOf(
+                    "pkexec",
+                    "sh",
+                    "-c",
+                    "pacman -U --noconfirm '${file.absolutePath}'",
+                ),
+                null,
+            )
+
+        for (method in installMethods) {
+            if (method == null) {
+                openTerminalForPacmanInstall(file.absolutePath)
+                return
+            }
+
+            try {
+                Logger.d { "Trying installation method: ${method.joinToString(" ")}" }
+                val process = ProcessBuilder(method).start()
+                val exitCode = process.waitFor()
+
+                if (exitCode == 0) {
+                    Logger.d { "Pacman package installed successfully" }
+                    tryShowNotification("Installation Complete", "Package installed successfully")
+                    return
+                } else {
+                    Logger.w { "Installation method failed with exit code: $exitCode" }
+                }
+            } catch (e: IOException) {
+                Logger.w { "Installation method not available: ${e.message}" }
+            }
+        }
+
+        throw IOException("Could not install pacman package. Please install it manually.")
+    }
+
+    private fun openTerminalForPacmanInstall(filePath: String) {
+        Logger.d { "Opening terminal for pacman -U install" }
+
+        val availableTerminals = detectAvailableTerminals()
+
+        if (availableTerminals.isEmpty()) {
+            tryShowNotification(
+                "Install via Terminal",
+                "Run: sudo pacman -U '$filePath'",
+            )
+            throw IOException("No terminal emulator found to run pacman install.")
+        }
+
+        val command =
+            buildString {
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo 'Installing Arch Package'; ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo ''; ")
+                append("echo 'You will be prompted for your sudo password.'; ")
+                append("echo ''; ")
+                append("sudo pacman -U '$filePath'; ")
+                append("EXIT=\$?; ")
+                append("echo ''; ")
+                append("if [ \$EXIT -eq 0 ]; then ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo 'Installation Complete!'; ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("else ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo 'Installation Failed (exit \$EXIT)'; ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("fi; ")
+                append("echo ''; ")
+                append("echo 'Press Enter to close...'; read")
+            }
+
+        runCommandInTerminal(command, availableTerminals)
+    }
+
+    private fun openTerminalForPacmanIncompatible(filePath: String) {
+        Logger.d { "Opening terminal to inform user .pkg.tar.zst is not installable on their distro" }
+
+        val availableTerminals = detectAvailableTerminals()
+
+        if (availableTerminals.isEmpty()) {
+            tryShowNotification(
+                "Wrong Package Type",
+                "This is an Arch Linux package (.pkg.tar.zst) — not supported on your distribution. Look for a .deb, .rpm, or .AppImage in the release.",
+            )
+            throw IOException(
+                "Arch packages (.pkg.tar.zst) can only be installed on Arch-based distributions.",
+            )
+        }
+
+        val command =
+            buildString {
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo 'Wrong Package Format'; ")
+                append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
+                append("echo ''; ")
+                append("echo 'This file is an Arch Linux package (.pkg.tar.zst):'; ")
+                append("echo '  $filePath'; ")
+                append("echo ''; ")
+                append("echo 'Your system uses a different package format.'; ")
+                append("echo 'Please download the .deb, .rpm, or .AppImage variant'; ")
+                append("echo 'instead from the release page.'; ")
+                append("echo ''; ")
+                append("echo 'Press Enter to close...'; read")
+            }
+
+        runCommandInTerminal(command, availableTerminals)
+        throw IOException(
+            "Arch packages (.pkg.tar.zst) can only be installed on Arch-based distributions.",
+        )
     }
 
     private fun openTerminalForDebInstall(filePath: String) {

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopInstaller.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopInstaller.kt
@@ -514,6 +514,42 @@ class DesktopInstaller(
         Logger.i { "Running in Flatpak sandbox — delegating installation to host system" }
         Logger.i { "File: ${file.absolutePath} (.$ext)" }
 
+        // Arch packages use the double extension `.pkg.tar.zst`. Callers
+        // may pass either "pkg.tar.zst" or just "zst" via `ext` depending
+        // on which classification path computed it, so gate on the
+        // filename directly — same authoritative check installLinux uses.
+        val nameLower = file.name.lowercase()
+        if (nameLower.endsWith(".pkg.tar.zst")) {
+            Logger.d { "Opening .pkg.tar.zst package via xdg-open portal for host installation" }
+            try {
+                val process = ProcessBuilder("xdg-open", file.absolutePath).start()
+                val exitCode = process.waitFor()
+                if (exitCode == 0) {
+                    Logger.i { "Arch package opened on host system for installation" }
+                    showFlatpakNotification(
+                        title = "Package Ready to Install",
+                        message = "The Arch package has been opened in your system's " +
+                            "package manager. Follow the prompts to complete installation.",
+                    )
+                } else {
+                    Logger.w { "xdg-open exited with code $exitCode" }
+                    showFlatpakNotification(
+                        title = "Installation",
+                        message = "Please open this .pkg.tar.zst file with your package manager.",
+                    )
+                    openInFileManager(file)
+                }
+            } catch (e: Exception) {
+                Logger.w { "Failed to open .pkg.tar.zst via xdg-open: ${e.message}" }
+                showFlatpakNotification(
+                    title = "Download Complete",
+                    message = "Please install manually: sudo pacman -U <path>",
+                )
+                openInFileManager(file)
+            }
+            return
+        }
+
         when (ext) {
             "deb", "rpm" -> {
                 Logger.d { "Opening .$ext package via xdg-open portal for host installation" }
@@ -949,6 +985,22 @@ class DesktopInstaller(
         throw IOException("Could not install RPM package. Please install it manually.")
     }
 
+    /**
+     * Wraps a string for safe embedding inside a POSIX shell
+     * single-quoted context. Handles embedded single quotes via the
+     * `'\''` closing-escaping-reopening trick.
+     *
+     *   `foo`          → `'foo'`
+     *   `foo'bar`      → `'foo'\''bar'`
+     *   `don't panic`  → `'don'\''t panic'`
+     *
+     * Use this whenever a filename (or any externally-sourced string)
+     * needs to be interpolated into a shell command that ends up being
+     * executed — terminal command builders, `sh -c` invocations, etc.
+     */
+    private fun shellQuoteSingleQuotes(s: String): String =
+        "'" + s.replace("'", "'\\''") + "'"
+
     private fun installPacmanPackage(file: File) {
         Logger.d { "Installing pacman package: ${file.absolutePath}" }
 
@@ -964,15 +1016,13 @@ class DesktopInstaller(
             return
         }
 
+        // argv-list invocation — no shell involved, so filenames with
+        // special chars are passed safely. No `sh -c` fallback needed
+        // here because pacman -U doesn't need any shell-level chaining
+        // (unlike DEB's `dpkg || apt-get install -f`).
         val installMethods =
             listOf(
                 listOf("pkexec", "pacman", "-U", "--noconfirm", file.absolutePath),
-                listOf(
-                    "pkexec",
-                    "sh",
-                    "-c",
-                    "pacman -U --noconfirm '${file.absolutePath}'",
-                ),
                 null,
             )
 
@@ -1006,11 +1056,14 @@ class DesktopInstaller(
         Logger.d { "Opening terminal for pacman -U install" }
 
         val availableTerminals = detectAvailableTerminals()
+        val quoted = shellQuoteSingleQuotes(filePath)
 
         if (availableTerminals.isEmpty()) {
+            // Notification body is user-visible text, not a shell command,
+            // so the raw path is fine to display here.
             tryShowNotification(
                 "Install via Terminal",
-                "Run: sudo pacman -U '$filePath'",
+                "Run: sudo pacman -U $quoted",
             )
             throw IOException("No terminal emulator found to run pacman install.")
         }
@@ -1023,7 +1076,7 @@ class DesktopInstaller(
                 append("echo ''; ")
                 append("echo 'You will be prompted for your sudo password.'; ")
                 append("echo ''; ")
-                append("sudo pacman -U '$filePath'; ")
+                append("sudo pacman -U $quoted; ")
                 append("EXIT=\$?; ")
                 append("echo ''; ")
                 append("if [ \$EXIT -eq 0 ]; then ")
@@ -1057,6 +1110,7 @@ class DesktopInstaller(
             )
         }
 
+        val quoted = shellQuoteSingleQuotes(filePath)
         val command =
             buildString {
                 append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
@@ -1064,7 +1118,10 @@ class DesktopInstaller(
                 append("echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'; ")
                 append("echo ''; ")
                 append("echo 'This file is an Arch Linux package (.pkg.tar.zst):'; ")
-                append("echo '  $filePath'; ")
+                // printf treats %s as a plain arg, so the shell-escaped
+                // $quoted resolves back to the real path when printed —
+                // no literal escape characters bleed into the display.
+                append("printf '  %s\\n' $quoted; ")
                 append("echo ''; ")
                 append("echo 'Your system uses a different package format.'; ")
                 append("echo 'Please download the .deb, .rpm, or .AppImage variant'; ")

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
@@ -262,7 +262,13 @@ private fun derivePlatformsFromAssets(release: GithubRelease?): List<DiscoveryPl
         if (names.any { it.endsWith(".apk") }) add(DiscoveryPlatform.Android)
         if (names.any { it.endsWith(".exe") || it.endsWith(".msi") }) add(DiscoveryPlatform.Windows)
         if (names.any { it.endsWith(".dmg") || it.endsWith(".pkg") }) add(DiscoveryPlatform.Macos)
-        if (names.any { it.endsWith(".appimage") || it.endsWith(".deb") || it.endsWith(".rpm") }) {
+        if (names.any {
+                it.endsWith(".appimage") ||
+                    it.endsWith(".deb") ||
+                    it.endsWith(".rpm") ||
+                    it.endsWith(".pkg.tar.zst")
+            }
+        ) {
             add(
                 DiscoveryPlatform.Linux,
             )

--- a/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/repository/DeveloperProfileRepositoryImpl.kt
+++ b/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/repository/DeveloperProfileRepositoryImpl.kt
@@ -189,7 +189,7 @@ class DeveloperProfileRepositoryImpl(
 
                         Platform.LINUX -> {
                             name.endsWith(".appimage") || name.endsWith(".deb") ||
-                                name.endsWith(".rpm")
+                                name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
                         }
                     }
                 }

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/repository/HomeRepositoryImpl.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/repository/HomeRepositoryImpl.kt
@@ -580,9 +580,7 @@ class HomeRepositoryImpl(
 
                         Platform.LINUX -> {
                             name.endsWith(".appimage") || name.endsWith(".deb") ||
-                                name.endsWith(
-                                    ".rpm",
-                                )
+                                name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
                         }
                     }
                 }

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -331,7 +331,8 @@ class SearchRepositoryImpl(
                 name.endsWith(".apk") ||
                     name.endsWith(".msi") || name.endsWith(".exe") ||
                     name.endsWith(".dmg") || name.endsWith(".pkg") ||
-                    name.endsWith(".appimage") || name.endsWith(".deb") || name.endsWith(".rpm")
+                    name.endsWith(".appimage") || name.endsWith(".deb") ||
+                    name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
             }
 
             DiscoveryPlatform.Android -> {
@@ -347,7 +348,8 @@ class SearchRepositoryImpl(
             }
 
             DiscoveryPlatform.Linux -> {
-                name.endsWith(".appimage") || name.endsWith(".deb") || name.endsWith(".rpm")
+                name.endsWith(".appimage") || name.endsWith(".deb") ||
+                    name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
             }
         }
     }


### PR DESCRIPTION
- Add `.pkg.tar.zst` to the list of recognized Linux installers across various repositories and presentation components.
- Introduce `LinuxPackageType.ARCH` to represent Arch-based distributions.
- Implement distribution detection for Arch and its derivatives (Manjaro, EndeavourOS, etc.) via `/etc/os-release` and `pacman` command checks.
- Add `installPacmanPackage` logic to `DesktopInstaller` using `pkexec pacman -U` with a fallback to a manual terminal-based installation.
- Implement a safety check and user notification when attempting to install an Arch package on a non-Arch system.
- Update installation priority logic to prefer native packages over AppImages when running inside Flatpak on Arch systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native support for Arch Linux and Arch-based distributions.
  * Arch package format (.pkg.tar.zst) is now recognized and can be installed via Pacman, with improved Flatpak-aware install flows.

* **Bug Fixes**
  * Improved Linux installer asset matching and distribution detection for more accurate discovery across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->