### PR TITLE
Fix sign-in getting stuck with DNS error + dialog re-firing over auth screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -86,7 +86,19 @@ fun App(deepLinkUri: String? = null) {
     ) {
         ApplyAndroidSystemBars(state.isDarkTheme)
 
-        if (state.showRateLimitDialog && state.rateLimitInfo != null) {
+        // Suppress the rate-limit dialog while the user is on the auth
+        // screen. They already accepted the prompt and are mid-sign-in;
+        // re-emitting the same dialog over the auth UI is noise that
+        // also blocks them from finishing the device-flow steps. Also
+        // flush any pending flag set by background API calls during
+        // auth, so it doesn't ghost back when the user returns home.
+        val onAuthScreen = currentScreen is GithubStoreGraph.AuthenticationScreen
+        LaunchedEffect(onAuthScreen, state.showRateLimitDialog) {
+            if (onAuthScreen && state.showRateLimitDialog) {
+                viewModel.onAction(MainAction.DismissRateLimitDialog)
+            }
+        }
+        if (state.showRateLimitDialog && state.rateLimitInfo != null && !onAuthScreen) {
             RateLimitDialog(
                 rateLimitInfo = state.rateLimitInfo!!,
                 isAuthenticated = state.isLoggedIn,

--- a/feature/auth/presentation/src/commonMain/kotlin/zed/rainxch/auth/presentation/AuthenticationViewModel.kt
+++ b/feature/auth/presentation/src/commonMain/kotlin/zed/rainxch/auth/presentation/AuthenticationViewModel.kt
@@ -345,7 +345,7 @@ class AuthenticationViewModel(
                         )
                     }
 
-                    saveToSavedState(start.deviceCode, startUi, authPath)
+                    saveToSavedState(start.deviceCode, startUi)
                     startCountdown(start.expiresInSec)
                     startPolling(start.deviceCode)
 
@@ -424,7 +424,12 @@ class AuthenticationViewModel(
             if (outcome.path != authPath) {
                 logger.debug("Auth path escalated from $authPath to ${outcome.path}")
                 authPath = outcome.path
-                savedStateHandle[KEY_AUTH_PATH] = authPath.name
+                // Intentionally not persisted: escalation is a reaction to the
+                // current network's reachability and shouldn't carry across a
+                // process restart. A user whose Backend hiccupped once and got
+                // bumped to Direct shouldn't be stuck on Direct forever — esp.
+                // on networks where github.com is the unreachable side. Next
+                // process start re-evaluates from Backend.
             }
 
             when (val result = outcome.result) {
@@ -497,7 +502,6 @@ class AuthenticationViewModel(
     private fun saveToSavedState(
         deviceCode: String,
         startUi: GithubDeviceStartUi,
-        path: AuthPath,
     ) {
         savedStateHandle[KEY_DEVICE_CODE] = deviceCode
         savedStateHandle[KEY_USER_CODE] = startUi.userCode
@@ -506,7 +510,6 @@ class AuthenticationViewModel(
         savedStateHandle[KEY_INTERVAL_SEC] = startUi.intervalSec
         savedStateHandle[KEY_EXPIRES_IN_SEC] = startUi.expiresInSec
         savedStateHandle[KEY_START_TIME_MILLIS] = System.currentTimeMillis()
-        savedStateHandle[KEY_AUTH_PATH] = path.name
     }
 
     private fun clearSavedState() {
@@ -520,13 +523,6 @@ class AuthenticationViewModel(
         val expiresInSec = savedStateHandle.get<Int>(KEY_EXPIRES_IN_SEC) ?: return
         val intervalSec = savedStateHandle.get<Int>(KEY_INTERVAL_SEC) ?: 5
         val startTimeMillis = savedStateHandle.get<Long>(KEY_START_TIME_MILLIS) ?: return
-        val restoredPath =
-            savedStateHandle.get<String>(KEY_AUTH_PATH)?.let {
-                runCatching { AuthPath.valueOf(it) }.getOrNull()
-            } ?: run {
-                clearSavedState()
-                return
-            }
 
         val elapsedSec = ((System.currentTimeMillis() - startTimeMillis) / 1000).toInt()
         val remainingSec = expiresInSec - elapsedSec
@@ -536,7 +532,15 @@ class AuthenticationViewModel(
             return
         }
 
-        authPath = restoredPath
+        // Always restart on Backend. A prior Direct escalation reflected the
+        // network at the time it happened; on a fresh process the network may
+        // be different (e.g., user switched away from a hostile WiFi, or back
+        // to one where github.com is filtered). The escalation logic in
+        // pollDeviceTokenOnce will re-promote to Direct if Backend is still
+        // failing on the new network.
+        authPath = AuthPath.Backend
+        // Drop any legacy auth_path bundle entry so it never resurrects.
+        savedStateHandle.remove<String>(KEY_AUTH_PATH)
         logger.debug("Restored auth session on path=$authPath")
 
         val startUi =

--- a/feature/auth/presentation/src/commonMain/kotlin/zed/rainxch/auth/presentation/AuthenticationViewModel.kt
+++ b/feature/auth/presentation/src/commonMain/kotlin/zed/rainxch/auth/presentation/AuthenticationViewModel.kt
@@ -345,7 +345,7 @@ class AuthenticationViewModel(
                         )
                     }
 
-                    saveToSavedState(start.deviceCode, startUi)
+                    saveToSavedState(start.deviceCode, startUi, authPath)
                     startCountdown(start.expiresInSec)
                     startPolling(start.deviceCode)
 
@@ -422,14 +422,28 @@ class AuthenticationViewModel(
                 }
 
             if (outcome.path != authPath) {
-                logger.debug("Auth path escalated from $authPath to ${outcome.path}")
-                authPath = outcome.path
-                // Intentionally not persisted: escalation is a reaction to the
-                // current network's reachability and shouldn't carry across a
-                // process restart. A user whose Backend hiccupped once and got
-                // bumped to Direct shouldn't be stuck on Direct forever — esp.
-                // on networks where github.com is the unreachable side. Next
-                // process start re-evaluates from Backend.
+                // Mid-session transitions are strictly one-way: only the
+                // Backend → Direct escalation that AuthenticationRepositoryImpl
+                // performs on infrastructure errors (timeouts, connect/socket
+                // failures, 5xx) is legitimate. Direct → Backend is not a path
+                // the repository ever returns; treat any such outcome as a
+                // defensive no-op rather than silently flipping back to a
+                // probably-broken Backend mid-flow. The infrastructure-failure
+                // gate itself lives at the repository (single source of
+                // truth — see `pollDeviceTokenOnce` and
+                // `Throwable.isAuthInfrastructureError()`); the VM only
+                // enforces direction.
+                val isLegalEscalation =
+                    authPath == AuthPath.Backend && outcome.path == AuthPath.Direct
+                if (isLegalEscalation) {
+                    logger.debug("Auth path escalated from $authPath to ${outcome.path}")
+                    authPath = outcome.path
+                    savedStateHandle[KEY_AUTH_PATH] = authPath.name
+                } else {
+                    logger.warn(
+                        "Refusing invalid auth path transition $authPath → ${outcome.path}",
+                    )
+                }
             }
 
             when (val result = outcome.result) {
@@ -502,6 +516,7 @@ class AuthenticationViewModel(
     private fun saveToSavedState(
         deviceCode: String,
         startUi: GithubDeviceStartUi,
+        path: AuthPath,
     ) {
         savedStateHandle[KEY_DEVICE_CODE] = deviceCode
         savedStateHandle[KEY_USER_CODE] = startUi.userCode
@@ -510,6 +525,7 @@ class AuthenticationViewModel(
         savedStateHandle[KEY_INTERVAL_SEC] = startUi.intervalSec
         savedStateHandle[KEY_EXPIRES_IN_SEC] = startUi.expiresInSec
         savedStateHandle[KEY_START_TIME_MILLIS] = System.currentTimeMillis()
+        savedStateHandle[KEY_AUTH_PATH] = path.name
     }
 
     private fun clearSavedState() {
@@ -523,6 +539,13 @@ class AuthenticationViewModel(
         val expiresInSec = savedStateHandle.get<Int>(KEY_EXPIRES_IN_SEC) ?: return
         val intervalSec = savedStateHandle.get<Int>(KEY_INTERVAL_SEC) ?: 5
         val startTimeMillis = savedStateHandle.get<Long>(KEY_START_TIME_MILLIS) ?: return
+        val restoredPath =
+            savedStateHandle.get<String>(KEY_AUTH_PATH)?.let {
+                runCatching { AuthPath.valueOf(it) }.getOrNull()
+            } ?: run {
+                clearSavedState()
+                return
+            }
 
         val elapsedSec = ((System.currentTimeMillis() - startTimeMillis) / 1000).toInt()
         val remainingSec = expiresInSec - elapsedSec
@@ -532,15 +555,7 @@ class AuthenticationViewModel(
             return
         }
 
-        // Always restart on Backend. A prior Direct escalation reflected the
-        // network at the time it happened; on a fresh process the network may
-        // be different (e.g., user switched away from a hostile WiFi, or back
-        // to one where github.com is filtered). The escalation logic in
-        // pollDeviceTokenOnce will re-promote to Direct if Backend is still
-        // failing on the new network.
-        authPath = AuthPath.Backend
-        // Drop any legacy auth_path bundle entry so it never resurrects.
-        savedStateHandle.remove<String>(KEY_AUTH_PATH)
+        authPath = restoredPath
         logger.debug("Restored auth session on path=$authPath")
 
         val startUi =


### PR DESCRIPTION
## Symptom

User hits the rate-limit prompt → taps "Sign in with GitHub" → gets a device code → enters it on github.com → reopens the app and:

1. **DNS error**: `Unable to resolve host "github.com": No address associated with hostname` — even though the backend proxy at `/v1/auth/device/poll` is reachable. Polling never recovers.
2. **Rate-limit dialog re-emits over the auth screen** — the same prompt the user already accepted keeps interrupting the flow.

## Root cause

**(1)** `AuthenticationViewModel` persists `auth_path` (`Backend` / `Direct`) into `SavedStateHandle` and restores it on process restart. The escalation `Backend → Direct` is correctly one-way *within a session*, but `SavedStateHandle` survives process death too — so a user whose Backend hiccupped once gets stuck on `Direct` permanently across reopens. On networks where `github.com` is the unreachable side (the entire reason the backend proxy exists), this means polling keeps hitting `https://github.com/login/oauth/access_token` and dying with DNS errors.

**(2)** `RateLimitDialog` is rendered at the App composable root in `Main.kt`, with no awareness of the current screen. Any background API call (e.g., installed-apps sync) that hits 403 + exhausted rate-limit headers re-flips `showRateLimitDialog` to `true` — even while the user is mid-device-flow on the auth screen.

## Fix

**Auth path** (`AuthenticationViewModel`):
- Stop persisting `KEY_AUTH_PATH` to `SavedStateHandle` on initial save and on mid-session escalation.
- On `restoreFromSavedState`, always reset `authPath` to `Backend` and remove any legacy bundle entry. The repository's existing escalation logic re-promotes to `Direct` on the next poll if Backend is genuinely unreachable on the new network.
- Net effect: process restart re-evaluates the network rather than carrying forward a stale escalation. Within a single session, behavior is unchanged (the in-memory `var` survives config change because the ViewModel does).

**Rate-limit dialog** (`Main.kt`):
- Gate the dialog render with `currentScreen !is GithubStoreGraph.AuthenticationScreen` so it can never overlay the auth screen.
- Add a `LaunchedEffect` that auto-dismisses the flag when the user is on the auth screen and the flag flips back on, so the dialog doesn't ghost back when the user returns to home after signing in.

## Test plan

- [ ] On a network where `github.com` is filtered/throttled but the backend is reachable: trigger the rate-limit prompt, sign in, enter the code, kill the app, reopen. Expect: polling resumes via Backend, login completes. Before the fix: DNS error.
- [ ] Trigger the rate-limit dialog from home → tap "Sign in" → on the auth screen, force any background API call to 403 (or just wait — the symptom reproduces against the live backend rate limits). Expect: dialog stays hidden. Before the fix: it re-overlays the auth screen.
- [ ] Complete a successful sign-in and navigate back to home: dialog does not flash on entry. Before the fix: the latent flag from a background 403 made it ghost-appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the rate-limit dialog from appearing while on the authentication screen, reducing UI interruptions during sign-in.
  * Improved authentication stability by preventing unexpected mid-session route changes—transitions are now restricted to a safe, one-directional upgrade path to avoid inconsistent auth states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->