### PR TITLE
Add VersionMath.isSameVersion for prefix-tolerant equality checks

### DIFF
--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/VersionMath.kt
@@ -96,6 +96,20 @@ object VersionMath {
         return compareNormalized(normA, normB)
     }
 
+    /**
+     * Returns `true` when both inputs normalize to the same version.
+     * Tolerates prefix/format drift the GitHub feed routinely produces
+     * (e.g. release tag `v3.1.3` vs system-reported `3.1.3`,
+     * `release-1.2.0` vs `1.2.0`, `1.2.3+sha.abcd` vs `1.2.3`).
+     *
+     * Two empty/null/blank inputs are treated as equal — this is fine
+     * for the UI-text guards that use this (don't render a redundant
+     * "installed: …" subtext when there's nothing meaningful to show).
+     * Callers that need a stricter "both present and equal" check
+     * should compare [normalizeVersion] against `""` first.
+     */
+    fun isSameVersion(a: String?, b: String?): Boolean = compareVersions(a, b) == 0
+
     private fun compareNormalized(a: String, b: String): Int {
         if (a == b) return 0
         val parsedA = parseSemanticVersion(a)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -7,6 +7,7 @@ import zed.rainxch.core.domain.model.GithubUserProfile
 import zed.rainxch.core.domain.model.InstalledApp
 import zed.rainxch.core.domain.model.SystemArchitecture
 import zed.rainxch.core.domain.model.isEffectivelyPreRelease
+import zed.rainxch.core.domain.util.VersionMath
 import zed.rainxch.details.domain.model.ReleaseCategory
 import zed.rainxch.details.domain.model.RepoStats
 import zed.rainxch.details.presentation.model.AttestationStatus
@@ -139,12 +140,13 @@ data class DetailsState(
             val stable = latestStableRelease ?: return false
             if (!latestStableHasInstallableAsset) return false
             val installedIsPreRelease =
-                allReleases.firstOrNull { it.tagName == app.installedVersion }
+                allReleases.firstOrNull { VersionMath.isSameVersion(it.tagName, app.installedVersion) }
                     ?.isEffectivelyPreRelease() == true
             if (!installedIsPreRelease) return false
             // Don't offer the button if the stable release IS the
-            // one the user has already (same tag string).
-            return stable.tagName != app.installedVersion
+            // one the user has already (same version, ignoring tag-prefix
+            // drift like "v" vs "" or "release-" vs "").
+            return !VersionMath.isSameVersion(stable.tagName, app.installedVersion)
         }
 
     /**

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
@@ -46,6 +46,7 @@ import zed.rainxch.core.domain.model.GithubRelease
 import zed.rainxch.core.domain.model.GithubRepoSummary
 import zed.rainxch.core.domain.model.GithubUserProfile
 import zed.rainxch.core.domain.model.InstalledApp
+import zed.rainxch.core.domain.util.VersionMath
 import zed.rainxch.core.presentation.components.ForkBadge
 import zed.rainxch.core.presentation.components.PlatformChip
 import zed.rainxch.core.presentation.utils.formatReleasedAt
@@ -207,7 +208,9 @@ fun AppHeader(
                         )
                     }
 
-                    if (installedApp != null && installedApp.installedVersion != release?.tagName) {
+                    if (installedApp != null &&
+                        !VersionMath.isSameVersion(installedApp.installedVersion, release?.tagName)
+                    ) {
                         Text(
                             text =
                                 stringResource(

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -96,9 +96,9 @@ fun SmartInstallButton(
 
     val isSameVersionInstalled =
         isInstalled &&
-            normalizeVersion(installedApp.installedVersion) ==
-            normalizeVersion(
-                state.selectedRelease?.tagName ?: "",
+            VersionMath.isSameVersion(
+                installedApp.installedVersion,
+                state.selectedRelease?.tagName,
             )
 
     val enabled =
@@ -648,8 +648,6 @@ private fun AttestationBadge(attestationStatus: AttestationStatus) {
         }
     }
 }
-
-private fun normalizeVersion(version: String): String = version.removePrefix("v").removePrefix("V").trim()
 
 private fun formatFileSize(bytes: Long): String =
     when {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -48,6 +48,7 @@ import io.github.fletchmckee.liquid.rememberLiquidState
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.domain.model.GithubAsset
 import zed.rainxch.core.domain.model.GithubUser
+import zed.rainxch.core.domain.util.VersionMath
 import zed.rainxch.details.presentation.DetailsAction
 import zed.rainxch.details.presentation.DetailsState
 import zed.rainxch.details.presentation.model.AttestationStatus
@@ -253,7 +254,11 @@ fun SmartInstallButton(
                 )
             }
 
-            isInstalled && installedApp.installedVersion != state.selectedRelease?.tagName -> {
+            isInstalled &&
+                !VersionMath.isSameVersion(
+                    installedApp.installedVersion,
+                    state.selectedRelease?.tagName,
+                ) -> {
                 stringResource(
                     Res.string.install_version,
                     state.selectedRelease?.tagName ?: "",

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -94,12 +94,22 @@ fun SmartInstallButton(
     val isUpdateAvailable =
         installedApp?.isUpdateAvailable == true && !installedApp.isPendingInstall
 
+    // VersionMath.isSameVersion treats two blank inputs as equal (both
+    // normalize to ""), which would otherwise drive the CTA to "Open" or
+    // skip the "Install version X" branch when we actually have no version
+    // info. Require both sides to be present and non-blank before letting
+    // the equality check influence the CTA, and reuse the trimmed
+    // selected tag downstream so it can never render as an empty string.
+    val normInstalled =
+        installedApp?.installedVersion?.trim()?.takeIf { it.isNotBlank() }
+    val normSelected =
+        state.selectedRelease?.tagName?.trim()?.takeIf { it.isNotBlank() }
+
     val isSameVersionInstalled =
         isInstalled &&
-            VersionMath.isSameVersion(
-                installedApp.installedVersion,
-                state.selectedRelease?.tagName,
-            )
+            normInstalled != null &&
+            normSelected != null &&
+            VersionMath.isSameVersion(normInstalled, normSelected)
 
     val enabled =
         remember(primaryAsset, isDownloading, isInstalling) {
@@ -255,14 +265,10 @@ fun SmartInstallButton(
             }
 
             isInstalled &&
-                !VersionMath.isSameVersion(
-                    installedApp.installedVersion,
-                    state.selectedRelease?.tagName,
-                ) -> {
-                stringResource(
-                    Res.string.install_version,
-                    state.selectedRelease?.tagName ?: "",
-                )
+                normInstalled != null &&
+                normSelected != null &&
+                !VersionMath.isSameVersion(normInstalled, normSelected) -> {
+                stringResource(Res.string.install_version, normSelected)
             }
 
             else -> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a semantic version equality helper to recognize equivalent versions despite formatting differences (prefixes, build metadata, blank/null).

* **Bug Fixes**
  * Install/update button visibility, installed-version labels, and rollback availability now correctly reflect version equivalence, avoiding false differences due to tag formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->