### PR TITLE
feat: add arrow key navigation for scrollable lists and grids

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(grep -r \"\\\\.FLATPAK\\\\|Flatpak\\\\|flatpak\" . --include=*.kt)",
-      "Bash(./gradlew *)"
+      "Bash(./gradlew *)",
+      "Bash(rtk find *)"
     ]
   }
 }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ArrowKeyScroll.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ArrowKeyScroll.kt
@@ -1,0 +1,126 @@
+package zed.rainxch.core.presentation.utils
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import kotlinx.coroutines.launch
+
+private const val ARROW_STEP_PX = 120f
+private const val PAGE_STEP_FRACTION = 0.9f
+
+@Composable
+fun Modifier.arrowKeyScroll(
+    listState: LazyListState,
+    autoFocus: Boolean = true,
+): Modifier =
+    arrowKeyScrollInternal(
+        autoFocus = autoFocus,
+        scrollBy = { delta -> listState.animateScrollBy(delta) },
+        pageSize = { listState.layoutInfo.viewportSize.height.toFloat() },
+        scrollToTop = { listState.animateScrollToItem(0) },
+        scrollToBottom = {
+            val last = (listState.layoutInfo.totalItemsCount - 1).coerceAtLeast(0)
+            listState.animateScrollToItem(last)
+        },
+    )
+
+@Composable
+fun Modifier.arrowKeyScroll(
+    gridState: LazyStaggeredGridState,
+    autoFocus: Boolean = true,
+): Modifier =
+    arrowKeyScrollInternal(
+        autoFocus = autoFocus,
+        scrollBy = { delta -> gridState.animateScrollBy(delta) },
+        pageSize = { gridState.layoutInfo.viewportSize.height.toFloat() },
+        scrollToTop = { gridState.animateScrollToItem(0) },
+        scrollToBottom = {
+            val last = (gridState.layoutInfo.totalItemsCount - 1).coerceAtLeast(0)
+            gridState.animateScrollToItem(last)
+        },
+    )
+
+@Composable
+fun Modifier.arrowKeyScroll(
+    scrollState: ScrollState,
+    autoFocus: Boolean = true,
+): Modifier =
+    arrowKeyScrollInternal(
+        autoFocus = autoFocus,
+        scrollBy = { delta -> scrollState.animateScrollBy(delta) },
+        pageSize = { scrollState.viewportSize.toFloat() },
+        scrollToTop = { scrollState.animateScrollTo(0) },
+        scrollToBottom = { scrollState.animateScrollTo(scrollState.maxValue) },
+    )
+
+@Composable
+private fun Modifier.arrowKeyScrollInternal(
+    autoFocus: Boolean,
+    scrollBy: suspend (Float) -> Unit,
+    pageSize: () -> Float,
+    scrollToTop: suspend () -> Unit,
+    scrollToBottom: suspend () -> Unit,
+): Modifier {
+    val requester = remember { FocusRequester() }
+    val scope = rememberCoroutineScope()
+
+    if (autoFocus) {
+        LaunchedEffect(Unit) {
+            runCatching { requester.requestFocus() }
+        }
+    }
+
+    return this
+        .focusRequester(requester)
+        .focusable()
+        .onKeyEvent { event ->
+            if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
+            when (event.key) {
+                Key.DirectionDown -> {
+                    scope.launch { scrollBy(ARROW_STEP_PX) }
+                    true
+                }
+
+                Key.DirectionUp -> {
+                    scope.launch { scrollBy(-ARROW_STEP_PX) }
+                    true
+                }
+
+                Key.PageDown -> {
+                    scope.launch { scrollBy(pageSize() * PAGE_STEP_FRACTION) }
+                    true
+                }
+
+                Key.PageUp -> {
+                    scope.launch { scrollBy(-pageSize() * PAGE_STEP_FRACTION) }
+                    true
+                }
+
+                Key.MoveHome -> {
+                    scope.launch { scrollToTop() }
+                    true
+                }
+
+                Key.MoveEnd -> {
+                    scope.launch { scrollToBottom() }
+                    true
+                }
+
+                else -> false
+            }
+        }
+}

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ArrowKeyScroll.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ArrowKeyScroll.kt
@@ -22,10 +22,13 @@ import kotlinx.coroutines.launch
 private const val ARROW_STEP_PX = 120f
 private const val PAGE_STEP_FRACTION = 0.9f
 
