### PR TITLE
Update InstallPolicy logic in DetailsViewModel

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -1489,11 +1489,11 @@ class DetailsViewModel(
                         } catch (e: Exception) {
                             InstallerType.DEFAULT
                         }
-
                     val policy =
-                        when (installerType) {
-                            InstallerType.SHIZUKU -> InstallPolicy.AlwaysInstall
-                            InstallerType.DEFAULT -> InstallPolicy.InstallWhileForeground
+                        when {
+                            platform != Platform.ANDROID -> InstallPolicy.AlwaysInstall
+                            installerType == InstallerType.SHIZUKU -> InstallPolicy.AlwaysInstall
+                            else -> InstallPolicy.InstallWhileForeground
                         }
 
                     downloadOrchestrator.enqueue(


### PR DESCRIPTION
Adjusts the `InstallPolicy` selection logic to prioritize `InstallPolicy.AlwaysInstall` for non-Android platforms and the Shizuku installer. Other Android installation types continue to use `InstallPolicy.InstallWhileForeground`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected installation behavior across platforms by refining how installation policies are determined based on device type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->