+// When `autoFocus = true`, the modifier requests keyboard focus on first
+// composition so arrow keys work without a prior click/tab. Pass `false` on
+// screens where a TextField should keep focus (e.g. search inputs).
 @Composable
 fun Modifier.arrowKeyScroll(
     listState: LazyListState,
-    autoFocus: Boolean = true,
+    autoFocus: Boolean = false,
 ): Modifier =
     arrowKeyScrollInternal(
         autoFocus = autoFocus,
@@ -35,13 +38,17 @@ fun Modifier.arrowKeyScroll(
         scrollToBottom = {
             val last = (listState.layoutInfo.totalItemsCount - 1).coerceAtLeast(0)
             listState.animateScrollToItem(last)
+            // `animateScrollToItem` aligns the target to the viewport start,
+            // which can leave empty space after the last item. A follow-up
+            // large-delta scroll is clamped to the real end.
+            listState.animateScrollBy(Float.MAX_VALUE)
         },
     )
 
 @Composable
 fun Modifier.arrowKeyScroll(
     gridState: LazyStaggeredGridState,
-    autoFocus: Boolean = true,
+    autoFocus: Boolean = false,
 ): Modifier =
     arrowKeyScrollInternal(
         autoFocus = autoFocus,
@@ -51,13 +58,14 @@ fun Modifier.arrowKeyScroll(
         scrollToBottom = {
             val last = (gridState.layoutInfo.totalItemsCount - 1).coerceAtLeast(0)
             gridState.animateScrollToItem(last)
+            gridState.animateScrollBy(Float.MAX_VALUE)
         },
     )
 
 @Composable
 fun Modifier.arrowKeyScroll(
     scrollState: ScrollState,
-    autoFocus: Boolean = true,
+    autoFocus: Boolean = false,
 ): Modifier =
     arrowKeyScrollInternal(
         autoFocus = autoFocus,

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -102,6 +102,7 @@ import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.add_by_link
 import zed.rainxch.githubstore.core.presentation.res.advanced_settings_open
@@ -515,7 +516,7 @@ fun AppsScreen(
                         ) {
                             LazyColumn(
                                 state = listState,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
                                 contentPadding = PaddingValues(16.dp),
                                 verticalArrangement = Arrangement.spacedBy(12.dp),
                             ) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -63,6 +63,7 @@ import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.core.presentation.utils.isLiquidFrostAvailable
 import zed.rainxch.details.presentation.components.LanguagePicker
 import zed.rainxch.details.presentation.components.sections.about
@@ -426,6 +427,7 @@ fun DetailsScreen(
                                 .fillMaxHeight()
                                 .widthIn(max = 680.dp)
                                 .fillMaxWidth()
+                                .arrowKeyScroll(listState)
                                 .then(
                                     if (state.isLiquidGlassEnabled) {
                                         Modifier.liquefiable(liquidTopbarState)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -427,7 +427,7 @@ fun DetailsScreen(
                                 .fillMaxHeight()
                                 .widthIn(max = 680.dp)
                                 .fillMaxWidth()
-                                .arrowKeyScroll(listState)
+                                .arrowKeyScroll(listState, autoFocus = true)
                                 .then(
                                     if (state.isLiquidGlassEnabled) {
                                         Modifier.liquefiable(liquidTopbarState)

--- a/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/DeveloperProfileRoot.kt
+++ b/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/DeveloperProfileRoot.kt
@@ -45,6 +45,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.components.GithubStoreButton
 import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.devprofile.domain.model.RepoFilterType
 import zed.rainxch.devprofile.presentation.components.DeveloperRepoItem
 import zed.rainxch.devprofile.presentation.components.FilterSortControls
@@ -133,7 +134,7 @@ fun DeveloperProfileScreen(
                     ) {
                         LazyColumn(
                             state = listState,
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {

--- a/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/DeveloperProfileRoot.kt
+++ b/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/DeveloperProfileRoot.kt
@@ -134,7 +134,7 @@ fun DeveloperProfileScreen(
                     ) {
                         LazyColumn(
                             state = listState,
-                            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
+                            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState, autoFocus = true),
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
@@ -35,6 +35,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.favourites.presentation.components.FavouriteRepositoryItem
 import zed.rainxch.githubstore.core.presentation.res.*
 
@@ -105,7 +106,7 @@ fun FavouritesScreen(
                     verticalItemSpacing = 12.dp,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
                 ) {
                     items(
                         items = state.favouriteRepositories,

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
@@ -106,7 +106,7 @@ fun FavouritesScreen(
                     verticalItemSpacing = 12.dp,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
+                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
                 ) {
                     items(
                         items = state.favouriteRepositories,

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -84,6 +84,7 @@ import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.core.presentation.utils.isScrollingUp
 import zed.rainxch.core.presentation.utils.toIcons
 import zed.rainxch.core.presentation.utils.toLabel
@@ -394,7 +395,7 @@ private fun MainState(
                     top = 12.dp,
                     bottom = bottomNavHeight + 32.dp,
                 ),
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
         ) {
             items(
                 items = visibleRepos,

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -395,7 +395,7 @@ private fun MainState(
                     top = 12.dp,
                     bottom = bottomNavHeight + 32.dp,
                 ),
-            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
+            modifier = Modifier.fillMaxSize().arrowKeyScroll(listState, autoFocus = true),
         ) {
             items(
                 items = visibleRepos,

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +34,7 @@ import zed.rainxch.core.presentation.locals.LocalBottomNavigationHeight
 import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.profile.presentation.components.ClearDownloadsDialog
 import zed.rainxch.profile.presentation.components.LogoutDialog
@@ -179,12 +181,15 @@ fun ProfileScreen(
                 },
             ),
     ) { innerPadding ->
+        val listState = rememberLazyListState()
         LazyColumn(
+            state = listState,
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .arrowKeyScroll(listState),
         ) {
             profile(
                 state = state,

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
@@ -189,7 +189,7 @@ fun ProfileScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
                     .padding(16.dp)
-                    .arrowKeyScroll(listState),
+                    .arrowKeyScroll(listState, autoFocus = true),
         ) {
             profile(
                 state = state,

--- a/feature/recently-viewed/presentation/src/commonMain/kotlin/zed/rainxch/recentlyviewed/presentation/RecentlyViewedRoot.kt
+++ b/feature/recently-viewed/presentation/src/commonMain/kotlin/zed/rainxch/recentlyviewed/presentation/RecentlyViewedRoot.kt
@@ -33,6 +33,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.recentlyviewed.presentation.components.RecentlyViewedItem
 
@@ -103,7 +104,7 @@ fun RecentlyViewedScreen(
                     verticalItemSpacing = 12.dp,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
                 ) {
                     items(
                         items = state.repositories,

--- a/feature/recently-viewed/presentation/src/commonMain/kotlin/zed/rainxch/recentlyviewed/presentation/RecentlyViewedRoot.kt
+++ b/feature/recently-viewed/presentation/src/commonMain/kotlin/zed/rainxch/recentlyviewed/presentation/RecentlyViewedRoot.kt
@@ -104,7 +104,7 @@ fun RecentlyViewedScreen(
                     verticalItemSpacing = 12.dp,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
+                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
                 ) {
                     items(
                         items = state.repositories,

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -93,6 +93,7 @@ import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.search.presentation.components.LanguageFilterBottomSheet
 import zed.rainxch.search.presentation.components.SearchHistorySection
@@ -595,6 +596,7 @@ fun SearchScreen(
                             modifier =
                                 Modifier
                                     .fillMaxSize()
+                                    .arrowKeyScroll(listState, autoFocus = false)
                                     .then(
                                         if (state.isLiquidGlassEnabled) {
                                             Modifier.liquefiable(liquidState)

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
@@ -51,6 +51,7 @@ import zed.rainxch.core.presentation.components.GithubStoreButton
 import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.starred.presentation.components.StarredRepositoryItem
 import zed.rainxch.starred.presentation.utils.formatRelativeTime
@@ -164,7 +165,7 @@ fun StarredScreen(
                                 verticalItemSpacing = 12.dp,
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
                             ) {
                                 items(
                                     items = state.starredRepositories,

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
@@ -165,7 +165,7 @@ fun StarredScreen(
                                 verticalItemSpacing = 12.dp,
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                                modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState),
+                                modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
                             ) {
                                 items(
                                     items = state.starredRepositories,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +35,7 @@ import zed.rainxch.core.presentation.locals.LocalBottomNavigationHeight
 import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.tweaks.presentation.components.ClearDownloadsDialog
 import zed.rainxch.tweaks.presentation.components.sections.about
@@ -195,12 +197,15 @@ fun TweaksScreen(
                 },
             ),
     ) { innerPadding ->
+        val listState = rememberLazyListState()
         LazyColumn(
+            state = listState,
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .arrowKeyScroll(listState),
         ) {
             settings(
                 state = state,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -205,7 +205,7 @@ fun TweaksScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
                     .padding(16.dp)
-                    .arrowKeyScroll(listState),
+                    .arrowKeyScroll(listState, autoFocus = true),
         ) {
             settings(
                 state = state,


### PR DESCRIPTION
- Introduce a new `arrowKeyScroll` modifier utility to enable keyboard navigation for `LazyListState`, `LazyStaggeredGridState`, and `ScrollState`.
- Support standard navigation keys including Up/Down arrows (120px steps), PageUp/PageDown (90% viewport height), and Home/End.
- Implement automatic focus requesting within the modifier to ensure immediate keyboard responsiveness.
- Apply the `arrowKeyScroll` modifier across various feature screens, including Developer Profile, Apps, Home, Tweaks, Profile, Favourites, Details, Search, Starred Repos, and Recently Viewed.
- Update Claude local settings to allow `rtk find` bash commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global keyboard navigation for all scrollable content (lazy lists, staggered grids, and plain scroll views).
  * Supports Arrow Up/Down, Page Up/Down, and Home/End for animated scrolling.
  * Most screens auto-focus for immediate keyboard use; search results keep auto-focus disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->