### PR TITLE
Add localization for E1, E5, and E10 features across 12 locales

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -803,7 +803,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">تم تخطي %1$d — يمكنك إعادة تشغيل الفحص من الإعدادات.</string>
     <string name="external_import_completion_action_view_all">عرض الكل</string>
-    <string name="external_import_empty_all_matched">تمت مطابقة الكل.\\nلا يوجد شيء للربط.</string>
+    <string name="external_import_empty_all_matched">تمت مطابقة الكل.\nلا يوجد شيء للربط.</string>
     <string name="external_import_empty_done">تم</string>
     <string name="external_import_empty_no_apps_title">لم نتمكن من العثور على أي تطبيقات GitHub على هذا الجهاز.</string>
     <string name="external_import_empty_no_apps_body">هذا يعني إما أن كل شيء تم تثبيته عبر متجر مختلف، أو أننا لا نملك صلاحية رؤية ما هو مثبّت.</string>
@@ -811,7 +811,7 @@
     <string name="external_import_empty_ok">حسناً</string>
     <string name="external_import_empty_add_manually">إضافة تطبيق من متجر آخر</string>
     <string name="external_import_permission_title">ابحث عن تطبيقات GitHub الخاصة بك</string>
-    <string name="external_import_permission_body">يمكننا فحص تطبيقاتك المثبّتة ومطابقتها مع إصدارات GitHub — حتى تعمل التحديثات والكشف تلقائياً.\\n\\nللقيام بذلك، نحتاج إلى معرفة التطبيقات التي لديك. بدون الإذن يمكننا رؤية نحو 5 تطبيقات فقط؛ معه يمكننا رؤية جميعها.\\n\\nنحن لا نرسل قائمة تطبيقاتك إلى أي مكان دون إذنك. تعمل المطابقة على جهازك. البحث الاختياري في الخادم يرسل فقط اسم الحزمة وتسمية التطبيق، وعند توفرها بصمة التوقيع ومصدر التثبيت وأي تلميح لمستودع GitHub مُعلَن في بيان التطبيق — وليس قائمة كاملة بما هو مثبّت.</string>
+    <string name="external_import_permission_body">يمكننا فحص تطبيقاتك المثبّتة ومطابقتها مع إصدارات GitHub — حتى تعمل التحديثات والكشف تلقائياً.\n\nللقيام بذلك، نحتاج إلى معرفة التطبيقات التي لديك. بدون الإذن يمكننا رؤية نحو 5 تطبيقات فقط؛ معه يمكننا رؤية جميعها.\n\nنحن لا نرسل قائمة تطبيقاتك إلى أي مكان دون إذنك. تعمل المطابقة على جهازك. البحث الاختياري في الخادم يرسل فقط اسم الحزمة وتسمية التطبيق، وعند توفرها بصمة التوقيع ومصدر التثبيت وأي تلميح لمستودع GitHub مُعلَن في بيان التطبيق — وليس قائمة كاملة بما هو مثبّت.</string>
     <string name="external_import_permission_continue">متابعة</string>
     <string name="external_import_permission_not_now">ليس الآن</string>
     <plurals name="external_import_proposal_banner_headline">
@@ -922,7 +922,7 @@
     <string name="mirror_section_community">مجتمع</string>
     <string name="mirror_status_ok">%1$dms</string>
     <string name="mirror_status_degraded">%1$dms</string>
-    <string name="mirror_status_down">(down)</string>
+    <string name="mirror_status_down">(متوقف)</string>
     <string name="mirror_status_unknown">?</string>
     <string name="mirror_custom_label">مرآة مخصصة…</string>
     <string name="mirror_custom_dialog_title">مرآة مخصصة</string>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -748,4 +748,202 @@
     <string name="pat_error_bad_credentials">هذا الرمز غير صالح أو تم إلغاؤه.</string>
     <string name="pat_error_insufficient_scope">هذا الرمز لا يمتلك الصلاحيات المطلوبة.</string>
     <string name="pat_error_generic">تعذّر حفظ الرمز. يرجى المحاولة مرة أخرى.</string>
+
+    <!-- E10 — Apps sort -->
+    <string name="sort_apps">ترتيب التطبيقات</string>
+    <string name="sort_updates_first">التحديثات أولاً</string>
+
+    <!-- Pre-release channel UX -->
+    <string name="channel_chip_include_betas">تضمين الإصدارات التجريبية</string>
+    <string name="channel_chip_stable_only">الإصدار المستقر فقط</string>
+    <string name="channel_toggle_cd">تبديل الإصدارات التجريبية لهذا التطبيق</string>
+    <string name="action_switch_to_stable">التبديل إلى الإصدار المستقر %1$s</string>
+    <string name="stalled_project_warning_months">لا يوجد إصدار مستقر منذ %1$d أشهر</string>
+    <string name="stalled_project_warning_days">لا يوجد إصدار مستقر منذ %1$d أيام</string>
+    <string name="stalled_project_warning_description">إصدارات تجريبية نشطة لكن المشروع لم يُصدر بناءً مستقراً منذ فترة. قد لا تتقارب الإصدارات التجريبية إلى إصدار مستقر.</string>
+    <string name="merged_whats_changed_title">ما الذي تغيّر منذ %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- E1 — External import wizard -->
+    <string name="external_import_top_bar_title">استيراد التطبيقات المثبّتة</string>
+    <string name="external_import_top_bar_back">رجوع</string>
+    <string name="external_import_overflow_more">خيارات أخرى</string>
+    <string name="external_import_overflow_skip_remaining">تخطي الباقي</string>
+    <string name="external_import_progress_scanning">جارٍ فحص تطبيقاتك…</string>
+    <string name="external_import_progress_auto_importing">جارٍ استيراد التطابقات…</string>
+    <string name="external_import_progress_working">جارٍ العمل…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="zero">لم نفحص أي تطبيق</item>
+        <item quantity="one">فحصنا تطبيقاً واحداً</item>
+        <item quantity="two">فحصنا تطبيقين</item>
+        <item quantity="few">فحصنا %1$d تطبيقات</item>
+        <item quantity="many">فحصنا %1$d تطبيقاً</item>
+        <item quantity="other">فحصنا %1$d تطبيق</item>
+    </plurals>
+    <string name="external_import_card_action_skip">تخطي</string>
+    <string name="external_import_card_action_link">ربط</string>
+    <string name="external_import_card_action_more">المزيد من التطابقات</string>
+    <string name="external_import_card_action_less">إخفاء التطابقات</string>
+    <string name="external_import_card_installer_chip">مثبّت عبر %1$s</string>
+    <string name="external_import_card_preselect_known">نعتقد أن هذا هو %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">اضغط للبحث عن مستودع</string>
+    <string name="external_import_card_expand_label">توسيع لرؤية تطابقات أخرى</string>
+    <string name="external_import_card_collapse_label">طي البطاقة</string>
+    <string name="external_import_search_icon_label">البحث في GitHub</string>
+    <string name="external_import_search_empty">لا توجد تطابقات</string>
+    <string name="external_import_search_error_default">فشل البحث</string>
+    <string name="external_import_search_placeholder_url">الصق رابط github.com أو ابحث…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="zero">لا يوجد تطبيق يتم تتبعه الآن.</item>
+        <item quantity="one">يتم تتبع تطبيق واحد الآن.</item>
+        <item quantity="two">يتم تتبع تطبيقين الآن.</item>
+        <item quantity="few">يتم تتبع %1$d تطبيقات الآن.</item>
+        <item quantity="many">يتم تتبع %1$d تطبيقاً الآن.</item>
+        <item quantity="other">يتم تتبع %1$d تطبيق الآن.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">تم تخطي %1$d — يمكنك إعادة تشغيل الفحص من الإعدادات.</string>
+    <string name="external_import_completion_action_view_all">عرض الكل</string>
+    <string name="external_import_empty_all_matched">تمت مطابقة الكل.\\nلا يوجد شيء للربط.</string>
+    <string name="external_import_empty_done">تم</string>
+    <string name="external_import_empty_no_apps_title">لم نتمكن من العثور على أي تطبيقات GitHub على هذا الجهاز.</string>
+    <string name="external_import_empty_no_apps_body">هذا يعني إما أن كل شيء تم تثبيته عبر متجر مختلف، أو أننا لا نملك صلاحية رؤية ما هو مثبّت.</string>
+    <string name="external_import_empty_grant_permission">منح الإذن</string>
+    <string name="external_import_empty_ok">حسناً</string>
+    <string name="external_import_empty_add_manually">إضافة تطبيق من متجر آخر</string>
+    <string name="external_import_permission_title">ابحث عن تطبيقات GitHub الخاصة بك</string>
+    <string name="external_import_permission_body">يمكننا فحص تطبيقاتك المثبّتة ومطابقتها مع إصدارات GitHub — حتى تعمل التحديثات والكشف تلقائياً.\\n\\nللقيام بذلك، نحتاج إلى معرفة التطبيقات التي لديك. بدون الإذن يمكننا رؤية نحو 5 تطبيقات فقط؛ معه يمكننا رؤية جميعها.\\n\\nنحن لا نرسل قائمة تطبيقاتك إلى أي مكان دون إذنك. تعمل المطابقة على جهازك. البحث الاختياري في الخادم يرسل فقط اسم الحزمة وتسمية التطبيق، وعند توفرها بصمة التوقيع ومصدر التثبيت وأي تلميح لمستودع GitHub مُعلَن في بيان التطبيق — وليس قائمة كاملة بما هو مثبّت.</string>
+    <string name="external_import_permission_continue">متابعة</string>
+    <string name="external_import_permission_not_now">ليس الآن</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="zero">لم نجد أي تطبيق من GitHub</item>
+        <item quantity="one">وجدنا تطبيقاً واحداً من GitHub</item>
+        <item quantity="two">وجدنا تطبيقين من GitHub</item>
+        <item quantity="few">وجدنا %1$d تطبيقات من GitHub</item>
+        <item quantity="many">وجدنا %1$d تطبيقاً من GitHub</item>
+        <item quantity="other">وجدنا %1$d تطبيق من GitHub</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">راجعها لتتبع التحديثات هنا.</string>
+    <string name="external_import_proposal_banner_review">مراجعة</string>
+    <string name="external_import_proposal_banner_dismiss">تجاهل</string>
+    <string name="external_import_match_confidence_a11y">درجة ثقة التطابق: %1$d بالمئة</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">تعذّر ربط هذا التطبيق — حاول مجدداً.</string>
+    <string name="external_import_error_link_network">تعذّر الوصول إلى GitHub. حاول مجدداً لاحقاً.</string>
+    <string name="external_import_error_scan_failed_default">فشل الفحص</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">المتصفح</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">مصدر غير معروف</string>
+    <string name="external_import_undo_linked">تم ربط %1$s.</string>
+    <string name="external_import_undo_skipped">تم تخطي %1$s.</string>
+    <string name="external_import_undo_action">تراجع</string>
+    <string name="external_import_undo_failed">تعذّر التراجع — حاول مجدداً.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="zero">لا يوجد تطبيق للمراجعة</item>
+        <item quantity="one">تطبيق واحد للمراجعة</item>
+        <item quantity="two">تطبيقان للمراجعة</item>
+        <item quantity="few">%1$d تطبيقات للمراجعة</item>
+        <item quantity="many">%1$d تطبيقاً للمراجعة</item>
+        <item quantity="other">%1$d تطبيق للمراجعة</item>
+    </plurals>
+    <string name="external_import_list_add_manually">لا ترى تطبيقك؟ أضفه يدوياً</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="zero">لم يتم ربط أي تطبيق تلقائياً</item>
+        <item quantity="one">تم ربط تطبيق واحد تلقائياً</item>
+        <item quantity="two">تم ربط تطبيقين تلقائياً</item>
+        <item quantity="few">تم ربط %1$d تطبيقات تلقائياً</item>
+        <item quantity="many">تم ربط %1$d تطبيقاً تلقائياً</item>
+        <item quantity="other">تم ربط %1$d تطبيق تلقائياً</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">لقد تعرّفنا عليها بثقة عالية. يمكنك التراجع عن تطابقات فردية من تفاصيل كل تطبيق، أو التراجع عن الكل الآن.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="zero">لا يوجد المزيد يحتاج إلى مدخلاتك.</item>
+        <item quantity="one">يحتاج %1$d آخر إلى مدخلاتك.</item>
+        <item quantity="two">يحتاج %1$d آخران إلى مدخلاتك.</item>
+        <item quantity="few">تحتاج %1$d أخرى إلى مدخلاتك.</item>
+        <item quantity="many">يحتاج %1$d آخر إلى مدخلاتك.</item>
+        <item quantity="other">يحتاج %1$d إلى مدخلاتك.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">متابعة</string>
+    <string name="external_import_auto_summary_undo_all">التراجع عن الكل</string>
+    <string name="external_import_auto_summary_more_count">+%1$d أخرى</string>
+    <string name="external_import_rescan_menu">فحص تطبيقات GitHub</string>
+
+    <!-- E1 — Details unlink dialog -->
+    <string name="details_unlink_external_app_menu">إلغاء الربط بهذا المستودع</string>
+    <string name="details_unlink_external_app_more_options">المزيد من الخيارات</string>
+    <string name="details_unlink_external_app_dialog_title">إلغاء ربط هذا التطبيق؟</string>
+    <string name="details_unlink_external_app_dialog_body">سنتوقف عن تتبع %1$s كمثبّت من هذا المستودع. يبقى التطبيق على جهازك — يُزال الرابط فقط.</string>
+    <string name="details_unlink_external_app_dialog_confirm">إلغاء الربط</string>
+    <string name="details_unlink_external_app_success">تم إلغاء الربط. سنقترح تطابقاً مجدداً في الفحص التالي.</string>
+    <string name="details_unlink_external_app_failure">تعذّر إلغاء الربط — حاول مجدداً.</string>
+
+    <!-- Feedback feature -->
+    <string name="feedback_send">إرسال ملاحظات</string>
+    <string name="feedback_title">إرسال ملاحظات</string>
+    <string name="feedback_close">إغلاق</string>
+    <string name="feedback_category_label">الفئة</string>
+    <string name="feedback_category_bug">خطأ</string>
+    <string name="feedback_category_feature">طلب ميزة</string>
+    <string name="feedback_category_change">طلب تغيير</string>
+    <string name="feedback_category_other">أخرى</string>
+    <string name="feedback_topic_label">الموضوع</string>
+    <string name="feedback_topic_install_update">التثبيت / التحديث</string>
+    <string name="feedback_topic_search">البحث &amp; الاكتشاف</string>
+    <string name="feedback_topic_details">تفاصيل المستودع</string>
+    <string name="feedback_topic_auth">المصادقة &amp; الحساب</string>
+    <string name="feedback_topic_ui">واجهة / تجربة المستخدم</string>
+    <string name="feedback_topic_translation">الترجمة / اللغة</string>
+    <string name="feedback_topic_performance">الأداء</string>
+    <string name="feedback_topic_other">أخرى</string>
+    <string name="feedback_field_title">العنوان</string>
+    <string name="feedback_field_description">الوصف</string>
+    <string name="feedback_field_steps">خطوات إعادة الإنتاج</string>
+    <string name="feedback_field_expected_actual">المتوقع مقابل الفعلي</string>
+    <string name="feedback_field_use_case">حالة الاستخدام</string>
+    <string name="feedback_field_proposed_solution">الحل المقترح</string>
+    <string name="feedback_field_current_behaviour">السلوك الحالي</string>
+    <string name="feedback_field_desired_behaviour">السلوك المطلوب</string>
+    <string name="feedback_diagnostics_header">التشخيصات</string>
+    <string name="feedback_diagnostics_include">تضمين التشخيصات</string>
+    <string name="feedback_send_via_email">إرسال بريد إلكتروني</string>
+    <string name="feedback_send_via_github">فتح كمشكلة GitHub</string>
+    <string name="feedback_send_success_email">شكراً — جارٍ فتح عميل البريد.</string>
+    <string name="feedback_send_success_github">شكراً — جارٍ فتح المتصفح.</string>
+    <string name="feedback_send_error">تعذّر فتح قناة الملاحظات: %1$s</string>
+
+    <!-- E5 — Mirror feature -->
+    <string name="mirror_tweaks_entry_label">مرآة التنزيل</string>
+    <string name="mirror_picker_title">مرآة التنزيل</string>
+    <string name="mirror_picker_description">تُستخدم لتنزيل أصول الإصدار. تتجه مكالمات GitHub API دائماً مباشرة. يجب على معظم المستخدمين إبقاء هذا على GitHub المباشر.</string>
+    <string name="mirror_section_official">رسمي</string>
+    <string name="mirror_section_community">مجتمع</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(down)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">مرآة مخصصة…</string>
+    <string name="mirror_custom_dialog_title">مرآة مخصصة</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">يجب أن يبدأ القالب بـ https://</string>
+    <string name="mirror_custom_validation_template">يجب أن يحتوي القالب على {url} مرة واحدة بالضبط</string>
+    <string name="mirror_custom_save">حفظ</string>
+    <string name="mirror_test_button">اختبار المحدد</string>
+    <string name="mirror_test_in_progress">جارٍ الاختبار…</string>
+    <string name="mirror_test_success">تم الوصول في %1$dms</string>
+    <string name="mirror_test_http_error">أرجعت المرآة %1$d</string>
+    <string name="mirror_test_timeout">انتهت المهلة بعد 5 ثوانٍ</string>
+    <string name="mirror_test_dns_fail">تعذّر حل اسم المضيف</string>
+    <string name="mirror_test_other">فشل: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">كل المرايا معطّلة؟ يمكنك استضافة مرآتك الخاصة في 5 دقائق — راجع الوثائق.</string>
+    <string name="mirror_removed_toast">%1$s لم يعد متاحاً، تم التبديل إلى GitHub المباشر.</string>
+    <string name="mirror_digest_mismatch_error">عدم تطابق المجموع الاختباري — قد يكون الملف قد تم التلاعب به</string>
+    <string name="mirror_auto_suggest_title">هل تجرب مرآة أسرع؟</string>
+    <string name="mirror_auto_suggest_body">يُفضّل بعض المستخدمين على الشبكات البطيئة استخدام وكيل مجتمعي.</string>
+    <string name="mirror_auto_suggest_pick_one">اختر واحدة</string>
+    <string name="mirror_auto_suggest_maybe_later">ربما لاحقاً</string>
+    <string name="mirror_auto_suggest_dont_ask_again">لا تسأل مجدداً</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -785,7 +785,7 @@
     <string name="external_import_card_action_more">المزيد من التطابقات</string>
     <string name="external_import_card_action_less">إخفاء التطابقات</string>
     <string name="external_import_card_installer_chip">مثبّت عبر %1$s</string>
-    <string name="external_import_card_preselect_known">نعتقد أن هذا هو %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">نعتقد أن هذا هو %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">اضغط للبحث عن مستودع</string>
     <string name="external_import_card_expand_label">توسيع لرؤية تطابقات أخرى</string>
     <string name="external_import_card_collapse_label">طي البطاقة</string>
@@ -826,7 +826,7 @@
     <string name="external_import_proposal_banner_review">مراجعة</string>
     <string name="external_import_proposal_banner_dismiss">تجاهل</string>
     <string name="external_import_match_confidence_a11y">درجة ثقة التطابق: %1$d بالمئة</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">تعذّر ربط هذا التطبيق — حاول مجدداً.</string>
     <string name="external_import_error_link_network">تعذّر الوصول إلى GitHub. حاول مجدداً لاحقاً.</string>
     <string name="external_import_error_scan_failed_default">فشل الفحص</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -795,7 +795,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d টি বাদ দেওয়া হয়েছে — সেটিংস থেকে আবার স্ক্যান করতে পারবেন।</string>
     <string name="external_import_completion_action_view_all">সব দেখুন</string>
-    <string name="external_import_empty_all_matched">সব মিলেছে।\\nলিঙ্ক করার কিছু নেই।</string>
+    <string name="external_import_empty_all_matched">সব মিলেছে।\nলিঙ্ক করার কিছু নেই।</string>
     <string name="external_import_empty_done">সম্পন্ন</string>
     <string name="external_import_empty_no_apps_title">এই ডিভাইসে কোনো GitHub অ্যাপ খুঁজে পাওয়া যায়নি।</string>
     <string name="external_import_empty_no_apps_body">এর মানে হয় সবকিছু অন্য স্টোর থেকে ইনস্টল করা হয়েছে, অথবা কী ইনস্টল আছে তা আমরা দেখতে পাচ্ছি না।</string>
@@ -803,7 +803,7 @@
     <string name="external_import_empty_ok">ঠিক আছে</string>
     <string name="external_import_empty_add_manually">অন্য স্টোর থেকে অ্যাপ যোগ করুন</string>
     <string name="external_import_permission_title">আপনার GitHub অ্যাপ খুঁজুন</string>
-    <string name="external_import_permission_body">আমরা আপনার ইনস্টল করা অ্যাপ স্ক্যান করে GitHub রিলিজের সাথে মিলাতে পারি — যাতে আপডেট ও শনাক্তকরণ স্বয়ংক্রিয়ভাবে কাজ করে।\\n\\nএর জন্য আপনার কাছে কোন অ্যাপ আছে তা জানতে হবে। অনুমতি ছাড়া আমরা প্রায় ৫টি অ্যাপ দেখতে পারি; অনুমতি দিলে সব দেখতে পারব।\\n\\nআপনার অনুমতি ছাড়া আমরা আপনার অ্যাপের তালিকা কোথাও পাঠাই না। মিলানো আপনার ডিভাইসে হয়। ঐচ্ছিক ব্যাকএন্ড লুকআপ শুধু প্যাকেজের নাম ও অ্যাপ লেবেল পাঠায়, এবং পাওয়া গেলে সাইনিং ফিঙ্গারপ্রিন্ট, ইনস্টল সোর্স ও অ্যাপের ম্যানিফেস্টে ঘোষিত যেকোনো GitHub-রিপো হিন্ট — কখনো ইনস্টল করা সব অ্যাপের পুরো তালিকা নয়।</string>
+    <string name="external_import_permission_body">আমরা আপনার ইনস্টল করা অ্যাপ স্ক্যান করে GitHub রিলিজের সাথে মিলাতে পারি — যাতে আপডেট ও শনাক্তকরণ স্বয়ংক্রিয়ভাবে কাজ করে।\n\nএর জন্য আপনার কাছে কোন অ্যাপ আছে তা জানতে হবে। অনুমতি ছাড়া আমরা প্রায় ৫টি অ্যাপ দেখতে পারি; অনুমতি দিলে সব দেখতে পারব।\n\nআপনার অনুমতি ছাড়া আমরা আপনার অ্যাপের তালিকা কোথাও পাঠাই না। মিলানো আপনার ডিভাইসে হয়। ঐচ্ছিক ব্যাকএন্ড লুকআপ শুধু প্যাকেজের নাম ও অ্যাপ লেবেল পাঠায়, এবং পাওয়া গেলে সাইনিং ফিঙ্গারপ্রিন্ট, ইনস্টল সোর্স ও অ্যাপের ম্যানিফেস্টে ঘোষিত যেকোনো GitHub-রিপো হিন্ট — কখনো ইনস্টল করা সব অ্যাপের পুরো তালিকা নয়।</string>
     <string name="external_import_permission_continue">চালিয়ে যান</string>
     <string name="external_import_permission_not_now">এখন না</string>
     <plurals name="external_import_proposal_banner_headline">
@@ -898,7 +898,7 @@
     <string name="mirror_section_community">কমিউনিটি</string>
     <string name="mirror_status_ok">%1$dms</string>
     <string name="mirror_status_degraded">%1$dms</string>
-    <string name="mirror_status_down">(down)</string>
+    <string name="mirror_status_down">(বন্ধ)</string>
     <string name="mirror_status_unknown">?</string>
     <string name="mirror_custom_label">কাস্টম মিরর…</string>
     <string name="mirror_custom_dialog_title">কাস্টম মিরর</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -747,4 +747,179 @@
     <string name="pat_error_bad_credentials">এই টোকেনটি অবৈধ অথবা বাতিল করা হয়েছে।</string>
     <string name="pat_error_insufficient_scope">এই টোকেনের প্রয়োজনীয় অনুমতি নেই।</string>
     <string name="pat_error_generic">টোকেন সংরক্ষণ করা যায়নি। আবার চেষ্টা করুন।</string>
+
+
+    <!-- E10 — Apps sort -->
+    <string name="sort_apps">অ্যাপ সাজান</string>
+    <string name="sort_updates_first">আপডেট আগে</string>
+
+    <!-- Pre-release channel UX -->
+    <string name="channel_chip_include_betas">বেটা অন্তর্ভুক্ত করুন</string>
+    <string name="channel_chip_stable_only">শুধুমাত্র স্থিতিশীল</string>
+    <string name="channel_toggle_cd">এই অ্যাপের জন্য বেটা রিলিজ টগল করুন</string>
+    <string name="action_switch_to_stable">স্থিতিশীল %1$s-এ যান</string>
+    <string name="stalled_project_warning_months">%1$d মাসে কোনো স্থিতিশীল রিলিজ নেই</string>
+    <string name="stalled_project_warning_days">%1$d দিনে কোনো স্থিতিশীল রিলিজ নেই</string>
+    <string name="stalled_project_warning_description">সক্রিয় প্রি-রিলিজ রয়েছে কিন্তু প্রকল্পটি কিছুদিন ধরে স্থিতিশীল বিল্ড প্রকাশ করেনি। বেটা স্থিতিশীল রিলিজে পরিণত নাও হতে পারে।</string>
+    <string name="merged_whats_changed_title">%1$s থেকে কী পরিবর্তন হয়েছে</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- E1 — External import wizard -->
+    <string name="external_import_top_bar_title">ইনস্টল করা অ্যাপ আমদানি করুন</string>
+    <string name="external_import_top_bar_back">পিছনে</string>
+    <string name="external_import_overflow_more">আরও বিকল্প</string>
+    <string name="external_import_overflow_skip_remaining">বাকিগুলো বাদ দিন</string>
+    <string name="external_import_progress_scanning">আপনার অ্যাপ স্ক্যান করা হচ্ছে…</string>
+    <string name="external_import_progress_auto_importing">মিল আমদানি করা হচ্ছে…</string>
+    <string name="external_import_progress_working">কাজ চলছে…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">%1$d টি অ্যাপ দেখা হয়েছে</item>
+        <item quantity="other">%1$d টি অ্যাপ দেখা হয়েছে</item>
+    </plurals>
+    <string name="external_import_card_action_skip">বাদ দিন</string>
+    <string name="external_import_card_action_link">লিঙ্ক করুন</string>
+    <string name="external_import_card_action_more">আরও মিল</string>
+    <string name="external_import_card_action_less">মিল লুকান</string>
+    <string name="external_import_card_installer_chip">%1$s দিয়ে ইনস্টল করা</string>
+    <string name="external_import_card_preselect_known">আমরা মনে করি এটি %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">রিপো খুঁজতে ট্যাপ করুন</string>
+    <string name="external_import_card_expand_label">অন্য মিল দেখতে প্রসারিত করুন</string>
+    <string name="external_import_card_collapse_label">কার্ড সংকুচিত করুন</string>
+    <string name="external_import_search_icon_label">GitHub-এ অনুসন্ধান</string>
+    <string name="external_import_search_empty">কোনো মিল নেই</string>
+    <string name="external_import_search_error_default">অনুসন্ধান ব্যর্থ হয়েছে</string>
+    <string name="external_import_search_placeholder_url">github.com URL পেস্ট করুন বা অনুসন্ধান করুন…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">এখন %1$d টি অ্যাপ ট্র্যাক করা হচ্ছে।</item>
+        <item quantity="other">এখন %1$d টি অ্যাপ ট্র্যাক করা হচ্ছে।</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d টি বাদ দেওয়া হয়েছে — সেটিংস থেকে আবার স্ক্যান করতে পারবেন।</string>
+    <string name="external_import_completion_action_view_all">সব দেখুন</string>
+    <string name="external_import_empty_all_matched">সব মিলেছে।\\nলিঙ্ক করার কিছু নেই।</string>
+    <string name="external_import_empty_done">সম্পন্ন</string>
+    <string name="external_import_empty_no_apps_title">এই ডিভাইসে কোনো GitHub অ্যাপ খুঁজে পাওয়া যায়নি।</string>
+    <string name="external_import_empty_no_apps_body">এর মানে হয় সবকিছু অন্য স্টোর থেকে ইনস্টল করা হয়েছে, অথবা কী ইনস্টল আছে তা আমরা দেখতে পাচ্ছি না।</string>
+    <string name="external_import_empty_grant_permission">অনুমতি দিন</string>
+    <string name="external_import_empty_ok">ঠিক আছে</string>
+    <string name="external_import_empty_add_manually">অন্য স্টোর থেকে অ্যাপ যোগ করুন</string>
+    <string name="external_import_permission_title">আপনার GitHub অ্যাপ খুঁজুন</string>
+    <string name="external_import_permission_body">আমরা আপনার ইনস্টল করা অ্যাপ স্ক্যান করে GitHub রিলিজের সাথে মিলাতে পারি — যাতে আপডেট ও শনাক্তকরণ স্বয়ংক্রিয়ভাবে কাজ করে।\\n\\nএর জন্য আপনার কাছে কোন অ্যাপ আছে তা জানতে হবে। অনুমতি ছাড়া আমরা প্রায় ৫টি অ্যাপ দেখতে পারি; অনুমতি দিলে সব দেখতে পারব।\\n\\nআপনার অনুমতি ছাড়া আমরা আপনার অ্যাপের তালিকা কোথাও পাঠাই না। মিলানো আপনার ডিভাইসে হয়। ঐচ্ছিক ব্যাকএন্ড লুকআপ শুধু প্যাকেজের নাম ও অ্যাপ লেবেল পাঠায়, এবং পাওয়া গেলে সাইনিং ফিঙ্গারপ্রিন্ট, ইনস্টল সোর্স ও অ্যাপের ম্যানিফেস্টে ঘোষিত যেকোনো GitHub-রিপো হিন্ট — কখনো ইনস্টল করা সব অ্যাপের পুরো তালিকা নয়।</string>
+    <string name="external_import_permission_continue">চালিয়ে যান</string>
+    <string name="external_import_permission_not_now">এখন না</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">GitHub থেকে %1$d টি অ্যাপ পাওয়া গেছে</item>
+        <item quantity="other">GitHub থেকে %1$d টি অ্যাপ পাওয়া গেছে</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">এখানে আপডেট ট্র্যাক করতে পর্যালোচনা করুন।</string>
+    <string name="external_import_proposal_banner_review">পর্যালোচনা</string>
+    <string name="external_import_proposal_banner_dismiss">খারিজ করুন</string>
+    <string name="external_import_match_confidence_a11y">মিলের আত্মবিশ্বাস: %1$d শতাংশ</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">এই অ্যাপ লিঙ্ক করা যায়নি — আবার চেষ্টা করুন।</string>
+    <string name="external_import_error_link_network">GitHub-এ পৌঁছানো যায়নি। পরে আবার চেষ্টা করুন।</string>
+    <string name="external_import_error_scan_failed_default">স্ক্যান ব্যর্থ হয়েছে</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">ব্রাউজার</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">অজানা উৎস</string>
+    <string name="external_import_undo_linked">%1$s লিঙ্ক করা হয়েছে।</string>
+    <string name="external_import_undo_skipped">%1$s বাদ দেওয়া হয়েছে।</string>
+    <string name="external_import_undo_action">পূর্বাবস্থায় ফেরান</string>
+    <string name="external_import_undo_failed">পূর্বাবস্থায় ফেরানো যায়নি — আবার চেষ্টা করুন।</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">পর্যালোচনার জন্য %1$d টি অ্যাপ</item>
+        <item quantity="other">পর্যালোচনার জন্য %1$d টি অ্যাপ</item>
+    </plurals>
+    <string name="external_import_list_add_manually">আপনার অ্যাপ দেখছেন না? ম্যানুয়ালি যোগ করুন</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">স্বয়ংক্রিয়ভাবে %1$d টি অ্যাপ লিঙ্ক করা হয়েছে</item>
+        <item quantity="other">স্বয়ংক্রিয়ভাবে %1$d টি অ্যাপ লিঙ্ক করা হয়েছে</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">আমরা উচ্চ আত্মবিশ্বাসে এগুলো চিনেছি। প্রতিটি অ্যাপের বিস্তারিত থেকে পৃথক মিল পূর্বাবস্থায় ফেরাতে পারবেন, অথবা এখনই সব পূর্বাবস্থায় ফেরান।</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d টি আরও আপনার ইনপুট প্রয়োজন।</item>
+        <item quantity="other">%1$d টি আরও আপনার ইনপুট প্রয়োজন।</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">চালিয়ে যান</string>
+    <string name="external_import_auto_summary_undo_all">সব পূর্বাবস্থায় ফেরান</string>
+    <string name="external_import_auto_summary_more_count">+%1$d আরও</string>
+    <string name="external_import_rescan_menu">GitHub অ্যাপ স্ক্যান করুন</string>
+
+    <!-- E1 — Details unlink dialog -->
+    <string name="details_unlink_external_app_menu">এই রিপো থেকে আনলিঙ্ক করুন</string>
+    <string name="details_unlink_external_app_more_options">আরও বিকল্প</string>
+    <string name="details_unlink_external_app_dialog_title">এই অ্যাপ আনলিঙ্ক করবেন?</string>
+    <string name="details_unlink_external_app_dialog_body">এই রিপো থেকে ইনস্টল হিসেবে %1$s ট্র্যাক করা বন্ধ করব। অ্যাপটি আপনার ডিভাইসে থাকবে — শুধু লিঙ্ক সরানো হবে।</string>
+    <string name="details_unlink_external_app_dialog_confirm">আনলিঙ্ক করুন</string>
+    <string name="details_unlink_external_app_success">আনলিঙ্ক করা হয়েছে। পরবর্তী স্ক্যানে আবার মিল সাজেস্ট করব।</string>
+    <string name="details_unlink_external_app_failure">আনলিঙ্ক করা যায়নি — আবার চেষ্টা করুন।</string>
+
+    <!-- Feedback feature -->
+    <string name="feedback_send">ফিডব্যাক পাঠান</string>
+    <string name="feedback_title">ফিডব্যাক পাঠান</string>
+    <string name="feedback_close">বন্ধ করুন</string>
+    <string name="feedback_category_label">বিভাগ</string>
+    <string name="feedback_category_bug">বাগ</string>
+    <string name="feedback_category_feature">ফিচার অনুরোধ</string>
+    <string name="feedback_category_change">পরিবর্তন অনুরোধ</string>
+    <string name="feedback_category_other">অন্যান্য</string>
+    <string name="feedback_topic_label">বিষয়</string>
+    <string name="feedback_topic_install_update">ইনস্টল / আপডেট</string>
+    <string name="feedback_topic_search">অনুসন্ধান &amp; আবিষ্কার</string>
+    <string name="feedback_topic_details">রিপো বিবরণ</string>
+    <string name="feedback_topic_auth">অথ &amp; অ্যাকাউন্ট</string>
+    <string name="feedback_topic_ui">UI / UX</string>
+    <string name="feedback_topic_translation">অনুবাদ / ভাষা</string>
+    <string name="feedback_topic_performance">পারফরম্যান্স</string>
+    <string name="feedback_topic_other">অন্যান্য</string>
+    <string name="feedback_field_title">শিরোনাম</string>
+    <string name="feedback_field_description">বিবরণ</string>
+    <string name="feedback_field_steps">পুনরুৎপাদনের পদক্ষেপ</string>
+    <string name="feedback_field_expected_actual">প্রত্যাশিত বনাম বাস্তব</string>
+    <string name="feedback_field_use_case">ব্যবহারের ক্ষেত্র</string>
+    <string name="feedback_field_proposed_solution">প্রস্তাবিত সমাধান</string>
+    <string name="feedback_field_current_behaviour">বর্তমান আচরণ</string>
+    <string name="feedback_field_desired_behaviour">কাঙ্ক্ষিত আচরণ</string>
+    <string name="feedback_diagnostics_header">ডায়াগনস্টিক্স</string>
+    <string name="feedback_diagnostics_include">ডায়াগনস্টিক্স অন্তর্ভুক্ত করুন</string>
+    <string name="feedback_send_via_email">ইমেইল পাঠান</string>
+    <string name="feedback_send_via_github">GitHub ইস্যু হিসেবে খুলুন</string>
+    <string name="feedback_send_success_email">ধন্যবাদ — মেইল ক্লায়েন্ট খোলা হচ্ছে।</string>
+    <string name="feedback_send_success_github">ধন্যবাদ — ব্রাউজার খোলা হচ্ছে।</string>
+    <string name="feedback_send_error">ফিডব্যাক চ্যানেল খোলা যায়নি: %1$s</string>
+
+    <!-- E5 — Mirror feature -->
+    <string name="mirror_tweaks_entry_label">ডাউনলোড মিরর</string>
+    <string name="mirror_picker_title">ডাউনলোড মিরর</string>
+    <string name="mirror_picker_description">রিলিজ অ্যাসেট ডাউনলোড করতে ব্যবহৃত। GitHub API কল সবসময় সরাসরি যায়। বেশিরভাগ ব্যবহারকারীর Direct GitHub-এ রাখা উচিত।</string>
+    <string name="mirror_section_official">অফিসিয়াল</string>
+    <string name="mirror_section_community">কমিউনিটি</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(down)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">কাস্টম মিরর…</string>
+    <string name="mirror_custom_dialog_title">কাস্টম মিরর</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">টেমপ্লেট অবশ্যই https:// দিয়ে শুরু হতে হবে</string>
+    <string name="mirror_custom_validation_template">টেমপ্লেটে {url} ঠিক একবার থাকতে হবে</string>
+    <string name="mirror_custom_save">সংরক্ষণ করুন</string>
+    <string name="mirror_test_button">নির্বাচিত পরীক্ষা করুন</string>
+    <string name="mirror_test_in_progress">পরীক্ষা চলছে…</string>
+    <string name="mirror_test_success">%1$dms-এ পৌঁছানো হয়েছে</string>
+    <string name="mirror_test_http_error">মিরর %1$d ফেরত দিয়েছে</string>
+    <string name="mirror_test_timeout">5 সেকেন্ড পরে টাইমআউট</string>
+    <string name="mirror_test_dns_fail">হোস্ট রিসলভ করা যায়নি</string>
+    <string name="mirror_test_other">ব্যর্থ: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">সব মিরর নষ্ট? ৫ মিনিটে নিজের মিরর হোস্ট করুন — ডক্স দেখুন।</string>
+    <string name="mirror_removed_toast">%1$s আর পাওয়া যাচ্ছে না, Direct GitHub-এ স্যুইচ করা হয়েছে।</string>
+    <string name="mirror_digest_mismatch_error">চেকসাম মিলছে না — ফাইলটি হয়তো পরিবর্তন করা হয়েছে</string>
+    <string name="mirror_auto_suggest_title">আরও দ্রুত মিরর চেষ্টা করবেন?</string>
+    <string name="mirror_auto_suggest_body">ধীর নেটওয়ার্কে কিছু ব্যবহারকারী কমিউনিটি প্রক্সিতে ভালো ফলাফল পান।</string>
+    <string name="mirror_auto_suggest_pick_one">একটি বেছে নিন</string>
+    <string name="mirror_auto_suggest_maybe_later">পরে হয়তো</string>
+    <string name="mirror_auto_suggest_dont_ask_again">আর জিজ্ঞেস করবেন না</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -781,7 +781,7 @@
     <string name="external_import_card_action_more">আরও মিল</string>
     <string name="external_import_card_action_less">মিল লুকান</string>
     <string name="external_import_card_installer_chip">%1$s দিয়ে ইনস্টল করা</string>
-    <string name="external_import_card_preselect_known">আমরা মনে করি এটি %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">আমরা মনে করি এটি %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">রিপো খুঁজতে ট্যাপ করুন</string>
     <string name="external_import_card_expand_label">অন্য মিল দেখতে প্রসারিত করুন</string>
     <string name="external_import_card_collapse_label">কার্ড সংকুচিত করুন</string>
@@ -814,7 +814,7 @@
     <string name="external_import_proposal_banner_review">পর্যালোচনা</string>
     <string name="external_import_proposal_banner_dismiss">খারিজ করুন</string>
     <string name="external_import_match_confidence_a11y">মিলের আত্মবিশ্বাস: %1$d শতাংশ</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">এই অ্যাপ লিঙ্ক করা যায়নি — আবার চেষ্টা করুন।</string>
     <string name="external_import_error_link_network">GitHub-এ পৌঁছানো যায়নি। পরে আবার চেষ্টা করুন।</string>
     <string name="external_import_error_scan_failed_default">স্ক্যান ব্যর্থ হয়েছে</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -761,7 +761,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">Se omitieron %1$d — puedes volver a escanear desde Ajustes.</string>
     <string name="external_import_completion_action_view_all">Ver todas</string>
-    <string name="external_import_empty_all_matched">Todo vinculado.\\nNada que vincular.</string>
+    <string name="external_import_empty_all_matched">Todo vinculado.\nNada que vincular.</string>
     <string name="external_import_empty_done">Listo</string>
     <string name="external_import_empty_no_apps_title">No se encontraron aplicaciones de GitHub en este dispositivo.</string>
     <string name="external_import_empty_no_apps_body">Esto significa que todo fue instalado a través de otra tienda, o que no tenemos visibilidad de lo que está instalado.</string>
@@ -769,7 +769,7 @@
     <string name="external_import_empty_ok">Aceptar</string>
     <string name="external_import_empty_add_manually">Añadir una aplicación de otra tienda</string>
     <string name="external_import_permission_title">Encuentra tus aplicaciones de GitHub</string>
-    <string name="external_import_permission_body">Podemos analizar tus aplicaciones instaladas y vincularlas a versiones de GitHub, para que las actualizaciones y la detección funcionen solas.\\n\\nPara eso, necesitamos ver qué aplicaciones tienes. Sin permiso solo podemos ver unas 5 aplicaciones; con él, podemos verlas todas.\\n\\nNunca enviamos la lista de tus aplicaciones a ningún lugar sin tu permiso. La comparación se ejecuta en tu dispositivo. La búsqueda opcional en el servidor solo envía el nombre del paquete y la etiqueta de la aplicación, y cuando esté disponible, la huella de firma, el origen de instalación y cualquier indicación de repositorio de GitHub declarada en el manifiesto de la aplicación; nunca una lista completa de lo instalado.</string>
+    <string name="external_import_permission_body">Podemos analizar tus aplicaciones instaladas y vincularlas a versiones de GitHub, para que las actualizaciones y la detección funcionen solas.\n\nPara eso, necesitamos ver qué aplicaciones tienes. Sin permiso solo podemos ver unas 5 aplicaciones; con él, podemos verlas todas.\n\nNunca enviamos la lista de tus aplicaciones a ningún lugar sin tu permiso. La comparación se ejecuta en tu dispositivo. La búsqueda opcional en el servidor solo envía el nombre del paquete y la etiqueta de la aplicación, y cuando esté disponible, la huella de firma, el origen de instalación y cualquier indicación de repositorio de GitHub declarada en el manifiesto de la aplicación; nunca una lista completa de lo instalado.</string>
     <string name="external_import_permission_continue">Continuar</string>
     <string name="external_import_permission_not_now">Ahora no</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -708,4 +708,191 @@
     <string name="pat_error_bad_credentials">Ese token no es válido o ha sido revocado.</string>
     <string name="pat_error_insufficient_scope">Ese token no tiene los permisos necesarios.</string>
     <string name="pat_error_generic">No se pudo guardar el token. Inténtalo de nuevo.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+     E10 — Apps sort
+     ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Ordenar aplicaciones</string>
+    <string name="sort_updates_first">Actualizaciones primero</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Incluir betas</string>
+    <string name="channel_chip_stable_only">Solo estable</string>
+    <string name="channel_toggle_cd">Alternar versiones beta de esta aplicación</string>
+    <string name="action_switch_to_stable">Cambiar a %1$s estable</string>
+    <string name="stalled_project_warning_months">Sin versión estable en %1$d meses</string>
+    <string name="stalled_project_warning_days">Sin versión estable en %1$d días</string>
+    <string name="stalled_project_warning_description">Hay versiones previas activas, pero el proyecto no ha lanzado una versión estable en un tiempo. Las betas podrían no derivar en una versión estable.</string>
+    <string name="merged_whats_changed_title">Novedades desde %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Importar aplicaciones instaladas</string>
+    <string name="external_import_top_bar_back">Atrás</string>
+    <string name="external_import_overflow_more">Más opciones</string>
+    <string name="external_import_overflow_skip_remaining">Omitir restantes</string>
+    <string name="external_import_progress_scanning">Analizando tus aplicaciones…</string>
+    <string name="external_import_progress_auto_importing">Importando coincidencias…</string>
+    <string name="external_import_progress_working">Procesando…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">Se revisó %1$d aplicación</item>
+        <item quantity="other">Se revisaron %1$d aplicaciones</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Omitir</string>
+    <string name="external_import_card_action_link">Vincular</string>
+    <string name="external_import_card_action_more">Más coincidencias</string>
+    <string name="external_import_card_action_less">Ocultar coincidencias</string>
+    <string name="external_import_card_installer_chip">Instalado a través de %1$s</string>
+    <string name="external_import_card_preselect_known">Creemos que es %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Toca para buscar un repositorio</string>
+    <string name="external_import_card_expand_label">Expandir para ver otras coincidencias</string>
+    <string name="external_import_card_collapse_label">Contraer tarjeta</string>
+    <string name="external_import_search_icon_label">Buscar en GitHub</string>
+    <string name="external_import_search_empty">Sin coincidencias</string>
+    <string name="external_import_search_error_default">Error de búsqueda</string>
+    <string name="external_import_search_placeholder_url">Pega una URL de github.com o busca…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">Ahora se rastrea %1$d aplicación.</item>
+        <item quantity="other">Ahora se rastrean %1$d aplicaciones.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">Se omitieron %1$d — puedes volver a escanear desde Ajustes.</string>
+    <string name="external_import_completion_action_view_all">Ver todas</string>
+    <string name="external_import_empty_all_matched">Todo vinculado.\\nNada que vincular.</string>
+    <string name="external_import_empty_done">Listo</string>
+    <string name="external_import_empty_no_apps_title">No se encontraron aplicaciones de GitHub en este dispositivo.</string>
+    <string name="external_import_empty_no_apps_body">Esto significa que todo fue instalado a través de otra tienda, o que no tenemos visibilidad de lo que está instalado.</string>
+    <string name="external_import_empty_grant_permission">Conceder permiso</string>
+    <string name="external_import_empty_ok">Aceptar</string>
+    <string name="external_import_empty_add_manually">Añadir una aplicación de otra tienda</string>
+    <string name="external_import_permission_title">Encuentra tus aplicaciones de GitHub</string>
+    <string name="external_import_permission_body">Podemos analizar tus aplicaciones instaladas y vincularlas a versiones de GitHub, para que las actualizaciones y la detección funcionen solas.\\n\\nPara eso, necesitamos ver qué aplicaciones tienes. Sin permiso solo podemos ver unas 5 aplicaciones; con él, podemos verlas todas.\\n\\nNunca enviamos la lista de tus aplicaciones a ningún lugar sin tu permiso. La comparación se ejecuta en tu dispositivo. La búsqueda opcional en el servidor solo envía el nombre del paquete y la etiqueta de la aplicación, y cuando esté disponible, la huella de firma, el origen de instalación y cualquier indicación de repositorio de GitHub declarada en el manifiesto de la aplicación; nunca una lista completa de lo instalado.</string>
+    <string name="external_import_permission_continue">Continuar</string>
+    <string name="external_import_permission_not_now">Ahora no</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">Se encontró %1$d aplicación de GitHub</item>
+        <item quantity="other">Se encontraron %1$d aplicaciones de GitHub</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Revísalas para rastrear actualizaciones aquí.</string>
+    <string name="external_import_proposal_banner_review">Revisar</string>
+    <string name="external_import_proposal_banner_dismiss">Descartar</string>
+    <string name="external_import_match_confidence_a11y">Confianza de coincidencia: %1$d por ciento</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">No se pudo vincular esta aplicación — inténtalo de nuevo.</string>
+    <string name="external_import_error_link_network">No se pudo conectar a GitHub. Inténtalo más tarde.</string>
+    <string name="external_import_error_scan_failed_default">Error de análisis</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Navegador</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Fuente desconocida</string>
+    <string name="external_import_undo_linked">%1$s vinculado.</string>
+    <string name="external_import_undo_skipped">%1$s omitido.</string>
+    <string name="external_import_undo_action">Deshacer</string>
+    <string name="external_import_undo_failed">No se pudo deshacer — inténtalo de nuevo.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d aplicación para revisar</item>
+        <item quantity="other">%1$d aplicaciones para revisar</item>
+    </plurals>
+    <string name="external_import_list_add_manually">¿No ves tu aplicación? Añadir manualmente</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d aplicación vinculada automáticamente</item>
+        <item quantity="other">%1$d aplicaciones vinculadas automáticamente</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Las reconocimos con alta confianza. Puedes deshacer coincidencias individuales desde los detalles de cada aplicación, o deshacer todas ahora.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d más necesita tu revisión.</item>
+        <item quantity="other">%1$d más necesitan tu revisión.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Continuar</string>
+    <string name="external_import_auto_summary_undo_all">Deshacer todo</string>
+    <string name="external_import_auto_summary_more_count">+%1$d más</string>
+    <string name="external_import_rescan_menu">Buscar aplicaciones de GitHub</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Desvincular de este repositorio</string>
+    <string name="details_unlink_external_app_more_options">Más opciones</string>
+    <string name="details_unlink_external_app_dialog_title">¿Desvincular esta aplicación?</string>
+    <string name="details_unlink_external_app_dialog_body">Dejaremos de rastrear %1$s como instalada desde este repositorio. La aplicación permanece en tu dispositivo — solo se elimina el vínculo.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Desvincular</string>
+    <string name="details_unlink_external_app_success">Desvinculado. Sugeriremos una coincidencia en el próximo análisis.</string>
+    <string name="details_unlink_external_app_failure">No se pudo desvincular — inténtalo de nuevo.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Enviar comentarios</string>
+    <string name="feedback_title">Enviar comentarios</string>
+    <string name="feedback_close">Cerrar</string>
+    <string name="feedback_category_label">Categoría</string>
+    <string name="feedback_category_bug">Error</string>
+    <string name="feedback_category_feature">Solicitud de función</string>
+    <string name="feedback_category_change">Solicitud de cambio</string>
+    <string name="feedback_category_other">Otro</string>
+    <string name="feedback_topic_label">Tema</string>
+    <string name="feedback_topic_install_update">Instalación / Actualización</string>
+    <string name="feedback_topic_search">Búsqueda &amp; Descubrimiento</string>
+    <string name="feedback_topic_details">Detalles del repositorio</string>
+    <string name="feedback_topic_auth">Autenticación &amp; Cuenta</string>
+    <string name="feedback_topic_ui">Interfaz / UX</string>
+    <string name="feedback_topic_translation">Traducción / Idioma</string>
+    <string name="feedback_topic_performance">Rendimiento</string>
+    <string name="feedback_topic_other">Otro</string>
+    <string name="feedback_field_title">Título</string>
+    <string name="feedback_field_description">Descripción</string>
+    <string name="feedback_field_steps">Pasos para reproducir</string>
+    <string name="feedback_field_expected_actual">Esperado vs actual</string>
+    <string name="feedback_field_use_case">Caso de uso</string>
+    <string name="feedback_field_proposed_solution">Solución propuesta</string>
+    <string name="feedback_field_current_behaviour">Comportamiento actual</string>
+    <string name="feedback_field_desired_behaviour">Comportamiento deseado</string>
+    <string name="feedback_diagnostics_header">Diagnósticos</string>
+    <string name="feedback_diagnostics_include">Incluir diagnósticos</string>
+    <string name="feedback_send_via_email">Enviar por correo</string>
+    <string name="feedback_send_via_github">Abrir como Issue en GitHub</string>
+    <string name="feedback_send_success_email">Gracias — abriendo tu cliente de correo.</string>
+    <string name="feedback_send_success_github">Gracias — abriendo tu navegador.</string>
+    <string name="feedback_send_error">No se pudo abrir el canal de comentarios: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">Espejo de descarga</string>
+    <string name="mirror_picker_title">Espejo de descarga</string>
+    <string name="mirror_picker_description">Se usa para descargar archivos de versiones. Las llamadas a la API de GitHub siempre van directas. La mayoría de los usuarios debería dejarlo en GitHub directo.</string>
+    <string name="mirror_section_official">Oficial</string>
+    <string name="mirror_section_community">Comunidad</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(caído)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Espejo personalizado…</string>
+    <string name="mirror_custom_dialog_title">Espejo personalizado</string>
+    <string name="mirror_custom_dialog_hint">https://tu-espejo.ejemplo/{url}</string>
+    <string name="mirror_custom_validation_https">La plantilla debe comenzar con https://</string>
+    <string name="mirror_custom_validation_template">La plantilla debe contener {url} exactamente una vez</string>
+    <string name="mirror_custom_save">Guardar</string>
+    <string name="mirror_test_button">Probar seleccionado</string>
+    <string name="mirror_test_in_progress">Probando…</string>
+    <string name="mirror_test_success">Alcanzado en %1$dms</string>
+    <string name="mirror_test_http_error">El espejo devolvió %1$d</string>
+    <string name="mirror_test_timeout">Tiempo de espera agotado tras 5s</string>
+    <string name="mirror_test_dns_fail">No se pudo resolver el host</string>
+    <string name="mirror_test_other">Error: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">¿Todos los espejos caídos? Puedes alojar el tuyo en 5 minutos — consulta la documentación.</string>
+    <string name="mirror_removed_toast">%1$s ya no está disponible; cambiado a GitHub directo.</string>
+    <string name="mirror_digest_mismatch_error">Error de suma de verificación — el archivo puede haber sido manipulado</string>
+    <string name="mirror_auto_suggest_title">¿Probar un espejo más rápido?</string>
+    <string name="mirror_auto_suggest_body">Algunos usuarios en redes lentas tienen mejor suerte con un proxy de la comunidad.</string>
+    <string name="mirror_auto_suggest_pick_one">Elegir uno</string>
+    <string name="mirror_auto_suggest_maybe_later">Quizás más tarde</string>
+    <string name="mirror_auto_suggest_dont_ask_again">No preguntar de nuevo</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -747,7 +747,7 @@
     <string name="external_import_card_action_more">Más coincidencias</string>
     <string name="external_import_card_action_less">Ocultar coincidencias</string>
     <string name="external_import_card_installer_chip">Instalado a través de %1$s</string>
-    <string name="external_import_card_preselect_known">Creemos que es %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Creemos que es %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Toca para buscar un repositorio</string>
     <string name="external_import_card_expand_label">Expandir para ver otras coincidencias</string>
     <string name="external_import_card_collapse_label">Contraer tarjeta</string>
@@ -780,7 +780,7 @@
     <string name="external_import_proposal_banner_review">Revisar</string>
     <string name="external_import_proposal_banner_dismiss">Descartar</string>
     <string name="external_import_match_confidence_a11y">Confianza de coincidencia: %1$d por ciento</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">No se pudo vincular esta aplicación — inténtalo de nuevo.</string>
     <string name="external_import_error_link_network">No se pudo conectar a GitHub. Inténtalo más tarde.</string>
     <string name="external_import_error_scan_failed_default">Error de análisis</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -762,7 +762,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d ignorée(s) — vous pouvez relancer une analyse depuis Paramètres.</string>
     <string name="external_import_completion_action_view_all">Tout afficher</string>
-    <string name="external_import_empty_all_matched">Tout est lié.\\nRien à lier.</string>
+    <string name="external_import_empty_all_matched">Tout est lié.\nRien à lier.</string>
     <string name="external_import_empty_done">Terminé</string>
     <string name="external_import_empty_no_apps_title">Aucune application GitHub trouvée sur cet appareil.</string>
     <string name="external_import_empty_no_apps_body">Cela signifie que tout a été installé via une autre boutique, ou que nous n\'avons pas accès à la liste des applications installées.</string>
@@ -770,7 +770,7 @@
     <string name="external_import_empty_ok">OK</string>
     <string name="external_import_empty_add_manually">Ajouter une application d\'une autre boutique</string>
     <string name="external_import_permission_title">Trouvez vos applications GitHub</string>
-    <string name="external_import_permission_body">Nous pouvons analyser vos applications installées et les associer aux versions GitHub, afin que les mises à jour et la détection fonctionnent automatiquement.\\n\\nPour cela, nous devons voir quelles applications vous avez. Sans permission, nous ne pouvons voir qu\'environ 5 applications ; avec elle, nous pouvons toutes les voir.\\n\\nNous n\'envoyons jamais la liste de vos applications sans votre permission. La correspondance s\'effectue sur votre appareil. La recherche optionnelle sur le serveur envoie uniquement le nom du paquet et l\'étiquette de l\'application, et si disponibles, l\'empreinte de signature, la source d\'installation et tout indice de dépôt GitHub déclaré dans le manifeste de l\'application — jamais une liste complète de ce qui est installé.</string>
+    <string name="external_import_permission_body">Nous pouvons analyser vos applications installées et les associer aux versions GitHub, afin que les mises à jour et la détection fonctionnent automatiquement.\n\nPour cela, nous devons voir quelles applications vous avez. Sans permission, nous ne pouvons voir qu\'environ 5 applications ; avec elle, nous pouvons toutes les voir.\n\nNous n\'envoyons jamais la liste de vos applications sans votre permission. La correspondance s\'effectue sur votre appareil. La recherche optionnelle sur le serveur envoie uniquement le nom du paquet et l\'étiquette de l\'application, et si disponibles, l\'empreinte de signature, la source d\'installation et tout indice de dépôt GitHub déclaré dans le manifeste de l\'application — jamais une liste complète de ce qui est installé.</string>
     <string name="external_import_permission_continue">Continuer</string>
     <string name="external_import_permission_not_now">Pas maintenant</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -725,7 +725,7 @@
     <string name="action_switch_to_stable">Passer à %1$s stable</string>
     <string name="stalled_project_warning_months">Aucune version stable depuis %1$d mois</string>
     <string name="stalled_project_warning_days">Aucune version stable depuis %1$d jour(s)</string>
-    <string name="stalled_project_warning_description">Des préversions actives existent, mais le projet n\'a pas publié de version stable depuis un moment. Les bêtas pourraient ne pas aboutir à une version stable.</string>
+    <string name="stalled_project_warning_description">Des préversions actives existent, mais le projet n'a pas publié de version stable depuis un moment. Les bêtas pourraient ne pas aboutir à une version stable.</string>
     <string name="merged_whats_changed_title">Nouveautés depuis %1$s</string>
     <string name="merged_release_heading">— %1$s —</string>
 
@@ -734,7 +734,7 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="external_import_top_bar_title">Importer les applications installées</string>
     <string name="external_import_top_bar_back">Retour</string>
-    <string name="external_import_overflow_more">Plus d\'options</string>
+    <string name="external_import_overflow_more">Plus d'options</string>
     <string name="external_import_overflow_skip_remaining">Ignorer les restantes</string>
     <string name="external_import_progress_scanning">Analyse de vos applications…</string>
     <string name="external_import_progress_auto_importing">Importation des correspondances…</string>
@@ -748,9 +748,9 @@
     <string name="external_import_card_action_more">Plus de correspondances</string>
     <string name="external_import_card_action_less">Masquer les correspondances</string>
     <string name="external_import_card_installer_chip">Installé via %1$s</string>
-    <string name="external_import_card_preselect_known">Nous pensons que c\'est %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Nous pensons que c'est %1$s · %2$d%%</string>
     <string name="external_import_card_preselect_unknown">Appuyez pour trouver un dépôt</string>
-    <string name="external_import_card_expand_label">Développer pour voir d\'autres correspondances</string>
+    <string name="external_import_card_expand_label">Développer pour voir d'autres correspondances</string>
     <string name="external_import_card_collapse_label">Réduire la carte</string>
     <string name="external_import_search_icon_label">Rechercher sur GitHub</string>
     <string name="external_import_search_empty">Aucune correspondance</string>
@@ -765,12 +765,12 @@
     <string name="external_import_empty_all_matched">Tout est lié.\nRien à lier.</string>
     <string name="external_import_empty_done">Terminé</string>
     <string name="external_import_empty_no_apps_title">Aucune application GitHub trouvée sur cet appareil.</string>
-    <string name="external_import_empty_no_apps_body">Cela signifie que tout a été installé via une autre boutique, ou que nous n\'avons pas accès à la liste des applications installées.</string>
+    <string name="external_import_empty_no_apps_body">Cela signifie que tout a été installé via une autre boutique, ou que nous n'avons pas accès à la liste des applications installées.</string>
     <string name="external_import_empty_grant_permission">Accorder la permission</string>
     <string name="external_import_empty_ok">OK</string>
-    <string name="external_import_empty_add_manually">Ajouter une application d\'une autre boutique</string>
+    <string name="external_import_empty_add_manually">Ajouter une application d'une autre boutique</string>
     <string name="external_import_permission_title">Trouvez vos applications GitHub</string>
-    <string name="external_import_permission_body">Nous pouvons analyser vos applications installées et les associer aux versions GitHub, afin que les mises à jour et la détection fonctionnent automatiquement.\n\nPour cela, nous devons voir quelles applications vous avez. Sans permission, nous ne pouvons voir qu\'environ 5 applications ; avec elle, nous pouvons toutes les voir.\n\nNous n\'envoyons jamais la liste de vos applications sans votre permission. La correspondance s\'effectue sur votre appareil. La recherche optionnelle sur le serveur envoie uniquement le nom du paquet et l\'étiquette de l\'application, et si disponibles, l\'empreinte de signature, la source d\'installation et tout indice de dépôt GitHub déclaré dans le manifeste de l\'application — jamais une liste complète de ce qui est installé.</string>
+    <string name="external_import_permission_body">Nous pouvons analyser vos applications installées et les associer aux versions GitHub, afin que les mises à jour et la détection fonctionnent automatiquement.\n\nPour cela, nous devons voir quelles applications vous avez. Sans permission, nous ne pouvons voir qu'environ 5 applications ; avec elle, nous pouvons toutes les voir.\n\nNous n'envoyons jamais la liste de vos applications sans votre permission. La correspondance s'effectue sur votre appareil. La recherche optionnelle sur le serveur envoie uniquement le nom du paquet et l'étiquette de l'application, et si disponibles, l'empreinte de signature, la source d'installation et tout indice de dépôt GitHub déclaré dans le manifeste de l'application — jamais une liste complète de ce qui est installé.</string>
     <string name="external_import_permission_continue">Continuer</string>
     <string name="external_import_permission_not_now">Pas maintenant</string>
     <plurals name="external_import_proposal_banner_headline">
@@ -783,8 +783,8 @@
     <string name="external_import_match_confidence_a11y">Confiance de correspondance : %1$d pour cent</string>
     <string name="external_import_match_confidence_chip">%1$d%%</string>
     <string name="external_import_error_link_failed">Impossible de lier cette application — réessayez.</string>
-    <string name="external_import_error_link_network">Impossible d\'atteindre GitHub. Réessayez plus tard.</string>
-    <string name="external_import_error_scan_failed_default">Échec de l\'analyse</string>
+    <string name="external_import_error_link_network">Impossible d'atteindre GitHub. Réessayez plus tard.</string>
+    <string name="external_import_error_scan_failed_default">Échec de l'analyse</string>
     <string name="external_import_installer_obtainium">Obtainium</string>
     <string name="external_import_installer_fdroid">F-Droid</string>
     <string name="external_import_installer_browser">Navigateur</string>
@@ -794,7 +794,7 @@
     <string name="external_import_undo_linked">%1$s lié.</string>
     <string name="external_import_undo_skipped">%1$s ignoré.</string>
     <string name="external_import_undo_action">Annuler</string>
-    <string name="external_import_undo_failed">Impossible d\'annuler — réessayez.</string>
+    <string name="external_import_undo_failed">Impossible d'annuler — réessayez.</string>
     <plurals name="external_import_list_remaining">
         <item quantity="one">%1$d application à examiner</item>
         <item quantity="other">%1$d applications à examiner</item>
@@ -818,9 +818,9 @@
          E1 — Details unlink dialog
          ═══════════════════════════════════════════════════════════════ -->
     <string name="details_unlink_external_app_menu">Délier de ce dépôt</string>
-    <string name="details_unlink_external_app_more_options">Plus d\'options</string>
+    <string name="details_unlink_external_app_more_options">Plus d'options</string>
     <string name="details_unlink_external_app_dialog_title">Délier cette application ?</string>
-    <string name="details_unlink_external_app_dialog_body">Nous cesserons de suivre %1$s comme installée depuis ce dépôt. L\'application reste sur votre appareil — seul le lien est supprimé.</string>
+    <string name="details_unlink_external_app_dialog_body">Nous cesserons de suivre %1$s comme installée depuis ce dépôt. L'application reste sur votre appareil — seul le lien est supprimé.</string>
     <string name="details_unlink_external_app_dialog_confirm">Délier</string>
     <string name="details_unlink_external_app_success">Délié. Nous proposerons une correspondance lors du prochain scan.</string>
     <string name="details_unlink_external_app_failure">Impossible de délier — réessayez.</string>
@@ -849,7 +849,7 @@
     <string name="feedback_field_description">Description</string>
     <string name="feedback_field_steps">Étapes pour reproduire</string>
     <string name="feedback_field_expected_actual">Attendu vs obtenu</string>
-    <string name="feedback_field_use_case">Cas d\'utilisation</string>
+    <string name="feedback_field_use_case">Cas d'utilisation</string>
     <string name="feedback_field_proposed_solution">Solution proposée</string>
     <string name="feedback_field_current_behaviour">Comportement actuel</string>
     <string name="feedback_field_desired_behaviour">Comportement souhaité</string>
@@ -859,14 +859,14 @@
     <string name="feedback_send_via_github">Ouvrir comme Issue GitHub</string>
     <string name="feedback_send_success_email">Merci — ouverture de votre client e-mail.</string>
     <string name="feedback_send_success_github">Merci — ouverture de votre navigateur.</string>
-    <string name="feedback_send_error">Impossible d\'ouvrir le canal de commentaires : %1$s</string>
+    <string name="feedback_send_error">Impossible d'ouvrir le canal de commentaires : %1$s</string>
 
     <!-- ═══════════════════════════════════════════════════════════════
          E5 — Mirror feature
          ═══════════════════════════════════════════════════════════════ -->
     <string name="mirror_tweaks_entry_label">Miroir de téléchargement</string>
     <string name="mirror_picker_title">Miroir de téléchargement</string>
-    <string name="mirror_picker_description">Utilisé pour télécharger les fichiers de versions. Les appels à l\'API GitHub passent toujours en direct. La plupart des utilisateurs devraient laisser ce paramètre sur GitHub direct.</string>
+    <string name="mirror_picker_description">Utilisé pour télécharger les fichiers de versions. Les appels à l'API GitHub passent toujours en direct. La plupart des utilisateurs devraient laisser ce paramètre sur GitHub direct.</string>
     <string name="mirror_section_official">Officiel</string>
     <string name="mirror_section_community">Communauté</string>
     <string name="mirror_status_ok">%1$dms</string>
@@ -884,10 +884,10 @@
     <string name="mirror_test_success">Atteint en %1$dms</string>
     <string name="mirror_test_http_error">Le miroir a renvoyé %1$d</string>
     <string name="mirror_test_timeout">Délai dépassé après 5s</string>
-    <string name="mirror_test_dns_fail">Impossible de résoudre l\'hôte</string>
+    <string name="mirror_test_dns_fail">Impossible de résoudre l'hôte</string>
     <string name="mirror_test_other">Échec : %1$s</string>
     <string name="mirror_deploy_your_own_hint">Tous les miroirs hors ligne ? Vous pouvez héberger le vôtre en 5 minutes — consultez la documentation.</string>
-    <string name="mirror_removed_toast">%1$s n\'est plus disponible, basculé vers GitHub direct.</string>
+    <string name="mirror_removed_toast">%1$s n'est plus disponible, basculé vers GitHub direct.</string>
     <string name="mirror_digest_mismatch_error">Somme de contrôle incorrecte — le fichier a peut-être été altéré</string>
     <string name="mirror_auto_suggest_title">Essayer un miroir plus rapide ?</string>
     <string name="mirror_auto_suggest_body">Certains utilisateurs sur des réseaux lents ont plus de succès avec un proxy communautaire.</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -748,7 +748,7 @@
     <string name="external_import_card_action_more">Plus de correspondances</string>
     <string name="external_import_card_action_less">Masquer les correspondances</string>
     <string name="external_import_card_installer_chip">Installé via %1$s</string>
-    <string name="external_import_card_preselect_known">Nous pensons que c'est %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Nous pensons que c'est %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Appuyez pour trouver un dépôt</string>
     <string name="external_import_card_expand_label">Développer pour voir d'autres correspondances</string>
     <string name="external_import_card_collapse_label">Réduire la carte</string>
@@ -781,7 +781,7 @@
     <string name="external_import_proposal_banner_review">Examiner</string>
     <string name="external_import_proposal_banner_dismiss">Ignorer</string>
     <string name="external_import_match_confidence_a11y">Confiance de correspondance : %1$d pour cent</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Impossible de lier cette application — réessayez.</string>
     <string name="external_import_error_link_network">Impossible d'atteindre GitHub. Réessayez plus tard.</string>
     <string name="external_import_error_scan_failed_default">Échec de l'analyse</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -709,4 +709,191 @@
     <string name="pat_error_bad_credentials">Ce token est invalide ou a été révoqué.</string>
     <string name="pat_error_insufficient_scope">Ce token ne dispose pas des autorisations requises.</string>
     <string name="pat_error_generic">Impossible d'enregistrer le token. Veuillez réessayer.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+     E10 — Apps sort
+     ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Trier les applications</string>
+    <string name="sort_updates_first">Mises à jour en premier</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Inclure les bêtas</string>
+    <string name="channel_chip_stable_only">Stable uniquement</string>
+    <string name="channel_toggle_cd">Activer/désactiver les versions bêta de cette application</string>
+    <string name="action_switch_to_stable">Passer à %1$s stable</string>
+    <string name="stalled_project_warning_months">Aucune version stable depuis %1$d mois</string>
+    <string name="stalled_project_warning_days">Aucune version stable depuis %1$d jour(s)</string>
+    <string name="stalled_project_warning_description">Des préversions actives existent, mais le projet n\'a pas publié de version stable depuis un moment. Les bêtas pourraient ne pas aboutir à une version stable.</string>
+    <string name="merged_whats_changed_title">Nouveautés depuis %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Importer les applications installées</string>
+    <string name="external_import_top_bar_back">Retour</string>
+    <string name="external_import_overflow_more">Plus d\'options</string>
+    <string name="external_import_overflow_skip_remaining">Ignorer les restantes</string>
+    <string name="external_import_progress_scanning">Analyse de vos applications…</string>
+    <string name="external_import_progress_auto_importing">Importation des correspondances…</string>
+    <string name="external_import_progress_working">Traitement en cours…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">%1$d application examinée</item>
+        <item quantity="other">%1$d applications examinées</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Ignorer</string>
+    <string name="external_import_card_action_link">Lier</string>
+    <string name="external_import_card_action_more">Plus de correspondances</string>
+    <string name="external_import_card_action_less">Masquer les correspondances</string>
+    <string name="external_import_card_installer_chip">Installé via %1$s</string>
+    <string name="external_import_card_preselect_known">Nous pensons que c\'est %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Appuyez pour trouver un dépôt</string>
+    <string name="external_import_card_expand_label">Développer pour voir d\'autres correspondances</string>
+    <string name="external_import_card_collapse_label">Réduire la carte</string>
+    <string name="external_import_search_icon_label">Rechercher sur GitHub</string>
+    <string name="external_import_search_empty">Aucune correspondance</string>
+    <string name="external_import_search_error_default">Échec de la recherche</string>
+    <string name="external_import_search_placeholder_url">Collez une URL github.com ou recherchez…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">%1$d application suivie maintenant.</item>
+        <item quantity="other">%1$d applications suivies maintenant.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d ignorée(s) — vous pouvez relancer une analyse depuis Paramètres.</string>
+    <string name="external_import_completion_action_view_all">Tout afficher</string>
+    <string name="external_import_empty_all_matched">Tout est lié.\\nRien à lier.</string>
+    <string name="external_import_empty_done">Terminé</string>
+    <string name="external_import_empty_no_apps_title">Aucune application GitHub trouvée sur cet appareil.</string>
+    <string name="external_import_empty_no_apps_body">Cela signifie que tout a été installé via une autre boutique, ou que nous n\'avons pas accès à la liste des applications installées.</string>
+    <string name="external_import_empty_grant_permission">Accorder la permission</string>
+    <string name="external_import_empty_ok">OK</string>
+    <string name="external_import_empty_add_manually">Ajouter une application d\'une autre boutique</string>
+    <string name="external_import_permission_title">Trouvez vos applications GitHub</string>
+    <string name="external_import_permission_body">Nous pouvons analyser vos applications installées et les associer aux versions GitHub, afin que les mises à jour et la détection fonctionnent automatiquement.\\n\\nPour cela, nous devons voir quelles applications vous avez. Sans permission, nous ne pouvons voir qu\'environ 5 applications ; avec elle, nous pouvons toutes les voir.\\n\\nNous n\'envoyons jamais la liste de vos applications sans votre permission. La correspondance s\'effectue sur votre appareil. La recherche optionnelle sur le serveur envoie uniquement le nom du paquet et l\'étiquette de l\'application, et si disponibles, l\'empreinte de signature, la source d\'installation et tout indice de dépôt GitHub déclaré dans le manifeste de l\'application — jamais une liste complète de ce qui est installé.</string>
+    <string name="external_import_permission_continue">Continuer</string>
+    <string name="external_import_permission_not_now">Pas maintenant</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">%1$d application GitHub trouvée</item>
+        <item quantity="other">%1$d applications GitHub trouvées</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Examinez-les pour suivre les mises à jour ici.</string>
+    <string name="external_import_proposal_banner_review">Examiner</string>
+    <string name="external_import_proposal_banner_dismiss">Ignorer</string>
+    <string name="external_import_match_confidence_a11y">Confiance de correspondance : %1$d pour cent</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">Impossible de lier cette application — réessayez.</string>
+    <string name="external_import_error_link_network">Impossible d\'atteindre GitHub. Réessayez plus tard.</string>
+    <string name="external_import_error_scan_failed_default">Échec de l\'analyse</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Navigateur</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Source inconnue</string>
+    <string name="external_import_undo_linked">%1$s lié.</string>
+    <string name="external_import_undo_skipped">%1$s ignoré.</string>
+    <string name="external_import_undo_action">Annuler</string>
+    <string name="external_import_undo_failed">Impossible d\'annuler — réessayez.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d application à examiner</item>
+        <item quantity="other">%1$d applications à examiner</item>
+    </plurals>
+    <string name="external_import_list_add_manually">Vous ne voyez pas votre application ? Ajouter manuellement</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d application liée automatiquement</item>
+        <item quantity="other">%1$d applications liées automatiquement</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Nous les avons reconnues avec une haute confiance. Vous pouvez annuler des correspondances individuelles depuis les détails de chaque application, ou tout annuler maintenant.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d autre nécessite votre attention.</item>
+        <item quantity="other">%1$d autres nécessitent votre attention.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Continuer</string>
+    <string name="external_import_auto_summary_undo_all">Tout annuler</string>
+    <string name="external_import_auto_summary_more_count">+%1$d autres</string>
+    <string name="external_import_rescan_menu">Rechercher des applications GitHub</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Délier de ce dépôt</string>
+    <string name="details_unlink_external_app_more_options">Plus d\'options</string>
+    <string name="details_unlink_external_app_dialog_title">Délier cette application ?</string>
+    <string name="details_unlink_external_app_dialog_body">Nous cesserons de suivre %1$s comme installée depuis ce dépôt. L\'application reste sur votre appareil — seul le lien est supprimé.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Délier</string>
+    <string name="details_unlink_external_app_success">Délié. Nous proposerons une correspondance lors du prochain scan.</string>
+    <string name="details_unlink_external_app_failure">Impossible de délier — réessayez.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Envoyer un commentaire</string>
+    <string name="feedback_title">Envoyer un commentaire</string>
+    <string name="feedback_close">Fermer</string>
+    <string name="feedback_category_label">Catégorie</string>
+    <string name="feedback_category_bug">Bogue</string>
+    <string name="feedback_category_feature">Demande de fonctionnalité</string>
+    <string name="feedback_category_change">Demande de modification</string>
+    <string name="feedback_category_other">Autre</string>
+    <string name="feedback_topic_label">Sujet</string>
+    <string name="feedback_topic_install_update">Installation / Mise à jour</string>
+    <string name="feedback_topic_search">Recherche &amp; Découverte</string>
+    <string name="feedback_topic_details">Détails du dépôt</string>
+    <string name="feedback_topic_auth">Auth &amp; Compte</string>
+    <string name="feedback_topic_ui">Interface / UX</string>
+    <string name="feedback_topic_translation">Traduction / Langue</string>
+    <string name="feedback_topic_performance">Performance</string>
+    <string name="feedback_topic_other">Autre</string>
+    <string name="feedback_field_title">Titre</string>
+    <string name="feedback_field_description">Description</string>
+    <string name="feedback_field_steps">Étapes pour reproduire</string>
+    <string name="feedback_field_expected_actual">Attendu vs obtenu</string>
+    <string name="feedback_field_use_case">Cas d\'utilisation</string>
+    <string name="feedback_field_proposed_solution">Solution proposée</string>
+    <string name="feedback_field_current_behaviour">Comportement actuel</string>
+    <string name="feedback_field_desired_behaviour">Comportement souhaité</string>
+    <string name="feedback_diagnostics_header">Diagnostics</string>
+    <string name="feedback_diagnostics_include">Inclure les diagnostics</string>
+    <string name="feedback_send_via_email">Envoyer par e-mail</string>
+    <string name="feedback_send_via_github">Ouvrir comme Issue GitHub</string>
+    <string name="feedback_send_success_email">Merci — ouverture de votre client e-mail.</string>
+    <string name="feedback_send_success_github">Merci — ouverture de votre navigateur.</string>
+    <string name="feedback_send_error">Impossible d\'ouvrir le canal de commentaires : %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">Miroir de téléchargement</string>
+    <string name="mirror_picker_title">Miroir de téléchargement</string>
+    <string name="mirror_picker_description">Utilisé pour télécharger les fichiers de versions. Les appels à l\'API GitHub passent toujours en direct. La plupart des utilisateurs devraient laisser ce paramètre sur GitHub direct.</string>
+    <string name="mirror_section_official">Officiel</string>
+    <string name="mirror_section_community">Communauté</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(hors ligne)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Miroir personnalisé…</string>
+    <string name="mirror_custom_dialog_title">Miroir personnalisé</string>
+    <string name="mirror_custom_dialog_hint">https://votre-miroir.exemple/{url}</string>
+    <string name="mirror_custom_validation_https">Le modèle doit commencer par https://</string>
+    <string name="mirror_custom_validation_template">Le modèle doit contenir {url} exactement une fois</string>
+    <string name="mirror_custom_save">Enregistrer</string>
+    <string name="mirror_test_button">Tester la sélection</string>
+    <string name="mirror_test_in_progress">Test en cours…</string>
+    <string name="mirror_test_success">Atteint en %1$dms</string>
+    <string name="mirror_test_http_error">Le miroir a renvoyé %1$d</string>
+    <string name="mirror_test_timeout">Délai dépassé après 5s</string>
+    <string name="mirror_test_dns_fail">Impossible de résoudre l\'hôte</string>
+    <string name="mirror_test_other">Échec : %1$s</string>
+    <string name="mirror_deploy_your_own_hint">Tous les miroirs hors ligne ? Vous pouvez héberger le vôtre en 5 minutes — consultez la documentation.</string>
+    <string name="mirror_removed_toast">%1$s n\'est plus disponible, basculé vers GitHub direct.</string>
+    <string name="mirror_digest_mismatch_error">Somme de contrôle incorrecte — le fichier a peut-être été altéré</string>
+    <string name="mirror_auto_suggest_title">Essayer un miroir plus rapide ?</string>
+    <string name="mirror_auto_suggest_body">Certains utilisateurs sur des réseaux lents ont plus de succès avec un proxy communautaire.</string>
+    <string name="mirror_auto_suggest_pick_one">En choisir un</string>
+    <string name="mirror_auto_suggest_maybe_later">Peut-être plus tard</string>
+    <string name="mirror_auto_suggest_dont_ask_again">Ne plus demander</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -800,7 +800,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d छोड़े — आप सेटिंग्स से पुनः स्कैन चला सकते हैं।</string>
     <string name="external_import_completion_action_view_all">सभी देखें</string>
-    <string name="external_import_empty_all_matched">सब लिंक हो गया।\\nलिंक करने के लिए कुछ नहीं।</string>
+    <string name="external_import_empty_all_matched">सब लिंक हो गया।\nलिंक करने के लिए कुछ नहीं।</string>
     <string name="external_import_empty_done">हो गया</string>
     <string name="external_import_empty_no_apps_title">इस डिवाइस पर कोई GitHub ऐप नहीं मिला।</string>
     <string name="external_import_empty_no_apps_body">इसका मतलब है कि सब किसी और स्टोर से इंस्टॉल हुआ, या हमें इंस्टॉल ऐप्स की जानकारी नहीं मिल पाई।</string>
@@ -808,7 +808,7 @@
     <string name="external_import_empty_ok">ठीक है</string>
     <string name="external_import_empty_add_manually">किसी और स्टोर से ऐप जोड़ें</string>
     <string name="external_import_permission_title">अपने GitHub ऐप्स खोजें</string>
-    <string name="external_import_permission_body">हम आपके इंस्टॉल ऐप्स स्कैन करके GitHub रिलीज़ से मिला सकते हैं, ताकि अपडेट और पहचान अपने आप काम करे।\\n\\nइसके लिए हमें देखना होगा कि आपके पास कौन से ऐप्स हैं। अनुमति के बिना हम केवल लगभग 5 ऐप्स देख सकते हैं; अनुमति के साथ सभी देख सकते हैं।\\n\\nहम आपकी अनुमति के बिना आपके ऐप्स की सूची कहीं नहीं भेजते। मिलान आपके डिवाइस पर होता है। वैकल्पिक सर्वर लुकअप केवल पैकेज नाम और ऐप लेबल भेजता है, और उपलब्ध होने पर साइनिंग फिंगरप्रिंट, इंस्टॉल स्रोत और ऐप के मैनिफेस्ट में घोषित GitHub रिपो संकेत भी — कभी भी इंस्टॉल की पूरी सूची नहीं।</string>
+    <string name="external_import_permission_body">हम आपके इंस्टॉल ऐप्स स्कैन करके GitHub रिलीज़ से मिला सकते हैं, ताकि अपडेट और पहचान अपने आप काम करे।\n\nइसके लिए हमें देखना होगा कि आपके पास कौन से ऐप्स हैं। अनुमति के बिना हम केवल लगभग 5 ऐप्स देख सकते हैं; अनुमति के साथ सभी देख सकते हैं।\n\nहम आपकी अनुमति के बिना आपके ऐप्स की सूची कहीं नहीं भेजते। मिलान आपके डिवाइस पर होता है। वैकल्पिक सर्वर लुकअप केवल पैकेज नाम और ऐप लेबल भेजता है, और उपलब्ध होने पर साइनिंग फिंगरप्रिंट, इंस्टॉल स्रोत और ऐप के मैनिफेस्ट में घोषित GitHub रिपो संकेत भी — कभी भी इंस्टॉल की पूरी सूची नहीं।</string>
     <string name="external_import_permission_continue">जारी रखें</string>
     <string name="external_import_permission_not_now">अभी नहीं</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -786,7 +786,7 @@
     <string name="external_import_card_action_more">अधिक मेल</string>
     <string name="external_import_card_action_less">मेल छुपाएं</string>
     <string name="external_import_card_installer_chip">%1$s के ज़रिए इंस्टॉल</string>
-    <string name="external_import_card_preselect_known">हमें लगता है यह %1$s है · %2$d%%</string>
+    <string name="external_import_card_preselect_known">हमें लगता है यह %1$s है · %2$d</string>
     <string name="external_import_card_preselect_unknown">रिपो खोजने के लिए टैप करें</string>
     <string name="external_import_card_expand_label">अन्य मेल देखने के लिए विस्तार करें</string>
     <string name="external_import_card_collapse_label">कार्ड संकुचित करें</string>
@@ -819,7 +819,7 @@
     <string name="external_import_proposal_banner_review">समीक्षा करें</string>
     <string name="external_import_proposal_banner_dismiss">हटाएं</string>
     <string name="external_import_match_confidence_a11y">मिलान विश्वास: %1$d प्रतिशत</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">इस ऐप को लिंक नहीं किया जा सका — फिर कोशिश करें।</string>
     <string name="external_import_error_link_network">GitHub तक नहीं पहुंचा जा सका। बाद में फिर कोशिश करें।</string>
     <string name="external_import_error_scan_failed_default">स्कैन विफल</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -746,4 +746,191 @@
     <string name="pat_error_bad_credentials">यह टोकन अमान्य है या निरस्त कर दिया गया है।</string>
     <string name="pat_error_insufficient_scope">इस टोकन के पास आवश्यक अनुमतियाँ नहीं हैं।</string>
     <string name="pat_error_generic">टोकन सेव नहीं हो सका। कृपया फिर से प्रयास करें।</string>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E10 — Apps sort
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">ऐप्स को क्रमबद्ध करें</string>
+    <string name="sort_updates_first">अपडेट पहले</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">बीटा शामिल करें</string>
+    <string name="channel_chip_stable_only">केवल स्थिर</string>
+    <string name="channel_toggle_cd">इस ऐप के बीटा रिलीज़ टॉगल करें</string>
+    <string name="action_switch_to_stable">%1$s स्थिर पर स्विच करें</string>
+    <string name="stalled_project_warning_months">%1$d महीनों में कोई स्थिर रिलीज़ नहीं</string>
+    <string name="stalled_project_warning_days">%1$d दिनों में कोई स्थिर रिलीज़ नहीं</string>
+    <string name="stalled_project_warning_description">सक्रिय प्री-रिलीज़ हैं, लेकिन प्रोजेक्ट ने काफी समय से कोई स्थिर बिल्ड नहीं दिया। बीटा स्थिर रिलीज़ में नहीं बदल सकते।</string>
+    <string name="merged_whats_changed_title">%1$s के बाद क्या बदला</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">इंस्टॉल ऐप्स आयात करें</string>
+    <string name="external_import_top_bar_back">वापस</string>
+    <string name="external_import_overflow_more">अधिक विकल्प</string>
+    <string name="external_import_overflow_skip_remaining">बाकी छोड़ें</string>
+    <string name="external_import_progress_scanning">आपके ऐप्स स्कैन हो रहे हैं…</string>
+    <string name="external_import_progress_auto_importing">मेल आयात हो रहे हैं…</string>
+    <string name="external_import_progress_working">प्रक्रिया चल रही है…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">%1$d ऐप देखा गया</item>
+        <item quantity="other">%1$d ऐप देखे गए</item>
+    </plurals>
+    <string name="external_import_card_action_skip">छोड़ें</string>
+    <string name="external_import_card_action_link">लिंक करें</string>
+    <string name="external_import_card_action_more">अधिक मेल</string>
+    <string name="external_import_card_action_less">मेल छुपाएं</string>
+    <string name="external_import_card_installer_chip">%1$s के ज़रिए इंस्टॉल</string>
+    <string name="external_import_card_preselect_known">हमें लगता है यह %1$s है · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">रिपो खोजने के लिए टैप करें</string>
+    <string name="external_import_card_expand_label">अन्य मेल देखने के लिए विस्तार करें</string>
+    <string name="external_import_card_collapse_label">कार्ड संकुचित करें</string>
+    <string name="external_import_search_icon_label">GitHub खोजें</string>
+    <string name="external_import_search_empty">कोई मेल नहीं</string>
+    <string name="external_import_search_error_default">खोज विफल</string>
+    <string name="external_import_search_placeholder_url">github.com URL पेस्ट करें या खोजें…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">अब %1$d ऐप ट्रैक हो रहा है।</item>
+        <item quantity="other">अब %1$d ऐप ट्रैक हो रहे हैं।</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d छोड़े — आप सेटिंग्स से पुनः स्कैन चला सकते हैं।</string>
+    <string name="external_import_completion_action_view_all">सभी देखें</string>
+    <string name="external_import_empty_all_matched">सब लिंक हो गया।\\nलिंक करने के लिए कुछ नहीं।</string>
+    <string name="external_import_empty_done">हो गया</string>
+    <string name="external_import_empty_no_apps_title">इस डिवाइस पर कोई GitHub ऐप नहीं मिला।</string>
+    <string name="external_import_empty_no_apps_body">इसका मतलब है कि सब किसी और स्टोर से इंस्टॉल हुआ, या हमें इंस्टॉल ऐप्स की जानकारी नहीं मिल पाई।</string>
+    <string name="external_import_empty_grant_permission">अनुमति दें</string>
+    <string name="external_import_empty_ok">ठीक है</string>
+    <string name="external_import_empty_add_manually">किसी और स्टोर से ऐप जोड़ें</string>
+    <string name="external_import_permission_title">अपने GitHub ऐप्स खोजें</string>
+    <string name="external_import_permission_body">हम आपके इंस्टॉल ऐप्स स्कैन करके GitHub रिलीज़ से मिला सकते हैं, ताकि अपडेट और पहचान अपने आप काम करे।\\n\\nइसके लिए हमें देखना होगा कि आपके पास कौन से ऐप्स हैं। अनुमति के बिना हम केवल लगभग 5 ऐप्स देख सकते हैं; अनुमति के साथ सभी देख सकते हैं।\\n\\nहम आपकी अनुमति के बिना आपके ऐप्स की सूची कहीं नहीं भेजते। मिलान आपके डिवाइस पर होता है। वैकल्पिक सर्वर लुकअप केवल पैकेज नाम और ऐप लेबल भेजता है, और उपलब्ध होने पर साइनिंग फिंगरप्रिंट, इंस्टॉल स्रोत और ऐप के मैनिफेस्ट में घोषित GitHub रिपो संकेत भी — कभी भी इंस्टॉल की पूरी सूची नहीं।</string>
+    <string name="external_import_permission_continue">जारी रखें</string>
+    <string name="external_import_permission_not_now">अभी नहीं</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">GitHub से %1$d ऐप मिला</item>
+        <item quantity="other">GitHub से %1$d ऐप मिले</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">यहाँ अपडेट ट्रैक करने के लिए समीक्षा करें।</string>
+    <string name="external_import_proposal_banner_review">समीक्षा करें</string>
+    <string name="external_import_proposal_banner_dismiss">हटाएं</string>
+    <string name="external_import_match_confidence_a11y">मिलान विश्वास: %1$d प्रतिशत</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">इस ऐप को लिंक नहीं किया जा सका — फिर कोशिश करें।</string>
+    <string name="external_import_error_link_network">GitHub तक नहीं पहुंचा जा सका। बाद में फिर कोशिश करें।</string>
+    <string name="external_import_error_scan_failed_default">स्कैन विफल</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">ब्राउज़र</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">अज्ञात स्रोत</string>
+    <string name="external_import_undo_linked">%1$s लिंक किया गया।</string>
+    <string name="external_import_undo_skipped">%1$s छोड़ा गया।</string>
+    <string name="external_import_undo_action">पूर्ववत करें</string>
+    <string name="external_import_undo_failed">पूर्ववत नहीं हो सका — फिर कोशिश करें।</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d ऐप समीक्षा के लिए</item>
+        <item quantity="other">%1$d ऐप समीक्षा के लिए</item>
+    </plurals>
+    <string name="external_import_list_add_manually">अपना ऐप नहीं दिख रहा? मैन्युअली जोड़ें</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d ऐप स्वचालित रूप से लिंक किया गया</item>
+        <item quantity="other">%1$d ऐप स्वचालित रूप से लिंक किए गए</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">हमने उन्हें उच्च विश्वास के साथ पहचाना। आप प्रत्येक ऐप की जानकारी से व्यक्तिगत मेल पूर्ववत कर सकते हैं, या अभी सभी पूर्ववत कर सकते हैं।</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d और को आपके इनपुट की ज़रूरत है।</item>
+        <item quantity="other">%1$d और को आपके इनपुट की ज़रूरत है।</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">जारी रखें</string>
+    <string name="external_import_auto_summary_undo_all">सब पूर्ववत करें</string>
+    <string name="external_import_auto_summary_more_count">+%1$d और</string>
+    <string name="external_import_rescan_menu">GitHub ऐप्स स्कैन करें</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">इस रिपो से अनलिंक करें</string>
+    <string name="details_unlink_external_app_more_options">अधिक विकल्प</string>
+    <string name="details_unlink_external_app_dialog_title">इस ऐप को अनलिंक करें?</string>
+    <string name="details_unlink_external_app_dialog_body">हम %1$s को इस रिपो से इंस्टॉल के रूप में ट्रैक करना बंद कर देंगे। ऐप आपके डिवाइस पर रहेगा — केवल लिंक हटाया जाएगा।</string>
+    <string name="details_unlink_external_app_dialog_confirm">अनलिंक करें</string>
+    <string name="details_unlink_external_app_success">अनलिंक हो गया। अगले स्कैन में हम फिर से मेल सुझाएंगे।</string>
+    <string name="details_unlink_external_app_failure">अनलिंक नहीं हो सका — फिर कोशिश करें।</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">फ़ीडबैक भेजें</string>
+    <string name="feedback_title">फ़ीडबैक भेजें</string>
+    <string name="feedback_close">बंद करें</string>
+    <string name="feedback_category_label">श्रेणी</string>
+    <string name="feedback_category_bug">बग</string>
+    <string name="feedback_category_feature">फीचर अनुरोध</string>
+    <string name="feedback_category_change">बदलाव अनुरोध</string>
+    <string name="feedback_category_other">अन्य</string>
+    <string name="feedback_topic_label">विषय</string>
+    <string name="feedback_topic_install_update">इंस्टॉल / अपडेट</string>
+    <string name="feedback_topic_search">खोज &amp; खोज</string>
+    <string name="feedback_topic_details">रिपो विवरण</string>
+    <string name="feedback_topic_auth">प्रमाणीकरण &amp; खाता</string>
+    <string name="feedback_topic_ui">UI / UX</string>
+    <string name="feedback_topic_translation">अनुवाद / भाषा</string>
+    <string name="feedback_topic_performance">प्रदर्शन</string>
+    <string name="feedback_topic_other">अन्य</string>
+    <string name="feedback_field_title">शीर्षक</string>
+    <string name="feedback_field_description">विवरण</string>
+    <string name="feedback_field_steps">पुनः उत्पन्न करने के चरण</string>
+    <string name="feedback_field_expected_actual">अपेक्षित बनाम वास्तविक</string>
+    <string name="feedback_field_use_case">उपयोग का मामला</string>
+    <string name="feedback_field_proposed_solution">प्रस्तावित समाधान</string>
+    <string name="feedback_field_current_behaviour">वर्तमान व्यवहार</string>
+    <string name="feedback_field_desired_behaviour">वांछित व्यवहार</string>
+    <string name="feedback_diagnostics_header">निदान</string>
+    <string name="feedback_diagnostics_include">निदान शामिल करें</string>
+    <string name="feedback_send_via_email">ईमेल भेजें</string>
+    <string name="feedback_send_via_github">GitHub Issue के रूप में खोलें</string>
+    <string name="feedback_send_success_email">धन्यवाद — आपका मेल क्लाइंट खुल रहा है।</string>
+    <string name="feedback_send_success_github">धन्यवाद — आपका ब्राउज़र खुल रहा है।</string>
+    <string name="feedback_send_error">फ़ीडबैक चैनल नहीं खुल सका: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">डाउनलोड मिरर</string>
+    <string name="mirror_picker_title">डाउनलोड मिरर</string>
+    <string name="mirror_picker_description">रिलीज़ फ़ाइलें डाउनलोड करने के लिए उपयोग किया जाता है। GitHub API कॉल हमेशा सीधे जाते हैं। अधिकांश उपयोगकर्ताओं को इसे Direct GitHub पर छोड़ देना चाहिए।</string>
+    <string name="mirror_section_official">आधिकारिक</string>
+    <string name="mirror_section_community">समुदाय</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(बंद)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">कस्टम मिरर…</string>
+    <string name="mirror_custom_dialog_title">कस्टम मिरर</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">टेम्पलेट https:// से शुरू होना चाहिए</string>
+    <string name="mirror_custom_validation_template">टेम्पलेट में {url} ठीक एक बार होना चाहिए</string>
+    <string name="mirror_custom_save">सहेजें</string>
+    <string name="mirror_test_button">चुने को टेस्ट करें</string>
+    <string name="mirror_test_in_progress">परीक्षण चल रहा है…</string>
+    <string name="mirror_test_success">%1$dms में पहुंचा</string>
+    <string name="mirror_test_http_error">मिरर ने %1$d लौटाया</string>
+    <string name="mirror_test_timeout">5s बाद टाइमआउट</string>
+    <string name="mirror_test_dns_fail">होस्ट हल नहीं हो सका</string>
+    <string name="mirror_test_other">विफल: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">सभी मिरर बंद हैं? आप 5 मिनट में अपना खुद का होस्ट कर सकते हैं — दस्तावेज़ देखें।</string>
+    <string name="mirror_removed_toast">%1$s अब उपलब्ध नहीं है, Direct GitHub पर स्विच किया गया।</string>
+    <string name="mirror_digest_mismatch_error">चेकसम मेल नहीं — फ़ाइल से छेड़छाड़ हो सकती है</string>
+    <string name="mirror_auto_suggest_title">तेज़ मिरर आज़माएं?</string>
+    <string name="mirror_auto_suggest_body">धीमे नेटवर्क पर कुछ उपयोगकर्ताओं को कम्युनिटी प्रॉक्सी से बेहतर परिणाम मिलते हैं।</string>
+    <string name="mirror_auto_suggest_pick_one">एक चुनें</string>
+    <string name="mirror_auto_suggest_maybe_later">शायद बाद में</string>
+    <string name="mirror_auto_suggest_dont_ask_again">दोबारा न पूछें</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -801,7 +801,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d saltate — puoi ripetere la scansione dalle Impostazioni.</string>
     <string name="external_import_completion_action_view_all">Vedi tutte</string>
-    <string name="external_import_empty_all_matched">Tutto collegato.\\nNiente da collegare.</string>
+    <string name="external_import_empty_all_matched">Tutto collegato.\nNiente da collegare.</string>
     <string name="external_import_empty_done">Fatto</string>
     <string name="external_import_empty_no_apps_title">Nessuna app GitHub trovata su questo dispositivo.</string>
     <string name="external_import_empty_no_apps_body">Significa che tutto è stato installato tramite un altro store, oppure che non abbiamo visibilità su ciò che è installato.</string>
@@ -809,7 +809,7 @@
     <string name="external_import_empty_ok">OK</string>
     <string name="external_import_empty_add_manually">Aggiungi un\'app da un altro store</string>
     <string name="external_import_permission_title">Trova le tue app GitHub</string>
-    <string name="external_import_permission_body">Possiamo analizzare le app installate e abbinarle alle release di GitHub, così gli aggiornamenti e il rilevamento funzionano automaticamente.\\n\\nPer farlo, dobbiamo sapere quali app hai. Senza permesso possiamo vedere solo circa 5 app; con il permesso le vediamo tutte.\\n\\nNon inviamo mai l\'elenco delle tue app senza il tuo consenso. L\'abbinamento avviene sul tuo dispositivo. La ricerca opzionale sul server invia solo il nome del pacchetto e l\'etichetta dell\'app, e quando disponibili, l\'impronta della firma, la fonte di installazione e qualsiasi riferimento al repository GitHub dichiarato nel manifest dell\'app — mai l\'elenco completo di ciò che è installato.</string>
+    <string name="external_import_permission_body">Possiamo analizzare le app installate e abbinarle alle release di GitHub, così gli aggiornamenti e il rilevamento funzionano automaticamente.\n\nPer farlo, dobbiamo sapere quali app hai. Senza permesso possiamo vedere solo circa 5 app; con il permesso le vediamo tutte.\n\nNon inviamo mai l\'elenco delle tue app senza il tuo consenso. L\'abbinamento avviene sul tuo dispositivo. La ricerca opzionale sul server invia solo il nome del pacchetto e l\'etichetta dell\'app, e quando disponibili, l\'impronta della firma, la fonte di installazione e qualsiasi riferimento al repository GitHub dichiarato nel manifest dell\'app — mai l\'elenco completo di ciò che è installato.</string>
     <string name="external_import_permission_continue">Continua</string>
     <string name="external_import_permission_not_now">Non ora</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -764,7 +764,7 @@
     <string name="action_switch_to_stable">Passa a %1$s stabile</string>
     <string name="stalled_project_warning_months">Nessuna versione stabile da %1$d mesi</string>
     <string name="stalled_project_warning_days">Nessuna versione stabile da %1$d giorni</string>
-    <string name="stalled_project_warning_description">Ci sono pre-release attive, ma il progetto non ha pubblicato una build stabile da un po\'. Le versioni beta potrebbero non convergere a un rilascio stabile.</string>
+    <string name="stalled_project_warning_description">Ci sono pre-release attive, ma il progetto non ha pubblicato una build stabile da un po'. Le versioni beta potrebbero non convergere a un rilascio stabile.</string>
     <string name="merged_whats_changed_title">Novità da %1$s</string>
     <string name="merged_release_heading">— %1$s —</string>
 
@@ -807,9 +807,9 @@
     <string name="external_import_empty_no_apps_body">Significa che tutto è stato installato tramite un altro store, oppure che non abbiamo visibilità su ciò che è installato.</string>
     <string name="external_import_empty_grant_permission">Concedi permesso</string>
     <string name="external_import_empty_ok">OK</string>
-    <string name="external_import_empty_add_manually">Aggiungi un\'app da un altro store</string>
+    <string name="external_import_empty_add_manually">Aggiungi un'app da un altro store</string>
     <string name="external_import_permission_title">Trova le tue app GitHub</string>
-    <string name="external_import_permission_body">Possiamo analizzare le app installate e abbinarle alle release di GitHub, così gli aggiornamenti e il rilevamento funzionano automaticamente.\n\nPer farlo, dobbiamo sapere quali app hai. Senza permesso possiamo vedere solo circa 5 app; con il permesso le vediamo tutte.\n\nNon inviamo mai l\'elenco delle tue app senza il tuo consenso. L\'abbinamento avviene sul tuo dispositivo. La ricerca opzionale sul server invia solo il nome del pacchetto e l\'etichetta dell\'app, e quando disponibili, l\'impronta della firma, la fonte di installazione e qualsiasi riferimento al repository GitHub dichiarato nel manifest dell\'app — mai l\'elenco completo di ciò che è installato.</string>
+    <string name="external_import_permission_body">Possiamo analizzare le app installate e abbinarle alle release di GitHub, così gli aggiornamenti e il rilevamento funzionano automaticamente.\n\nPer farlo, dobbiamo sapere quali app hai. Senza permesso possiamo vedere solo circa 5 app; con il permesso le vediamo tutte.\n\nNon inviamo mai l'elenco delle tue app senza il tuo consenso. L'abbinamento avviene sul tuo dispositivo. La ricerca opzionale sul server invia solo il nome del pacchetto e l'etichetta dell'app, e quando disponibili, l'impronta della firma, la fonte di installazione e qualsiasi riferimento al repository GitHub dichiarato nel manifest dell'app — mai l'elenco completo di ciò che è installato.</string>
     <string name="external_import_permission_continue">Continua</string>
     <string name="external_import_permission_not_now">Non ora</string>
     <plurals name="external_import_proposal_banner_headline">
@@ -859,7 +859,7 @@
     <string name="details_unlink_external_app_menu">Scollega da questo repository</string>
     <string name="details_unlink_external_app_more_options">Altre opzioni</string>
     <string name="details_unlink_external_app_dialog_title">Scollegare questa app?</string>
-    <string name="details_unlink_external_app_dialog_body">Smetteremo di tracciare %1$s come installata da questo repository. L\'app rimane sul dispositivo — viene rimosso solo il collegamento.</string>
+    <string name="details_unlink_external_app_dialog_body">Smetteremo di tracciare %1$s come installata da questo repository. L'app rimane sul dispositivo — viene rimosso solo il collegamento.</string>
     <string name="details_unlink_external_app_dialog_confirm">Scollega</string>
     <string name="details_unlink_external_app_success">Scollegata. Proporremo una corrispondenza alla prossima scansione.</string>
     <string name="details_unlink_external_app_failure">Impossibile scollegare — riprova.</string>
@@ -888,7 +888,7 @@
     <string name="feedback_field_description">Descrizione</string>
     <string name="feedback_field_steps">Passaggi per riprodurre</string>
     <string name="feedback_field_expected_actual">Atteso vs effettivo</string>
-    <string name="feedback_field_use_case">Caso d\'uso</string>
+    <string name="feedback_field_use_case">Caso d'uso</string>
     <string name="feedback_field_proposed_solution">Soluzione proposta</string>
     <string name="feedback_field_current_behaviour">Comportamento attuale</string>
     <string name="feedback_field_desired_behaviour">Comportamento desiderato</string>
@@ -923,7 +923,7 @@
     <string name="mirror_test_success">Raggiunto in %1$dms</string>
     <string name="mirror_test_http_error">Il mirror ha restituito %1$d</string>
     <string name="mirror_test_timeout">Timeout dopo 5s</string>
-    <string name="mirror_test_dns_fail">Impossibile risolvere l\'host</string>
+    <string name="mirror_test_dns_fail">Impossibile risolvere l'host</string>
     <string name="mirror_test_other">Errore: %1$s</string>
     <string name="mirror_deploy_your_own_hint">Tutti i mirror non disponibili? Puoi ospitarne uno tuo in 5 minuti — consulta la documentazione.</string>
     <string name="mirror_removed_toast">%1$s non è più disponibile, passato a GitHub diretto.</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -787,7 +787,7 @@
     <string name="external_import_card_action_more">Altre corrispondenze</string>
     <string name="external_import_card_action_less">Nascondi corrispondenze</string>
     <string name="external_import_card_installer_chip">Installata tramite %1$s</string>
-    <string name="external_import_card_preselect_known">Pensiamo sia %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Pensiamo sia %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Tocca per trovare un repository</string>
     <string name="external_import_card_expand_label">Espandi per vedere altre corrispondenze</string>
     <string name="external_import_card_collapse_label">Comprimi scheda</string>
@@ -820,7 +820,7 @@
     <string name="external_import_proposal_banner_review">Esamina</string>
     <string name="external_import_proposal_banner_dismiss">Ignora</string>
     <string name="external_import_match_confidence_a11y">Confidenza di corrispondenza: %1$d percento</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Impossibile collegare questa app — riprova.</string>
     <string name="external_import_error_link_network">Impossibile raggiungere GitHub. Riprova più tardi.</string>
     <string name="external_import_error_scan_failed_default">Scansione non riuscita</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -747,4 +747,191 @@
     <string name="pat_error_bad_credentials">Questo token non è valido o è stato revocato.</string>
     <string name="pat_error_insufficient_scope">Questo token non ha le autorizzazioni richieste.</string>
     <string name="pat_error_generic">Impossibile salvare il token. Riprova.</string>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E10 — Apps sort
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Ordina app</string>
+    <string name="sort_updates_first">Aggiornamenti prima</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Includi beta</string>
+    <string name="channel_chip_stable_only">Solo stabile</string>
+    <string name="channel_toggle_cd">Attiva/disattiva le versioni beta per questa app</string>
+    <string name="action_switch_to_stable">Passa a %1$s stabile</string>
+    <string name="stalled_project_warning_months">Nessuna versione stabile da %1$d mesi</string>
+    <string name="stalled_project_warning_days">Nessuna versione stabile da %1$d giorni</string>
+    <string name="stalled_project_warning_description">Ci sono pre-release attive, ma il progetto non ha pubblicato una build stabile da un po\'. Le versioni beta potrebbero non convergere a un rilascio stabile.</string>
+    <string name="merged_whats_changed_title">Novità da %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Importa le app installate</string>
+    <string name="external_import_top_bar_back">Indietro</string>
+    <string name="external_import_overflow_more">Altre opzioni</string>
+    <string name="external_import_overflow_skip_remaining">Salta i restanti</string>
+    <string name="external_import_progress_scanning">Scansione delle app in corso…</string>
+    <string name="external_import_progress_auto_importing">Importazione delle corrispondenze…</string>
+    <string name="external_import_progress_working">Elaborazione…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">Esaminata %1$d app</item>
+        <item quantity="other">Esaminate %1$d app</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Salta</string>
+    <string name="external_import_card_action_link">Collega</string>
+    <string name="external_import_card_action_more">Altre corrispondenze</string>
+    <string name="external_import_card_action_less">Nascondi corrispondenze</string>
+    <string name="external_import_card_installer_chip">Installata tramite %1$s</string>
+    <string name="external_import_card_preselect_known">Pensiamo sia %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Tocca per trovare un repository</string>
+    <string name="external_import_card_expand_label">Espandi per vedere altre corrispondenze</string>
+    <string name="external_import_card_collapse_label">Comprimi scheda</string>
+    <string name="external_import_search_icon_label">Cerca su GitHub</string>
+    <string name="external_import_search_empty">Nessuna corrispondenza</string>
+    <string name="external_import_search_error_default">Ricerca non riuscita</string>
+    <string name="external_import_search_placeholder_url">Incolla un URL di github.com o cerca…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">Ora tracciata %1$d app.</item>
+        <item quantity="other">Ora tracciate %1$d app.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d saltate — puoi ripetere la scansione dalle Impostazioni.</string>
+    <string name="external_import_completion_action_view_all">Vedi tutte</string>
+    <string name="external_import_empty_all_matched">Tutto collegato.\\nNiente da collegare.</string>
+    <string name="external_import_empty_done">Fatto</string>
+    <string name="external_import_empty_no_apps_title">Nessuna app GitHub trovata su questo dispositivo.</string>
+    <string name="external_import_empty_no_apps_body">Significa che tutto è stato installato tramite un altro store, oppure che non abbiamo visibilità su ciò che è installato.</string>
+    <string name="external_import_empty_grant_permission">Concedi permesso</string>
+    <string name="external_import_empty_ok">OK</string>
+    <string name="external_import_empty_add_manually">Aggiungi un\'app da un altro store</string>
+    <string name="external_import_permission_title">Trova le tue app GitHub</string>
+    <string name="external_import_permission_body">Possiamo analizzare le app installate e abbinarle alle release di GitHub, così gli aggiornamenti e il rilevamento funzionano automaticamente.\\n\\nPer farlo, dobbiamo sapere quali app hai. Senza permesso possiamo vedere solo circa 5 app; con il permesso le vediamo tutte.\\n\\nNon inviamo mai l\'elenco delle tue app senza il tuo consenso. L\'abbinamento avviene sul tuo dispositivo. La ricerca opzionale sul server invia solo il nome del pacchetto e l\'etichetta dell\'app, e quando disponibili, l\'impronta della firma, la fonte di installazione e qualsiasi riferimento al repository GitHub dichiarato nel manifest dell\'app — mai l\'elenco completo di ciò che è installato.</string>
+    <string name="external_import_permission_continue">Continua</string>
+    <string name="external_import_permission_not_now">Non ora</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">Trovata %1$d app da GitHub</item>
+        <item quantity="other">Trovate %1$d app da GitHub</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Esaminale per tracciare gli aggiornamenti qui.</string>
+    <string name="external_import_proposal_banner_review">Esamina</string>
+    <string name="external_import_proposal_banner_dismiss">Ignora</string>
+    <string name="external_import_match_confidence_a11y">Confidenza di corrispondenza: %1$d percento</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">Impossibile collegare questa app — riprova.</string>
+    <string name="external_import_error_link_network">Impossibile raggiungere GitHub. Riprova più tardi.</string>
+    <string name="external_import_error_scan_failed_default">Scansione non riuscita</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Browser</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Fonte sconosciuta</string>
+    <string name="external_import_undo_linked">%1$s collegata.</string>
+    <string name="external_import_undo_skipped">%1$s saltata.</string>
+    <string name="external_import_undo_action">Annulla</string>
+    <string name="external_import_undo_failed">Impossibile annullare — riprova.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d app da esaminare</item>
+        <item quantity="other">%1$d app da esaminare</item>
+    </plurals>
+    <string name="external_import_list_add_manually">Non vedi la tua app? Aggiungi manualmente</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d app collegata automaticamente</item>
+        <item quantity="other">%1$d app collegate automaticamente</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Le abbiamo riconosciute con alta confidenza. Puoi annullare le corrispondenze singole dai dettagli di ciascuna app, oppure annullarle tutte ora.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d altra richiede la tua attenzione.</item>
+        <item quantity="other">%1$d altre richiedono la tua attenzione.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Continua</string>
+    <string name="external_import_auto_summary_undo_all">Annulla tutto</string>
+    <string name="external_import_auto_summary_more_count">+%1$d altre</string>
+    <string name="external_import_rescan_menu">Cerca app GitHub</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Scollega da questo repository</string>
+    <string name="details_unlink_external_app_more_options">Altre opzioni</string>
+    <string name="details_unlink_external_app_dialog_title">Scollegare questa app?</string>
+    <string name="details_unlink_external_app_dialog_body">Smetteremo di tracciare %1$s come installata da questo repository. L\'app rimane sul dispositivo — viene rimosso solo il collegamento.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Scollega</string>
+    <string name="details_unlink_external_app_success">Scollegata. Proporremo una corrispondenza alla prossima scansione.</string>
+    <string name="details_unlink_external_app_failure">Impossibile scollegare — riprova.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Invia feedback</string>
+    <string name="feedback_title">Invia feedback</string>
+    <string name="feedback_close">Chiudi</string>
+    <string name="feedback_category_label">Categoria</string>
+    <string name="feedback_category_bug">Bug</string>
+    <string name="feedback_category_feature">Richiesta funzionalità</string>
+    <string name="feedback_category_change">Richiesta di modifica</string>
+    <string name="feedback_category_other">Altro</string>
+    <string name="feedback_topic_label">Argomento</string>
+    <string name="feedback_topic_install_update">Installazione / Aggiornamento</string>
+    <string name="feedback_topic_search">Ricerca &amp; Scoperta</string>
+    <string name="feedback_topic_details">Dettagli repository</string>
+    <string name="feedback_topic_auth">Auth &amp; Account</string>
+    <string name="feedback_topic_ui">Interfaccia / UX</string>
+    <string name="feedback_topic_translation">Traduzione / Lingua</string>
+    <string name="feedback_topic_performance">Prestazioni</string>
+    <string name="feedback_topic_other">Altro</string>
+    <string name="feedback_field_title">Titolo</string>
+    <string name="feedback_field_description">Descrizione</string>
+    <string name="feedback_field_steps">Passaggi per riprodurre</string>
+    <string name="feedback_field_expected_actual">Atteso vs effettivo</string>
+    <string name="feedback_field_use_case">Caso d\'uso</string>
+    <string name="feedback_field_proposed_solution">Soluzione proposta</string>
+    <string name="feedback_field_current_behaviour">Comportamento attuale</string>
+    <string name="feedback_field_desired_behaviour">Comportamento desiderato</string>
+    <string name="feedback_diagnostics_header">Diagnostica</string>
+    <string name="feedback_diagnostics_include">Includi diagnostica</string>
+    <string name="feedback_send_via_email">Invia per e-mail</string>
+    <string name="feedback_send_via_github">Apri come Issue GitHub</string>
+    <string name="feedback_send_success_email">Grazie — apertura del client di posta.</string>
+    <string name="feedback_send_success_github">Grazie — apertura del browser.</string>
+    <string name="feedback_send_error">Impossibile aprire il canale di feedback: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">Mirror di download</string>
+    <string name="mirror_picker_title">Mirror di download</string>
+    <string name="mirror_picker_description">Utilizzato per scaricare i file delle release. Le chiamate API di GitHub passano sempre in modo diretto. La maggior parte degli utenti dovrebbe lasciare questa impostazione su GitHub diretto.</string>
+    <string name="mirror_section_official">Ufficiale</string>
+    <string name="mirror_section_community">Comunità</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(non disponibile)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Mirror personalizzato…</string>
+    <string name="mirror_custom_dialog_title">Mirror personalizzato</string>
+    <string name="mirror_custom_dialog_hint">https://tuo-mirror.esempio/{url}</string>
+    <string name="mirror_custom_validation_https">Il modello deve iniziare con https://</string>
+    <string name="mirror_custom_validation_template">Il modello deve contenere {url} esattamente una volta</string>
+    <string name="mirror_custom_save">Salva</string>
+    <string name="mirror_test_button">Testa selezionato</string>
+    <string name="mirror_test_in_progress">Test in corso…</string>
+    <string name="mirror_test_success">Raggiunto in %1$dms</string>
+    <string name="mirror_test_http_error">Il mirror ha restituito %1$d</string>
+    <string name="mirror_test_timeout">Timeout dopo 5s</string>
+    <string name="mirror_test_dns_fail">Impossibile risolvere l\'host</string>
+    <string name="mirror_test_other">Errore: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">Tutti i mirror non disponibili? Puoi ospitarne uno tuo in 5 minuti — consulta la documentazione.</string>
+    <string name="mirror_removed_toast">%1$s non è più disponibile, passato a GitHub diretto.</string>
+    <string name="mirror_digest_mismatch_error">Checksum non corrispondente — il file potrebbe essere stato manomesso</string>
+    <string name="mirror_auto_suggest_title">Provare un mirror più veloce?</string>
+    <string name="mirror_auto_suggest_body">Alcuni utenti con connessioni lente hanno risultati migliori con un proxy della comunità.</string>
+    <string name="mirror_auto_suggest_pick_one">Scegli uno</string>
+    <string name="mirror_auto_suggest_maybe_later">Forse più tardi</string>
+    <string name="mirror_auto_suggest_dont_ask_again">Non chiedere di nuovo</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -760,7 +760,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d 件をスキップ — 設定から再スキャンできます。</string>
     <string name="external_import_completion_action_view_all">すべて表示</string>
-    <string name="external_import_empty_all_matched">すべてリンク済みです。\\nリンクするものはありません。</string>
+    <string name="external_import_empty_all_matched">すべてリンク済みです。\nリンクするものはありません。</string>
     <string name="external_import_empty_done">完了</string>
     <string name="external_import_empty_no_apps_title">このデバイスに GitHub アプリが見つかりませんでした。</string>
     <string name="external_import_empty_no_apps_body">すべて別のストアからインストールされたか、インストール済みアプリへのアクセス権がないためです。</string>
@@ -768,7 +768,7 @@
     <string name="external_import_empty_ok">OK</string>
     <string name="external_import_empty_add_manually">別のストアからアプリを追加</string>
     <string name="external_import_permission_title">GitHub アプリを見つける</string>
-    <string name="external_import_permission_body">インストール済みのアプリをスキャンして GitHub のリリースと照合できます。これにより、アップデートの検出が自動的に機能します。\\n\\nそのためには、インストールされているアプリを確認する必要があります。権限なしでは約 5 個のアプリしか確認できません。権限があればすべて確認できます。\\n\\nあなたの許可なくアプリのリストをどこかに送信することはありません。照合はデバイス上で行われます。任意のサーバー検索では、パッケージ名とアプリラベルのみを送信し、利用可能な場合は署名フィンガープリント、インストール元、アプリのマニフェストで宣言された GitHub リポジトリのヒントも送信しますが、インストール済みアプリの完全なリストは一切送信しません。</string>
+    <string name="external_import_permission_body">インストール済みのアプリをスキャンして GitHub のリリースと照合できます。これにより、アップデートの検出が自動的に機能します。\n\nそのためには、インストールされているアプリを確認する必要があります。権限なしでは約 5 個のアプリしか確認できません。権限があればすべて確認できます。\n\nあなたの許可なくアプリのリストをどこかに送信することはありません。照合はデバイス上で行われます。任意のサーバー検索では、パッケージ名とアプリラベルのみを送信し、利用可能な場合は署名フィンガープリント、インストール元、アプリのマニフェストで宣言された GitHub リポジトリのヒントも送信しますが、インストール済みアプリの完全なリストは一切送信しません。</string>
     <string name="external_import_permission_continue">続行</string>
     <string name="external_import_permission_not_now">後で</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -747,7 +747,7 @@
     <string name="external_import_card_action_more">他の一致を表示</string>
     <string name="external_import_card_action_less">一致を非表示</string>
     <string name="external_import_card_installer_chip">%1$s 経由でインストール</string>
-    <string name="external_import_card_preselect_known">おそらく %1$s です · %2$d%%</string>
+    <string name="external_import_card_preselect_known">おそらく %1$s です · %2$d</string>
     <string name="external_import_card_preselect_unknown">リポジトリを検索するにはタップ</string>
     <string name="external_import_card_expand_label">展開して他の一致を表示</string>
     <string name="external_import_card_collapse_label">カードを折りたたむ</string>
@@ -778,7 +778,7 @@
     <string name="external_import_proposal_banner_review">確認</string>
     <string name="external_import_proposal_banner_dismiss">閉じる</string>
     <string name="external_import_match_confidence_a11y">一致の信頼度: %1$d パーセント</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">このアプリをリンクできませんでした — もう一度お試しください。</string>
     <string name="external_import_error_link_network">GitHub に接続できませんでした。後でもう一度お試しください。</string>
     <string name="external_import_error_scan_failed_default">スキャンに失敗しました</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -708,4 +708,185 @@
     <string name="pat_error_bad_credentials">このトークンは無効か、取り消されています。</string>
     <string name="pat_error_insufficient_scope">このトークンには必要な権限がありません。</string>
     <string name="pat_error_generic">トークンを保存できませんでした。もう一度お試しください。</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+     E10 — Apps sort
+     ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">アプリを並べ替え</string>
+    <string name="sort_updates_first">アップデートを優先</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">ベータを含む</string>
+    <string name="channel_chip_stable_only">安定版のみ</string>
+    <string name="channel_toggle_cd">このアプリのベータリリースを切り替え</string>
+    <string name="action_switch_to_stable">%1$s の安定版に切り替え</string>
+    <string name="stalled_project_warning_months">%1$d か月間、安定版リリースなし</string>
+    <string name="stalled_project_warning_days">%1$d 日間、安定版リリースなし</string>
+    <string name="stalled_project_warning_description">プレリリースは活発ですが、プロジェクトはしばらく安定版をリリースしていません。ベータ版が安定版リリースに至らない可能性があります。</string>
+    <string name="merged_whats_changed_title">%1$s 以降の変更点</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">インストール済みアプリをインポート</string>
+    <string name="external_import_top_bar_back">戻る</string>
+    <string name="external_import_overflow_more">その他のオプション</string>
+    <string name="external_import_overflow_skip_remaining">残りをスキップ</string>
+    <string name="external_import_progress_scanning">アプリをスキャン中…</string>
+    <string name="external_import_progress_auto_importing">一致をインポート中…</string>
+    <string name="external_import_progress_working">処理中…</string>
+    <!-- Japanese uses "other" only -->
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="other">%1$d 個のアプリを確認済み</item>
+    </plurals>
+    <string name="external_import_card_action_skip">スキップ</string>
+    <string name="external_import_card_action_link">リンク</string>
+    <string name="external_import_card_action_more">他の一致を表示</string>
+    <string name="external_import_card_action_less">一致を非表示</string>
+    <string name="external_import_card_installer_chip">%1$s 経由でインストール</string>
+    <string name="external_import_card_preselect_known">おそらく %1$s です · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">リポジトリを検索するにはタップ</string>
+    <string name="external_import_card_expand_label">展開して他の一致を表示</string>
+    <string name="external_import_card_collapse_label">カードを折りたたむ</string>
+    <string name="external_import_search_icon_label">GitHub を検索</string>
+    <string name="external_import_search_empty">一致なし</string>
+    <string name="external_import_search_error_default">検索に失敗しました</string>
+    <string name="external_import_search_placeholder_url">github.com の URL を貼り付けるか検索…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="other">%1$d 個のアプリを追跡中。</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d 件をスキップ — 設定から再スキャンできます。</string>
+    <string name="external_import_completion_action_view_all">すべて表示</string>
+    <string name="external_import_empty_all_matched">すべてリンク済みです。\\nリンクするものはありません。</string>
+    <string name="external_import_empty_done">完了</string>
+    <string name="external_import_empty_no_apps_title">このデバイスに GitHub アプリが見つかりませんでした。</string>
+    <string name="external_import_empty_no_apps_body">すべて別のストアからインストールされたか、インストール済みアプリへのアクセス権がないためです。</string>
+    <string name="external_import_empty_grant_permission">権限を付与</string>
+    <string name="external_import_empty_ok">OK</string>
+    <string name="external_import_empty_add_manually">別のストアからアプリを追加</string>
+    <string name="external_import_permission_title">GitHub アプリを見つける</string>
+    <string name="external_import_permission_body">インストール済みのアプリをスキャンして GitHub のリリースと照合できます。これにより、アップデートの検出が自動的に機能します。\\n\\nそのためには、インストールされているアプリを確認する必要があります。権限なしでは約 5 個のアプリしか確認できません。権限があればすべて確認できます。\\n\\nあなたの許可なくアプリのリストをどこかに送信することはありません。照合はデバイス上で行われます。任意のサーバー検索では、パッケージ名とアプリラベルのみを送信し、利用可能な場合は署名フィンガープリント、インストール元、アプリのマニフェストで宣言された GitHub リポジトリのヒントも送信しますが、インストール済みアプリの完全なリストは一切送信しません。</string>
+    <string name="external_import_permission_continue">続行</string>
+    <string name="external_import_permission_not_now">後で</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="other">GitHub から %1$d 個のアプリが見つかりました</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">確認してここでアップデートを追跡しましょう。</string>
+    <string name="external_import_proposal_banner_review">確認</string>
+    <string name="external_import_proposal_banner_dismiss">閉じる</string>
+    <string name="external_import_match_confidence_a11y">一致の信頼度: %1$d パーセント</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">このアプリをリンクできませんでした — もう一度お試しください。</string>
+    <string name="external_import_error_link_network">GitHub に接続できませんでした。後でもう一度お試しください。</string>
+    <string name="external_import_error_scan_failed_default">スキャンに失敗しました</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">ブラウザ</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">不明なソース</string>
+    <string name="external_import_undo_linked">%1$s をリンクしました。</string>
+    <string name="external_import_undo_skipped">%1$s をスキップしました。</string>
+    <string name="external_import_undo_action">元に戻す</string>
+    <string name="external_import_undo_failed">元に戻せませんでした — もう一度お試しください。</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="other">確認待ち: %1$d 個のアプリ</item>
+    </plurals>
+    <string name="external_import_list_add_manually">アプリが見当たりませんか？手動で追加</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="other">%1$d 個のアプリを自動的にリンクしました</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">高い信頼度で認識されました。各アプリの詳細から個別に元に戻すか、今すべて元に戻すことができます。</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="other">さらに %1$d 件の確認が必要です。</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">続行</string>
+    <string name="external_import_auto_summary_undo_all">すべて元に戻す</string>
+    <string name="external_import_auto_summary_more_count">+%1$d 件</string>
+    <string name="external_import_rescan_menu">GitHub アプリをスキャン</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">このリポジトリからリンクを解除</string>
+    <string name="details_unlink_external_app_more_options">その他のオプション</string>
+    <string name="details_unlink_external_app_dialog_title">このアプリのリンクを解除しますか？</string>
+    <string name="details_unlink_external_app_dialog_body">このリポジトリからインストールされたものとして %1$s の追跡を停止します。アプリはデバイスに残ります — リンクのみ削除されます。</string>
+    <string name="details_unlink_external_app_dialog_confirm">リンクを解除</string>
+    <string name="details_unlink_external_app_success">リンクを解除しました。次回のスキャンで再度一致候補を提示します。</string>
+    <string name="details_unlink_external_app_failure">リンクを解除できませんでした — もう一度お試しください。</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">フィードバックを送信</string>
+    <string name="feedback_title">フィードバックを送信</string>
+    <string name="feedback_close">閉じる</string>
+    <string name="feedback_category_label">カテゴリ</string>
+    <string name="feedback_category_bug">バグ</string>
+    <string name="feedback_category_feature">機能リクエスト</string>
+    <string name="feedback_category_change">変更リクエスト</string>
+    <string name="feedback_category_other">その他</string>
+    <string name="feedback_topic_label">トピック</string>
+    <string name="feedback_topic_install_update">インストール / アップデート</string>
+    <string name="feedback_topic_search">検索 &amp; 発見</string>
+    <string name="feedback_topic_details">リポジトリの詳細</string>
+    <string name="feedback_topic_auth">認証 &amp; アカウント</string>
+    <string name="feedback_topic_ui">UI / UX</string>
+    <string name="feedback_topic_translation">翻訳 / 言語</string>
+    <string name="feedback_topic_performance">パフォーマンス</string>
+    <string name="feedback_topic_other">その他</string>
+    <string name="feedback_field_title">タイトル</string>
+    <string name="feedback_field_description">説明</string>
+    <string name="feedback_field_steps">再現手順</string>
+    <string name="feedback_field_expected_actual">期待値 vs 実際の動作</string>
+    <string name="feedback_field_use_case">ユースケース</string>
+    <string name="feedback_field_proposed_solution">提案する解決策</string>
+    <string name="feedback_field_current_behaviour">現在の動作</string>
+    <string name="feedback_field_desired_behaviour">望む動作</string>
+    <string name="feedback_diagnostics_header">診断情報</string>
+    <string name="feedback_diagnostics_include">診断情報を含める</string>
+    <string name="feedback_send_via_email">メールで送信</string>
+    <string name="feedback_send_via_github">GitHub Issue として開く</string>
+    <string name="feedback_send_success_email">ありがとうございます — メールクライアントを開いています。</string>
+    <string name="feedback_send_success_github">ありがとうございます — ブラウザを開いています。</string>
+    <string name="feedback_send_error">フィードバックチャンネルを開けませんでした: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">ダウンロードミラー</string>
+    <string name="mirror_picker_title">ダウンロードミラー</string>
+    <string name="mirror_picker_description">リリースアセットのダウンロードに使用されます。GitHub API の呼び出しは常に直接行われます。ほとんどのユーザーは「GitHub 直接」のままにしておくことをお勧めします。</string>
+    <string name="mirror_section_official">公式</string>
+    <string name="mirror_section_community">コミュニティ</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(ダウン)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">カスタムミラー…</string>
+    <string name="mirror_custom_dialog_title">カスタムミラー</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">テンプレートは https:// で始まる必要があります</string>
+    <string name="mirror_custom_validation_template">テンプレートには {url} がちょうど 1 回含まれている必要があります</string>
+    <string name="mirror_custom_save">保存</string>
+    <string name="mirror_test_button">選択したものをテスト</string>
+    <string name="mirror_test_in_progress">テスト中…</string>
+    <string name="mirror_test_success">%1$dms で到達</string>
+    <string name="mirror_test_http_error">ミラーが %1$d を返しました</string>
+    <string name="mirror_test_timeout">5s 後にタイムアウト</string>
+    <string name="mirror_test_dns_fail">ホストを解決できませんでした</string>
+    <string name="mirror_test_other">失敗: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">すべてのミラーが使えない場合は、5 分で自前のミラーをホストできます — ドキュメントをご覧ください。</string>
+    <string name="mirror_removed_toast">%1$s は利用できなくなりました。GitHub 直接に切り替えました。</string>
+    <string name="mirror_digest_mismatch_error">チェックサムが一致しません — ファイルが改ざんされている可能性があります</string>
+    <string name="mirror_auto_suggest_title">より速いミラーを試しますか？</string>
+    <string name="mirror_auto_suggest_body">低速なネットワークを使用している一部のユーザーには、コミュニティプロキシの方が効果的な場合があります。</string>
+    <string name="mirror_auto_suggest_pick_one">選択する</string>
+    <string name="mirror_auto_suggest_maybe_later">後で</string>
+    <string name="mirror_auto_suggest_dont_ask_again">今後表示しない</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -795,7 +795,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d개 건너뜀 — 설정에서 다시 스캔할 수 있습니다.</string>
     <string name="external_import_completion_action_view_all">모두 보기</string>
-    <string name="external_import_empty_all_matched">모두 연결되었습니다.\\n연결할 항목이 없습니다.</string>
+    <string name="external_import_empty_all_matched">모두 연결되었습니다.\n연결할 항목이 없습니다.</string>
     <string name="external_import_empty_done">완료</string>
     <string name="external_import_empty_no_apps_title">이 기기에서 GitHub 앱을 찾을 수 없습니다.</string>
     <string name="external_import_empty_no_apps_body">다른 스토어를 통해 설치되었거나 설치된 앱을 확인할 수 없는 상태입니다.</string>
@@ -803,7 +803,7 @@
     <string name="external_import_empty_ok">확인</string>
     <string name="external_import_empty_add_manually">다른 스토어에서 앱 추가</string>
     <string name="external_import_permission_title">GitHub 앱 찾기</string>
-    <string name="external_import_permission_body">설치된 앱을 스캔하여 GitHub 릴리스와 매칭할 수 있습니다. 이렇게 하면 업데이트 감지가 자동으로 동작합니다.\\n\\n그러려면 어떤 앱이 설치되어 있는지 확인해야 합니다. 권한 없이는 약 5개의 앱만 볼 수 있고, 권한이 있으면 모두 볼 수 있습니다.\\n\\n귀하의 허가 없이 앱 목록을 어디에도 전송하지 않습니다. 매칭은 기기에서 이루어집니다. 선택적 서버 조회는 패키지 이름과 앱 레이블만 전송하며, 사용 가능한 경우 서명 지문, 설치 출처, 앱 매니페스트에 선언된 GitHub 저장소 힌트도 포함합니다. 설치된 앱의 전체 목록은 절대 전송하지 않습니다.</string>
+    <string name="external_import_permission_body">설치된 앱을 스캔하여 GitHub 릴리스와 매칭할 수 있습니다. 이렇게 하면 업데이트 감지가 자동으로 동작합니다.\n\n그러려면 어떤 앱이 설치되어 있는지 확인해야 합니다. 권한 없이는 약 5개의 앱만 볼 수 있고, 권한이 있으면 모두 볼 수 있습니다.\n\n귀하의 허가 없이 앱 목록을 어디에도 전송하지 않습니다. 매칭은 기기에서 이루어집니다. 선택적 서버 조회는 패키지 이름과 앱 레이블만 전송하며, 사용 가능한 경우 서명 지문, 설치 출처, 앱 매니페스트에 선언된 GitHub 저장소 힌트도 포함합니다. 설치된 앱의 전체 목록은 절대 전송하지 않습니다.</string>
     <string name="external_import_permission_continue">계속</string>
     <string name="external_import_permission_not_now">나중에</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -782,7 +782,7 @@
     <string name="external_import_card_action_more">더 많은 일치 항목</string>
     <string name="external_import_card_action_less">일치 항목 숨기기</string>
     <string name="external_import_card_installer_chip">%1$s를 통해 설치됨</string>
-    <string name="external_import_card_preselect_known">%1$s(으)로 추정됩니다 · %2$d%%</string>
+    <string name="external_import_card_preselect_known">%1$s(으)로 추정됩니다 · %2$d</string>
     <string name="external_import_card_preselect_unknown">저장소를 찾으려면 탭하세요</string>
     <string name="external_import_card_expand_label">다른 일치 항목을 보려면 펼치기</string>
     <string name="external_import_card_collapse_label">카드 접기</string>
@@ -813,7 +813,7 @@
     <string name="external_import_proposal_banner_review">검토</string>
     <string name="external_import_proposal_banner_dismiss">닫기</string>
     <string name="external_import_match_confidence_a11y">일치 신뢰도: %1$d퍼센트</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">이 앱을 연결할 수 없습니다 — 다시 시도하세요.</string>
     <string name="external_import_error_link_network">GitHub에 연결할 수 없습니다. 나중에 다시 시도하세요.</string>
     <string name="external_import_error_scan_failed_default">스캔 실패</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -743,4 +743,185 @@
     <string name="pat_error_bad_credentials">이 토큰은 유효하지 않거나 취소되었습니다.</string>
     <string name="pat_error_insufficient_scope">이 토큰에는 필요한 권한이 없습니다.</string>
     <string name="pat_error_generic">토큰을 저장할 수 없습니다. 다시 시도해 주세요.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+     E10 — Apps sort
+     ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">앱 정렬</string>
+    <string name="sort_updates_first">업데이트 우선</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">베타 포함</string>
+    <string name="channel_chip_stable_only">안정 버전만</string>
+    <string name="channel_toggle_cd">이 앱의 베타 릴리스 전환</string>
+    <string name="action_switch_to_stable">%1$s 안정 버전으로 전환</string>
+    <string name="stalled_project_warning_months">%1$d개월간 안정 릴리스 없음</string>
+    <string name="stalled_project_warning_days">%1$d일간 안정 릴리스 없음</string>
+    <string name="stalled_project_warning_description">사전 릴리스가 활발하지만 프로젝트가 한동안 안정 빌드를 출시하지 않았습니다. 베타가 안정 릴리스로 이어지지 않을 수 있습니다.</string>
+    <string name="merged_whats_changed_title">%1$s 이후 변경 사항</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">설치된 앱 가져오기</string>
+    <string name="external_import_top_bar_back">뒤로</string>
+    <string name="external_import_overflow_more">더 많은 옵션</string>
+    <string name="external_import_overflow_skip_remaining">나머지 건너뛰기</string>
+    <string name="external_import_progress_scanning">앱을 스캔하는 중…</string>
+    <string name="external_import_progress_auto_importing">일치 항목을 가져오는 중…</string>
+    <string name="external_import_progress_working">처리 중…</string>
+    <!-- Korean uses "other" only -->
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="other">%1$d개 앱 확인됨</item>
+    </plurals>
+    <string name="external_import_card_action_skip">건너뛰기</string>
+    <string name="external_import_card_action_link">연결</string>
+    <string name="external_import_card_action_more">더 많은 일치 항목</string>
+    <string name="external_import_card_action_less">일치 항목 숨기기</string>
+    <string name="external_import_card_installer_chip">%1$s를 통해 설치됨</string>
+    <string name="external_import_card_preselect_known">%1$s(으)로 추정됩니다 · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">저장소를 찾으려면 탭하세요</string>
+    <string name="external_import_card_expand_label">다른 일치 항목을 보려면 펼치기</string>
+    <string name="external_import_card_collapse_label">카드 접기</string>
+    <string name="external_import_search_icon_label">GitHub 검색</string>
+    <string name="external_import_search_empty">일치 항목 없음</string>
+    <string name="external_import_search_error_default">검색 실패</string>
+    <string name="external_import_search_placeholder_url">github.com URL을 붙여넣거나 검색하세요…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="other">%1$d개 앱을 추적 중입니다.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d개 건너뜀 — 설정에서 다시 스캔할 수 있습니다.</string>
+    <string name="external_import_completion_action_view_all">모두 보기</string>
+    <string name="external_import_empty_all_matched">모두 연결되었습니다.\\n연결할 항목이 없습니다.</string>
+    <string name="external_import_empty_done">완료</string>
+    <string name="external_import_empty_no_apps_title">이 기기에서 GitHub 앱을 찾을 수 없습니다.</string>
+    <string name="external_import_empty_no_apps_body">다른 스토어를 통해 설치되었거나 설치된 앱을 확인할 수 없는 상태입니다.</string>
+    <string name="external_import_empty_grant_permission">권한 허용</string>
+    <string name="external_import_empty_ok">확인</string>
+    <string name="external_import_empty_add_manually">다른 스토어에서 앱 추가</string>
+    <string name="external_import_permission_title">GitHub 앱 찾기</string>
+    <string name="external_import_permission_body">설치된 앱을 스캔하여 GitHub 릴리스와 매칭할 수 있습니다. 이렇게 하면 업데이트 감지가 자동으로 동작합니다.\\n\\n그러려면 어떤 앱이 설치되어 있는지 확인해야 합니다. 권한 없이는 약 5개의 앱만 볼 수 있고, 권한이 있으면 모두 볼 수 있습니다.\\n\\n귀하의 허가 없이 앱 목록을 어디에도 전송하지 않습니다. 매칭은 기기에서 이루어집니다. 선택적 서버 조회는 패키지 이름과 앱 레이블만 전송하며, 사용 가능한 경우 서명 지문, 설치 출처, 앱 매니페스트에 선언된 GitHub 저장소 힌트도 포함합니다. 설치된 앱의 전체 목록은 절대 전송하지 않습니다.</string>
+    <string name="external_import_permission_continue">계속</string>
+    <string name="external_import_permission_not_now">나중에</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="other">GitHub에서 %1$d개 앱을 찾았습니다</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">여기에서 업데이트를 추적하려면 검토하세요.</string>
+    <string name="external_import_proposal_banner_review">검토</string>
+    <string name="external_import_proposal_banner_dismiss">닫기</string>
+    <string name="external_import_match_confidence_a11y">일치 신뢰도: %1$d퍼센트</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">이 앱을 연결할 수 없습니다 — 다시 시도하세요.</string>
+    <string name="external_import_error_link_network">GitHub에 연결할 수 없습니다. 나중에 다시 시도하세요.</string>
+    <string name="external_import_error_scan_failed_default">스캔 실패</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">브라우저</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">알 수 없는 출처</string>
+    <string name="external_import_undo_linked">%1$s이(가) 연결되었습니다.</string>
+    <string name="external_import_undo_skipped">%1$s이(가) 건너뛰어졌습니다.</string>
+    <string name="external_import_undo_action">실행 취소</string>
+    <string name="external_import_undo_failed">실행 취소에 실패했습니다 — 다시 시도하세요.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="other">검토할 앱 %1$d개</item>
+    </plurals>
+    <string name="external_import_list_add_manually">앱이 보이지 않나요? 수동으로 추가</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="other">%1$d개 앱이 자동으로 연결되었습니다</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">높은 신뢰도로 인식되었습니다. 각 앱의 세부 정보에서 개별 매칭을 취소하거나 지금 모두 취소할 수 있습니다.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="other">%1$d개가 더 검토를 필요로 합니다.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">계속</string>
+    <string name="external_import_auto_summary_undo_all">모두 실행 취소</string>
+    <string name="external_import_auto_summary_more_count">+%1$d개 더</string>
+    <string name="external_import_rescan_menu">GitHub 앱 스캔</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">이 저장소에서 연결 해제</string>
+    <string name="details_unlink_external_app_more_options">더 많은 옵션</string>
+    <string name="details_unlink_external_app_dialog_title">이 앱의 연결을 해제하시겠습니까?</string>
+    <string name="details_unlink_external_app_dialog_body">이 저장소에서 설치된 앱으로 %1$s 추적을 중단합니다. 앱은 기기에 그대로 남습니다 — 연결만 제거됩니다.</string>
+    <string name="details_unlink_external_app_dialog_confirm">연결 해제</string>
+    <string name="details_unlink_external_app_success">연결 해제되었습니다. 다음 스캔에서 매칭을 다시 제안합니다.</string>
+    <string name="details_unlink_external_app_failure">연결 해제에 실패했습니다 — 다시 시도하세요.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">피드백 보내기</string>
+    <string name="feedback_title">피드백 보내기</string>
+    <string name="feedback_close">닫기</string>
+    <string name="feedback_category_label">카테고리</string>
+    <string name="feedback_category_bug">버그</string>
+    <string name="feedback_category_feature">기능 요청</string>
+    <string name="feedback_category_change">변경 요청</string>
+    <string name="feedback_category_other">기타</string>
+    <string name="feedback_topic_label">주제</string>
+    <string name="feedback_topic_install_update">설치 / 업데이트</string>
+    <string name="feedback_topic_search">검색 &amp; 탐색</string>
+    <string name="feedback_topic_details">저장소 세부 정보</string>
+    <string name="feedback_topic_auth">인증 &amp; 계정</string>
+    <string name="feedback_topic_ui">UI / UX</string>
+    <string name="feedback_topic_translation">번역 / 언어</string>
+    <string name="feedback_topic_performance">성능</string>
+    <string name="feedback_topic_other">기타</string>
+    <string name="feedback_field_title">제목</string>
+    <string name="feedback_field_description">설명</string>
+    <string name="feedback_field_steps">재현 단계</string>
+    <string name="feedback_field_expected_actual">예상 결과 vs 실제 결과</string>
+    <string name="feedback_field_use_case">사용 사례</string>
+    <string name="feedback_field_proposed_solution">제안된 해결책</string>
+    <string name="feedback_field_current_behaviour">현재 동작</string>
+    <string name="feedback_field_desired_behaviour">원하는 동작</string>
+    <string name="feedback_diagnostics_header">진단</string>
+    <string name="feedback_diagnostics_include">진단 포함</string>
+    <string name="feedback_send_via_email">이메일로 보내기</string>
+    <string name="feedback_send_via_github">GitHub Issue로 열기</string>
+    <string name="feedback_send_success_email">감사합니다 — 메일 클라이언트를 열고 있습니다.</string>
+    <string name="feedback_send_success_github">감사합니다 — 브라우저를 열고 있습니다.</string>
+    <string name="feedback_send_error">피드백 채널을 열 수 없습니다: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">다운로드 미러</string>
+    <string name="mirror_picker_title">다운로드 미러</string>
+    <string name="mirror_picker_description">릴리스 파일 다운로드에 사용됩니다. GitHub API 호출은 항상 직접 이루어집니다. 대부분의 사용자는 GitHub 직접으로 두는 것이 좋습니다.</string>
+    <string name="mirror_section_official">공식</string>
+    <string name="mirror_section_community">커뮤니티</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(다운)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">사용자 정의 미러…</string>
+    <string name="mirror_custom_dialog_title">사용자 정의 미러</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">템플릿은 https://로 시작해야 합니다</string>
+    <string name="mirror_custom_validation_template">템플릿에는 {url}이 정확히 한 번 포함되어야 합니다</string>
+    <string name="mirror_custom_save">저장</string>
+    <string name="mirror_test_button">선택한 항목 테스트</string>
+    <string name="mirror_test_in_progress">테스트 중…</string>
+    <string name="mirror_test_success">%1$dms에 도달</string>
+    <string name="mirror_test_http_error">미러가 %1$d를 반환했습니다</string>
+    <string name="mirror_test_timeout">5s 후 타임아웃</string>
+    <string name="mirror_test_dns_fail">호스트를 확인할 수 없습니다</string>
+    <string name="mirror_test_other">실패: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">모든 미러가 다운되었나요? 5분 안에 직접 호스팅할 수 있습니다 — 문서를 참조하세요.</string>
+    <string name="mirror_removed_toast">%1$s를 더 이상 사용할 수 없어 GitHub 직접으로 전환했습니다.</string>
+    <string name="mirror_digest_mismatch_error">체크섬 불일치 — 파일이 변조되었을 수 있습니다</string>
+    <string name="mirror_auto_suggest_title">더 빠른 미러를 사용해 볼까요?</string>
+    <string name="mirror_auto_suggest_body">느린 네트워크에서 일부 사용자는 커뮤니티 프록시를 사용할 때 더 나은 경험을 합니다.</string>
+    <string name="mirror_auto_suggest_pick_one">선택하기</string>
+    <string name="mirror_auto_suggest_maybe_later">나중에</string>
+    <string name="mirror_auto_suggest_dont_ask_again">다시 묻지 않기</string>
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -774,7 +774,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">Pominięto %1$d — możesz ponownie uruchomić skanowanie w Ustawieniach.</string>
     <string name="external_import_completion_action_view_all">Zobacz wszystkie</string>
-    <string name="external_import_empty_all_matched">Wszystko dopasowane.\\nNie ma nic do połączenia.</string>
+    <string name="external_import_empty_all_matched">Wszystko dopasowane.\nNie ma nic do połączenia.</string>
     <string name="external_import_empty_done">Gotowe</string>
     <string name="external_import_empty_no_apps_title">Nie znaleziono żadnych aplikacji GitHub na tym urządzeniu.</string>
     <string name="external_import_empty_no_apps_body">Oznacza to, że wszystko zostało zainstalowane przez inny sklep lub nie mamy wglądu w to, co jest zainstalowane.</string>
@@ -782,7 +782,7 @@
     <string name="external_import_empty_ok">OK</string>
     <string name="external_import_empty_add_manually">Dodaj aplikację z innego sklepu</string>
     <string name="external_import_permission_title">Znajdź swoje aplikacje GitHub</string>
-    <string name="external_import_permission_body">Możemy przeskanować zainstalowane aplikacje i dopasować je do wydań GitHub, dzięki czemu aktualizacje i wykrywanie działają automatycznie.\\n\\nAby to zrobić, musimy widzieć, jakie masz aplikacje. Bez zgody możemy zobaczyć tylko około 5 aplikacji; po jej udzieleniu — wszystkie.\\n\\nNigdy nie wysyłamy listy Twoich aplikacji bez Twojej zgody. Dopasowywanie odbywa się na Twoim urządzeniu. Opcjonalne wyszukiwanie serwerowe wysyła jedynie nazwę pakietu i etykietę aplikacji, a jeśli są dostępne — odcisk palca podpisu, źródło instalacji oraz wskazówkę dotyczącą repozytorium GitHub zadeklarowaną w manifeście aplikacji; nigdy pełną listę zainstalowanych aplikacji.</string>
+    <string name="external_import_permission_body">Możemy przeskanować zainstalowane aplikacje i dopasować je do wydań GitHub, dzięki czemu aktualizacje i wykrywanie działają automatycznie.\n\nAby to zrobić, musimy widzieć, jakie masz aplikacje. Bez zgody możemy zobaczyć tylko około 5 aplikacji; po jej udzieleniu — wszystkie.\n\nNigdy nie wysyłamy listy Twoich aplikacji bez Twojej zgody. Dopasowywanie odbywa się na Twoim urządzeniu. Opcjonalne wyszukiwanie serwerowe wysyła jedynie nazwę pakietu i etykietę aplikacji, a jeśli są dostępne — odcisk palca podpisu, źródło instalacji oraz wskazówkę dotyczącą repozytorium GitHub zadeklarowaną w manifeście aplikacji; nigdy pełną listę zainstalowanych aplikacji.</string>
     <string name="external_import_permission_continue">Kontynuuj</string>
     <string name="external_import_permission_not_now">Nie teraz</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -758,7 +758,7 @@
     <string name="external_import_card_action_more">Więcej dopasowań</string>
     <string name="external_import_card_action_less">Ukryj dopasowania</string>
     <string name="external_import_card_installer_chip">Zainstalowano przez %1$s</string>
-    <string name="external_import_card_preselect_known">Uważamy, że to %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Uważamy, że to %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Dotknij, aby znaleźć repozytorium</string>
     <string name="external_import_card_expand_label">Rozwiń, aby zobaczyć inne dopasowania</string>
     <string name="external_import_card_collapse_label">Zwiń kartę</string>
@@ -795,7 +795,7 @@
     <string name="external_import_proposal_banner_review">Przejrzyj</string>
     <string name="external_import_proposal_banner_dismiss">Odrzuć</string>
     <string name="external_import_match_confidence_a11y">Pewność dopasowania: %1$d procent</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Nie udało się połączyć tej aplikacji — spróbuj ponownie.</string>
     <string name="external_import_error_link_network">Nie można było połączyć się z GitHub. Spróbuj ponownie później.</string>
     <string name="external_import_error_scan_failed_default">Skanowanie nie powiodło się</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -715,4 +715,205 @@
     <string name="pat_error_bad_credentials">Ten token jest nieprawidłowy lub został unieważniony.</string>
     <string name="pat_error_insufficient_scope">Ten token nie ma wymaganych uprawnień.</string>
     <string name="pat_error_generic">Nie udało się zapisać tokena. Spróbuj ponownie.</string>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E10 — Apps sort
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Sortuj aplikacje</string>
+    <string name="sort_updates_first">Najpierw aktualizacje</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Uwzględnij wersje beta</string>
+    <string name="channel_chip_stable_only">Tylko stabilne</string>
+    <string name="channel_toggle_cd">Przełącz wydania beta dla tej aplikacji</string>
+    <string name="action_switch_to_stable">Przejdź do stabilnej wersji %1$s</string>
+    <string name="stalled_project_warning_months">Brak stabilnego wydania od %1$d miesięcy</string>
+    <string name="stalled_project_warning_days">Brak stabilnego wydania od %1$d dni</string>
+    <string name="stalled_project_warning_description">Są aktywne wersje przedpremierowe, ale projekt od dłuższego czasu nie wydał stabilnej kompilacji. Wersje beta mogą nie prowadzić do stabilnego wydania.</string>
+    <string name="merged_whats_changed_title">Co zmieniło się od %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Importuj zainstalowane aplikacje</string>
+    <string name="external_import_top_bar_back">Wróć</string>
+    <string name="external_import_overflow_more">Więcej opcji</string>
+    <string name="external_import_overflow_skip_remaining">Pomiń pozostałe</string>
+    <string name="external_import_progress_scanning">Skanowanie aplikacji…</string>
+    <string name="external_import_progress_auto_importing">Importowanie dopasowań…</string>
+    <string name="external_import_progress_working">Przetwarzanie…</string>
+    <!-- Polish plurals: one (ends in 1 not 11), few (ends in 2-4 not 12-14), many (rest), other (fractions) -->
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">Sprawdzono %1$d aplikację</item>
+        <item quantity="few">Sprawdzono %1$d aplikacje</item>
+        <item quantity="many">Sprawdzono %1$d aplikacji</item>
+        <item quantity="other">Sprawdzono %1$d aplikacji</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Pomiń</string>
+    <string name="external_import_card_action_link">Połącz</string>
+    <string name="external_import_card_action_more">Więcej dopasowań</string>
+    <string name="external_import_card_action_less">Ukryj dopasowania</string>
+    <string name="external_import_card_installer_chip">Zainstalowano przez %1$s</string>
+    <string name="external_import_card_preselect_known">Uważamy, że to %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Dotknij, aby znaleźć repozytorium</string>
+    <string name="external_import_card_expand_label">Rozwiń, aby zobaczyć inne dopasowania</string>
+    <string name="external_import_card_collapse_label">Zwiń kartę</string>
+    <string name="external_import_search_icon_label">Szukaj w GitHub</string>
+    <string name="external_import_search_empty">Brak dopasowań</string>
+    <string name="external_import_search_error_default">Wyszukiwanie nie powiodło się</string>
+    <string name="external_import_search_placeholder_url">Wklej adres URL github.com lub wyszukaj…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">Śledzono %1$d aplikację.</item>
+        <item quantity="few">Śledzono %1$d aplikacje.</item>
+        <item quantity="many">Śledzono %1$d aplikacji.</item>
+        <item quantity="other">Śledzono %1$d aplikacji.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">Pominięto %1$d — możesz ponownie uruchomić skanowanie w Ustawieniach.</string>
+    <string name="external_import_completion_action_view_all">Zobacz wszystkie</string>
+    <string name="external_import_empty_all_matched">Wszystko dopasowane.\\nNie ma nic do połączenia.</string>
+    <string name="external_import_empty_done">Gotowe</string>
+    <string name="external_import_empty_no_apps_title">Nie znaleziono żadnych aplikacji GitHub na tym urządzeniu.</string>
+    <string name="external_import_empty_no_apps_body">Oznacza to, że wszystko zostało zainstalowane przez inny sklep lub nie mamy wglądu w to, co jest zainstalowane.</string>
+    <string name="external_import_empty_grant_permission">Udziel uprawnień</string>
+    <string name="external_import_empty_ok">OK</string>
+    <string name="external_import_empty_add_manually">Dodaj aplikację z innego sklepu</string>
+    <string name="external_import_permission_title">Znajdź swoje aplikacje GitHub</string>
+    <string name="external_import_permission_body">Możemy przeskanować zainstalowane aplikacje i dopasować je do wydań GitHub, dzięki czemu aktualizacje i wykrywanie działają automatycznie.\\n\\nAby to zrobić, musimy widzieć, jakie masz aplikacje. Bez zgody możemy zobaczyć tylko około 5 aplikacji; po jej udzieleniu — wszystkie.\\n\\nNigdy nie wysyłamy listy Twoich aplikacji bez Twojej zgody. Dopasowywanie odbywa się na Twoim urządzeniu. Opcjonalne wyszukiwanie serwerowe wysyła jedynie nazwę pakietu i etykietę aplikacji, a jeśli są dostępne — odcisk palca podpisu, źródło instalacji oraz wskazówkę dotyczącą repozytorium GitHub zadeklarowaną w manifeście aplikacji; nigdy pełną listę zainstalowanych aplikacji.</string>
+    <string name="external_import_permission_continue">Kontynuuj</string>
+    <string name="external_import_permission_not_now">Nie teraz</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">Znaleziono %1$d aplikację z GitHub</item>
+        <item quantity="few">Znaleziono %1$d aplikacje z GitHub</item>
+        <item quantity="many">Znaleziono %1$d aplikacji z GitHub</item>
+        <item quantity="other">Znaleziono %1$d aplikacji z GitHub</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Przejrzyj je, aby śledzić aktualizacje tutaj.</string>
+    <string name="external_import_proposal_banner_review">Przejrzyj</string>
+    <string name="external_import_proposal_banner_dismiss">Odrzuć</string>
+    <string name="external_import_match_confidence_a11y">Pewność dopasowania: %1$d procent</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">Nie udało się połączyć tej aplikacji — spróbuj ponownie.</string>
+    <string name="external_import_error_link_network">Nie można było połączyć się z GitHub. Spróbuj ponownie później.</string>
+    <string name="external_import_error_scan_failed_default">Skanowanie nie powiodło się</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Przeglądarka</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Nieznane źródło</string>
+    <string name="external_import_undo_linked">%1$s połączono.</string>
+    <string name="external_import_undo_skipped">%1$s pominięto.</string>
+    <string name="external_import_undo_action">Cofnij</string>
+    <string name="external_import_undo_failed">Nie udało się cofnąć — spróbuj ponownie.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d aplikacja do przejrzenia</item>
+        <item quantity="few">%1$d aplikacje do przejrzenia</item>
+        <item quantity="many">%1$d aplikacji do przejrzenia</item>
+        <item quantity="other">%1$d aplikacji do przejrzenia</item>
+    </plurals>
+    <string name="external_import_list_add_manually">Nie widzisz swojej aplikacji? Dodaj ręcznie</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d aplikacja połączona automatycznie</item>
+        <item quantity="few">%1$d aplikacje połączone automatycznie</item>
+        <item quantity="many">%1$d aplikacji połączonych automatycznie</item>
+        <item quantity="other">%1$d aplikacji połączonych automatycznie</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Rozpoznaliśmy je z dużą pewnością. Możesz cofnąć poszczególne dopasowania z poziomu szczegółów każdej aplikacji lub cofnąć wszystkie teraz.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d kolejna wymaga Twojej uwagi.</item>
+        <item quantity="few">%1$d kolejne wymagają Twojej uwagi.</item>
+        <item quantity="many">%1$d kolejnych wymaga Twojej uwagi.</item>
+        <item quantity="other">%1$d kolejnych wymaga Twojej uwagi.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Kontynuuj</string>
+    <string name="external_import_auto_summary_undo_all">Cofnij wszystkie</string>
+    <string name="external_import_auto_summary_more_count">+%1$d więcej</string>
+    <string name="external_import_rescan_menu">Skanuj w poszukiwaniu aplikacji GitHub</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Odłącz od tego repozytorium</string>
+    <string name="details_unlink_external_app_more_options">Więcej opcji</string>
+    <string name="details_unlink_external_app_dialog_title">Odłączyć tę aplikację?</string>
+    <string name="details_unlink_external_app_dialog_body">Przestaniemy śledzić %1$s jako zainstalowaną z tego repozytorium. Aplikacja pozostaje na urządzeniu — usuwane jest tylko połączenie.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Odłącz</string>
+    <string name="details_unlink_external_app_success">Odłączono. Zasugerujemy dopasowanie przy następnym skanowaniu.</string>
+    <string name="details_unlink_external_app_failure">Nie udało się odłączyć — spróbuj ponownie.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Wyślij opinię</string>
+    <string name="feedback_title">Wyślij opinię</string>
+    <string name="feedback_close">Zamknij</string>
+    <string name="feedback_category_label">Kategoria</string>
+    <string name="feedback_category_bug">Błąd</string>
+    <string name="feedback_category_feature">Prośba o funkcję</string>
+    <string name="feedback_category_change">Prośba o zmianę</string>
+    <string name="feedback_category_other">Inne</string>
+    <string name="feedback_topic_label">Temat</string>
+    <string name="feedback_topic_install_update">Instalacja / Aktualizacja</string>
+    <string name="feedback_topic_search">Wyszukiwanie &amp; Odkrywanie</string>
+    <string name="feedback_topic_details">Szczegóły repozytorium</string>
+    <string name="feedback_topic_auth">Autoryzacja &amp; Konto</string>
+    <string name="feedback_topic_ui">Interfejs / UX</string>
+    <string name="feedback_topic_translation">Tłumaczenie / Język</string>
+    <string name="feedback_topic_performance">Wydajność</string>
+    <string name="feedback_topic_other">Inne</string>
+    <string name="feedback_field_title">Tytuł</string>
+    <string name="feedback_field_description">Opis</string>
+    <string name="feedback_field_steps">Kroki do odtworzenia</string>
+    <string name="feedback_field_expected_actual">Oczekiwane a rzeczywiste</string>
+    <string name="feedback_field_use_case">Przypadek użycia</string>
+    <string name="feedback_field_proposed_solution">Proponowane rozwiązanie</string>
+    <string name="feedback_field_current_behaviour">Aktualne zachowanie</string>
+    <string name="feedback_field_desired_behaviour">Pożądane zachowanie</string>
+    <string name="feedback_diagnostics_header">Diagnostyka</string>
+    <string name="feedback_diagnostics_include">Dołącz diagnostykę</string>
+    <string name="feedback_send_via_email">Wyślij e-mailem</string>
+    <string name="feedback_send_via_github">Otwórz jako Issue w GitHub</string>
+    <string name="feedback_send_success_email">Dziękujemy — otwieramy klienta poczty.</string>
+    <string name="feedback_send_success_github">Dziękujemy — otwieramy przeglądarkę.</string>
+    <string name="feedback_send_error">Nie udało się otworzyć kanału opinii: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">Serwer lustrzany pobierania</string>
+    <string name="mirror_picker_title">Serwer lustrzany pobierania</string>
+    <string name="mirror_picker_description">Używany do pobierania plików wydań. Wywołania API GitHub zawsze przechodzą bezpośrednio. Większość użytkowników powinna pozostawić to ustawienie na GitHub bezpośrednio.</string>
+    <string name="mirror_section_official">Oficjalny</string>
+    <string name="mirror_section_community">Społeczność</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(niedostępny)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Własny serwer lustrzany…</string>
+    <string name="mirror_custom_dialog_title">Własny serwer lustrzany</string>
+    <string name="mirror_custom_dialog_hint">https://twoje-lustro.przyklad/{url}</string>
+    <string name="mirror_custom_validation_https">Szablon musi zaczynać się od https://</string>
+    <string name="mirror_custom_validation_template">Szablon musi zawierać {url} dokładnie jeden raz</string>
+    <string name="mirror_custom_save">Zapisz</string>
+    <string name="mirror_test_button">Testuj wybrany</string>
+    <string name="mirror_test_in_progress">Testowanie…</string>
+    <string name="mirror_test_success">Osiągnięto w %1$dms</string>
+    <string name="mirror_test_http_error">Serwer lustrzany zwrócił %1$d</string>
+    <string name="mirror_test_timeout">Przekroczono limit czasu po 5s</string>
+    <string name="mirror_test_dns_fail">Nie można rozwiązać nazwy hosta</string>
+    <string name="mirror_test_other">Niepowodzenie: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">Wszystkie serwery lustrzane niedostępne? Możesz uruchomić własny w 5 minut — sprawdź dokumentację.</string>
+    <string name="mirror_removed_toast">%1$s nie jest już dostępny, przełączono na GitHub bezpośrednio.</string>
+    <string name="mirror_digest_mismatch_error">Niezgodność sumy kontrolnej — plik mógł zostać zmodyfikowany</string>
+    <string name="mirror_auto_suggest_title">Wypróbować szybszy serwer lustrzany?</string>
+    <string name="mirror_auto_suggest_body">Niektórzy użytkownicy z wolnymi sieciami osiągają lepsze wyniki z proxy społeczności.</string>
+    <string name="mirror_auto_suggest_pick_one">Wybierz jeden</string>
+    <string name="mirror_auto_suggest_maybe_later">Może później</string>
+    <string name="mirror_auto_suggest_dont_ask_again">Nie pytaj ponownie</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -774,7 +774,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">Пропущено %1$d — повторите сканирование в Настройках.</string>
     <string name="external_import_completion_action_view_all">Посмотреть все</string>
-    <string name="external_import_empty_all_matched">Всё связано.\\nНечего связывать.</string>
+    <string name="external_import_empty_all_matched">Всё связано.\nНечего связывать.</string>
     <string name="external_import_empty_done">Готово</string>
     <string name="external_import_empty_no_apps_title">На этом устройстве не найдено приложений GitHub.</string>
     <string name="external_import_empty_no_apps_body">Это означает, что всё установлено через другой магазин или у нас нет доступа к списку установленных приложений.</string>
@@ -782,7 +782,7 @@
     <string name="external_import_empty_ok">ОК</string>
     <string name="external_import_empty_add_manually">Добавить приложение из другого магазина</string>
     <string name="external_import_permission_title">Найдите ваши приложения GitHub</string>
-    <string name="external_import_permission_body">Мы можем просканировать установленные приложения и сопоставить их с релизами GitHub, чтобы обновления и обнаружение работали автоматически.\\n\\nДля этого нам нужно видеть, какие приложения у вас установлены. Без разрешения мы можем видеть только около 5 приложений; с ним — все.\\n\\nМы никогда не отправляем список ваших приложений без вашего согласия. Сопоставление выполняется на вашем устройстве. Необязательный серверный поиск передаёт только имя пакета и метку приложения, а при наличии — отпечаток подписи, источник установки и любую подсказку о репозитории GitHub, указанную в манифесте приложения; полный список установленных приложений никогда не передаётся.</string>
+    <string name="external_import_permission_body">Мы можем просканировать установленные приложения и сопоставить их с релизами GitHub, чтобы обновления и обнаружение работали автоматически.\n\nДля этого нам нужно видеть, какие приложения у вас установлены. Без разрешения мы можем видеть только около 5 приложений; с ним — все.\n\nМы никогда не отправляем список ваших приложений без вашего согласия. Сопоставление выполняется на вашем устройстве. Необязательный серверный поиск передаёт только имя пакета и метку приложения, а при наличии — отпечаток подписи, источник установки и любую подсказку о репозитории GitHub, указанную в манифесте приложения; полный список установленных приложений никогда не передаётся.</string>
     <string name="external_import_permission_continue">Продолжить</string>
     <string name="external_import_permission_not_now">Не сейчас</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -758,7 +758,7 @@
     <string name="external_import_card_action_more">Другие совпадения</string>
     <string name="external_import_card_action_less">Скрыть совпадения</string>
     <string name="external_import_card_installer_chip">Установлено через %1$s</string>
-    <string name="external_import_card_preselect_known">Мы думаем, это %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Мы думаем, это %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Нажмите, чтобы найти репозиторий</string>
     <string name="external_import_card_expand_label">Развернуть для просмотра других совпадений</string>
     <string name="external_import_card_collapse_label">Свернуть карточку</string>
@@ -795,7 +795,7 @@
     <string name="external_import_proposal_banner_review">Просмотреть</string>
     <string name="external_import_proposal_banner_dismiss">Закрыть</string>
     <string name="external_import_match_confidence_a11y">Достоверность совпадения: %1$d процентов</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Не удалось связать это приложение — попробуйте ещё раз.</string>
     <string name="external_import_error_link_network">Не удалось подключиться к GitHub. Попробуйте позже.</string>
     <string name="external_import_error_scan_failed_default">Ошибка сканирования</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -715,4 +715,205 @@
     <string name="pat_error_bad_credentials">Этот токен недействителен или отозван.</string>
     <string name="pat_error_insufficient_scope">У этого токена нет необходимых прав.</string>
     <string name="pat_error_generic">Не удалось сохранить токен. Попробуйте снова.</string>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E10 — Apps sort
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Сортировка приложений</string>
+    <string name="sort_updates_first">Сначала обновления</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Включить бета-версии</string>
+    <string name="channel_chip_stable_only">Только стабильные</string>
+    <string name="channel_toggle_cd">Переключить бета-релизы для этого приложения</string>
+    <string name="action_switch_to_stable">Перейти на стабильную %1$s</string>
+    <string name="stalled_project_warning_months">Нет стабильного релиза уже %1$d месяцев</string>
+    <string name="stalled_project_warning_days">Нет стабильного релиза уже %1$d дней</string>
+    <string name="stalled_project_warning_description">Есть активные предварительные версии, но проект давно не выпускал стабильную сборку. Бета-версии могут так и не перейти в стабильный релиз.</string>
+    <string name="merged_whats_changed_title">Что изменилось с %1$s</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Импорт установленных приложений</string>
+    <string name="external_import_top_bar_back">Назад</string>
+    <string name="external_import_overflow_more">Другие параметры</string>
+    <string name="external_import_overflow_skip_remaining">Пропустить оставшиеся</string>
+    <string name="external_import_progress_scanning">Сканирование приложений…</string>
+    <string name="external_import_progress_auto_importing">Импорт совпадений…</string>
+    <string name="external_import_progress_working">Обработка…</string>
+    <!-- Russian plurals: one (ends in 1 not 11), few (ends in 2-4 not 12-14), many (rest), other (fractions) -->
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">Проверено %1$d приложение</item>
+        <item quantity="few">Проверено %1$d приложения</item>
+        <item quantity="many">Проверено %1$d приложений</item>
+        <item quantity="other">Проверено %1$d приложения</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Пропустить</string>
+    <string name="external_import_card_action_link">Связать</string>
+    <string name="external_import_card_action_more">Другие совпадения</string>
+    <string name="external_import_card_action_less">Скрыть совпадения</string>
+    <string name="external_import_card_installer_chip">Установлено через %1$s</string>
+    <string name="external_import_card_preselect_known">Мы думаем, это %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Нажмите, чтобы найти репозиторий</string>
+    <string name="external_import_card_expand_label">Развернуть для просмотра других совпадений</string>
+    <string name="external_import_card_collapse_label">Свернуть карточку</string>
+    <string name="external_import_search_icon_label">Поиск в GitHub</string>
+    <string name="external_import_search_empty">Нет совпадений</string>
+    <string name="external_import_search_error_default">Ошибка поиска</string>
+    <string name="external_import_search_placeholder_url">Вставьте URL github.com или выполните поиск…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">Отслеживается %1$d приложение.</item>
+        <item quantity="few">Отслеживается %1$d приложения.</item>
+        <item quantity="many">Отслеживается %1$d приложений.</item>
+        <item quantity="other">Отслеживается %1$d приложения.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">Пропущено %1$d — повторите сканирование в Настройках.</string>
+    <string name="external_import_completion_action_view_all">Посмотреть все</string>
+    <string name="external_import_empty_all_matched">Всё связано.\\nНечего связывать.</string>
+    <string name="external_import_empty_done">Готово</string>
+    <string name="external_import_empty_no_apps_title">На этом устройстве не найдено приложений GitHub.</string>
+    <string name="external_import_empty_no_apps_body">Это означает, что всё установлено через другой магазин или у нас нет доступа к списку установленных приложений.</string>
+    <string name="external_import_empty_grant_permission">Предоставить разрешение</string>
+    <string name="external_import_empty_ok">ОК</string>
+    <string name="external_import_empty_add_manually">Добавить приложение из другого магазина</string>
+    <string name="external_import_permission_title">Найдите ваши приложения GitHub</string>
+    <string name="external_import_permission_body">Мы можем просканировать установленные приложения и сопоставить их с релизами GitHub, чтобы обновления и обнаружение работали автоматически.\\n\\nДля этого нам нужно видеть, какие приложения у вас установлены. Без разрешения мы можем видеть только около 5 приложений; с ним — все.\\n\\nМы никогда не отправляем список ваших приложений без вашего согласия. Сопоставление выполняется на вашем устройстве. Необязательный серверный поиск передаёт только имя пакета и метку приложения, а при наличии — отпечаток подписи, источник установки и любую подсказку о репозитории GitHub, указанную в манифесте приложения; полный список установленных приложений никогда не передаётся.</string>
+    <string name="external_import_permission_continue">Продолжить</string>
+    <string name="external_import_permission_not_now">Не сейчас</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">Найдено %1$d приложение из GitHub</item>
+        <item quantity="few">Найдено %1$d приложения из GitHub</item>
+        <item quantity="many">Найдено %1$d приложений из GitHub</item>
+        <item quantity="other">Найдено %1$d приложения из GitHub</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Просмотрите их, чтобы отслеживать обновления здесь.</string>
+    <string name="external_import_proposal_banner_review">Просмотреть</string>
+    <string name="external_import_proposal_banner_dismiss">Закрыть</string>
+    <string name="external_import_match_confidence_a11y">Достоверность совпадения: %1$d процентов</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">Не удалось связать это приложение — попробуйте ещё раз.</string>
+    <string name="external_import_error_link_network">Не удалось подключиться к GitHub. Попробуйте позже.</string>
+    <string name="external_import_error_scan_failed_default">Ошибка сканирования</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Браузер</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Неизвестный источник</string>
+    <string name="external_import_undo_linked">%1$s связано.</string>
+    <string name="external_import_undo_skipped">%1$s пропущено.</string>
+    <string name="external_import_undo_action">Отменить</string>
+    <string name="external_import_undo_failed">Не удалось отменить — попробуйте ещё раз.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">%1$d приложение для просмотра</item>
+        <item quantity="few">%1$d приложения для просмотра</item>
+        <item quantity="many">%1$d приложений для просмотра</item>
+        <item quantity="other">%1$d приложения для просмотра</item>
+    </plurals>
+    <string name="external_import_list_add_manually">Не видите своё приложение? Добавить вручную</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d приложение связано автоматически</item>
+        <item quantity="few">%1$d приложения связано автоматически</item>
+        <item quantity="many">%1$d приложений связано автоматически</item>
+        <item quantity="other">%1$d приложения связано автоматически</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Мы распознали их с высокой точностью. Вы можете отменить отдельные совпадения в деталях каждого приложения или отменить все сейчас.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">Ещё %1$d требует вашего внимания.</item>
+        <item quantity="few">Ещё %1$d требуют вашего внимания.</item>
+        <item quantity="many">Ещё %1$d требуют вашего внимания.</item>
+        <item quantity="other">Ещё %1$d требуют вашего внимания.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Продолжить</string>
+    <string name="external_import_auto_summary_undo_all">Отменить все</string>
+    <string name="external_import_auto_summary_more_count">+%1$d ещё</string>
+    <string name="external_import_rescan_menu">Сканировать приложения GitHub</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Отвязать от этого репозитория</string>
+    <string name="details_unlink_external_app_more_options">Другие параметры</string>
+    <string name="details_unlink_external_app_dialog_title">Отвязать это приложение?</string>
+    <string name="details_unlink_external_app_dialog_body">Мы перестанем отслеживать %1$s как установленное из этого репозитория. Приложение останется на устройстве — удаляется только связь.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Отвязать</string>
+    <string name="details_unlink_external_app_success">Отвязано. При следующем сканировании мы предложим совпадение.</string>
+    <string name="details_unlink_external_app_failure">Не удалось отвязать — попробуйте ещё раз.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Отправить отзыв</string>
+    <string name="feedback_title">Отправить отзыв</string>
+    <string name="feedback_close">Закрыть</string>
+    <string name="feedback_category_label">Категория</string>
+    <string name="feedback_category_bug">Ошибка</string>
+    <string name="feedback_category_feature">Запрос функции</string>
+    <string name="feedback_category_change">Запрос на изменение</string>
+    <string name="feedback_category_other">Другое</string>
+    <string name="feedback_topic_label">Тема</string>
+    <string name="feedback_topic_install_update">Установка / Обновление</string>
+    <string name="feedback_topic_search">Поиск &amp; Обнаружение</string>
+    <string name="feedback_topic_details">Детали репозитория</string>
+    <string name="feedback_topic_auth">Авторизация &amp; Аккаунт</string>
+    <string name="feedback_topic_ui">Интерфейс / UX</string>
+    <string name="feedback_topic_translation">Перевод / Язык</string>
+    <string name="feedback_topic_performance">Производительность</string>
+    <string name="feedback_topic_other">Другое</string>
+    <string name="feedback_field_title">Заголовок</string>
+    <string name="feedback_field_description">Описание</string>
+    <string name="feedback_field_steps">Шаги для воспроизведения</string>
+    <string name="feedback_field_expected_actual">Ожидаемое и фактическое</string>
+    <string name="feedback_field_use_case">Сценарий использования</string>
+    <string name="feedback_field_proposed_solution">Предлагаемое решение</string>
+    <string name="feedback_field_current_behaviour">Текущее поведение</string>
+    <string name="feedback_field_desired_behaviour">Желаемое поведение</string>
+    <string name="feedback_diagnostics_header">Диагностика</string>
+    <string name="feedback_diagnostics_include">Включить диагностику</string>
+    <string name="feedback_send_via_email">Отправить по e-mail</string>
+    <string name="feedback_send_via_github">Открыть как Issue на GitHub</string>
+    <string name="feedback_send_success_email">Спасибо — открываем почтовый клиент.</string>
+    <string name="feedback_send_success_github">Спасибо — открываем браузер.</string>
+    <string name="feedback_send_error">Не удалось открыть канал обратной связи: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">Зеркало для загрузки</string>
+    <string name="mirror_picker_title">Зеркало для загрузки</string>
+    <string name="mirror_picker_description">Используется для загрузки файлов релизов. Обращения к API GitHub всегда идут напрямую. Большинству пользователей следует оставить настройку «Напрямую через GitHub».</string>
+    <string name="mirror_section_official">Официальное</string>
+    <string name="mirror_section_community">Сообщество</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(недоступно)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Своё зеркало…</string>
+    <string name="mirror_custom_dialog_title">Своё зеркало</string>
+    <string name="mirror_custom_dialog_hint">https://vashezerkalo.primer/{url}</string>
+    <string name="mirror_custom_validation_https">Шаблон должен начинаться с https://</string>
+    <string name="mirror_custom_validation_template">Шаблон должен содержать {url} ровно один раз</string>
+    <string name="mirror_custom_save">Сохранить</string>
+    <string name="mirror_test_button">Проверить выбранное</string>
+    <string name="mirror_test_in_progress">Проверка…</string>
+    <string name="mirror_test_success">Достигнуто за %1$dms</string>
+    <string name="mirror_test_http_error">Зеркало вернуло %1$d</string>
+    <string name="mirror_test_timeout">Превышено время ожидания (5s)</string>
+    <string name="mirror_test_dns_fail">Не удалось разрешить имя хоста</string>
+    <string name="mirror_test_other">Ошибка: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">Все зеркала недоступны? За 5 минут можно развернуть своё — смотрите документацию.</string>
+    <string name="mirror_removed_toast">%1$s больше недоступно, выполнен переход на прямой доступ через GitHub.</string>
+    <string name="mirror_digest_mismatch_error">Несоответствие контрольной суммы — файл мог быть изменён</string>
+    <string name="mirror_auto_suggest_title">Попробовать более быстрое зеркало?</string>
+    <string name="mirror_auto_suggest_body">Некоторым пользователям с медленным соединением лучше подходит прокси сообщества.</string>
+    <string name="mirror_auto_suggest_pick_one">Выбрать</string>
+    <string name="mirror_auto_suggest_maybe_later">Может быть, позже</string>
+    <string name="mirror_auto_suggest_dont_ask_again">Больше не спрашивать</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -798,7 +798,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">%1$d atlandı — Ayarlar\'dan yeniden tarama yapabilirsiniz.</string>
     <string name="external_import_completion_action_view_all">Tümünü görüntüle</string>
-    <string name="external_import_empty_all_matched">Tümü eşleşti.\\nBağlanacak bir şey yok.</string>
+    <string name="external_import_empty_all_matched">Tümü eşleşti.\nBağlanacak bir şey yok.</string>
     <string name="external_import_empty_done">Tamam</string>
     <string name="external_import_empty_no_apps_title">Bu cihazda GitHub uygulaması bulunamadı.</string>
     <string name="external_import_empty_no_apps_body">Bu, her şeyin farklı bir mağaza aracılığıyla yüklendiği ya da yüklü uygulamalara erişimimizin olmadığı anlamına gelir.</string>
@@ -806,7 +806,7 @@
     <string name="external_import_empty_ok">Tamam</string>
     <string name="external_import_empty_add_manually">Başka bir mağazadan uygulama ekle</string>
     <string name="external_import_permission_title">GitHub uygulamalarınızı bulun</string>
-    <string name="external_import_permission_body">Yüklü uygulamalarınızı tarayıp GitHub sürümleriyle eşleştirebiliriz; böylece güncellemeler ve algılama otomatik çalışır.\\n\\nBunun için hangi uygulamaların yüklü olduğunu görmemiz gerekiyor. İzin vermeden yalnızca yaklaşık 5 uygulama görebiliriz; izinle tümünü görebiliriz.\\n\\nUygulama listenizi izniniz olmadan hiçbir yere göndermiyoruz. Eşleştirme işlemi cihazınızda gerçekleşir. İsteğe bağlı sunucu araması yalnızca paket adını ve uygulama etiketini, varsa imza parmak izini, kurulum kaynağını ve uygulama manifest\'inde belirtilen GitHub depo ipucunu gönderir; yüklü uygulamaların tam listesini asla göndermez.</string>
+    <string name="external_import_permission_body">Yüklü uygulamalarınızı tarayıp GitHub sürümleriyle eşleştirebiliriz; böylece güncellemeler ve algılama otomatik çalışır.\n\nBunun için hangi uygulamaların yüklü olduğunu görmemiz gerekiyor. İzin vermeden yalnızca yaklaşık 5 uygulama görebiliriz; izinle tümünü görebiliriz.\n\nUygulama listenizi izniniz olmadan hiçbir yere göndermiyoruz. Eşleştirme işlemi cihazınızda gerçekleşir. İsteğe bağlı sunucu araması yalnızca paket adını ve uygulama etiketini, varsa imza parmak izini, kurulum kaynağını ve uygulama manifest\'inde belirtilen GitHub depo ipucunu gönderir; yüklü uygulamaların tam listesini asla göndermez.</string>
     <string name="external_import_permission_continue">Devam et</string>
     <string name="external_import_permission_not_now">Şimdi değil</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -788,15 +788,15 @@
     <string name="external_import_card_preselect_unknown">Depo bulmak için dokun</string>
     <string name="external_import_card_expand_label">Diğer eşleşmeleri görmek için genişlet</string>
     <string name="external_import_card_collapse_label">Kartı daralt</string>
-    <string name="external_import_search_icon_label">GitHub\'da ara</string>
+    <string name="external_import_search_icon_label">GitHub'da ara</string>
     <string name="external_import_search_empty">Eşleşme yok</string>
     <string name="external_import_search_error_default">Arama başarısız</string>
-    <string name="external_import_search_placeholder_url">Bir github.com URL\'si yapıştırın veya arayın…</string>
+    <string name="external_import_search_placeholder_url">Bir github.com URL'si yapıştırın veya arayın…</string>
     <plurals name="external_import_completion_headline">
         <item quantity="one">%1$d uygulama artık takip ediliyor.</item>
         <item quantity="other">%1$d uygulama artık takip ediliyor.</item>
     </plurals>
-    <string name="external_import_completion_skipped_subline">%1$d atlandı — Ayarlar\'dan yeniden tarama yapabilirsiniz.</string>
+    <string name="external_import_completion_skipped_subline">%1$d atlandı — Ayarlar'dan yeniden tarama yapabilirsiniz.</string>
     <string name="external_import_completion_action_view_all">Tümünü görüntüle</string>
     <string name="external_import_empty_all_matched">Tümü eşleşti.\nBağlanacak bir şey yok.</string>
     <string name="external_import_empty_done">Tamam</string>
@@ -806,12 +806,12 @@
     <string name="external_import_empty_ok">Tamam</string>
     <string name="external_import_empty_add_manually">Başka bir mağazadan uygulama ekle</string>
     <string name="external_import_permission_title">GitHub uygulamalarınızı bulun</string>
-    <string name="external_import_permission_body">Yüklü uygulamalarınızı tarayıp GitHub sürümleriyle eşleştirebiliriz; böylece güncellemeler ve algılama otomatik çalışır.\n\nBunun için hangi uygulamaların yüklü olduğunu görmemiz gerekiyor. İzin vermeden yalnızca yaklaşık 5 uygulama görebiliriz; izinle tümünü görebiliriz.\n\nUygulama listenizi izniniz olmadan hiçbir yere göndermiyoruz. Eşleştirme işlemi cihazınızda gerçekleşir. İsteğe bağlı sunucu araması yalnızca paket adını ve uygulama etiketini, varsa imza parmak izini, kurulum kaynağını ve uygulama manifest\'inde belirtilen GitHub depo ipucunu gönderir; yüklü uygulamaların tam listesini asla göndermez.</string>
+    <string name="external_import_permission_body">Yüklü uygulamalarınızı tarayıp GitHub sürümleriyle eşleştirebiliriz; böylece güncellemeler ve algılama otomatik çalışır.\n\nBunun için hangi uygulamaların yüklü olduğunu görmemiz gerekiyor. İzin vermeden yalnızca yaklaşık 5 uygulama görebiliriz; izinle tümünü görebiliriz.\n\nUygulama listenizi izniniz olmadan hiçbir yere göndermiyoruz. Eşleştirme işlemi cihazınızda gerçekleşir. İsteğe bağlı sunucu araması yalnızca paket adını ve uygulama etiketini, varsa imza parmak izini, kurulum kaynağını ve uygulama manifest'inde belirtilen GitHub depo ipucunu gönderir; yüklü uygulamaların tam listesini asla göndermez.</string>
     <string name="external_import_permission_continue">Devam et</string>
     <string name="external_import_permission_not_now">Şimdi değil</string>
     <plurals name="external_import_proposal_banner_headline">
-        <item quantity="one">GitHub\'dan %1$d uygulama bulundu</item>
-        <item quantity="other">GitHub\'dan %1$d uygulama bulundu</item>
+        <item quantity="one">GitHub'dan %1$d uygulama bulundu</item>
+        <item quantity="other">GitHub'dan %1$d uygulama bulundu</item>
     </plurals>
     <string name="external_import_proposal_banner_body">Güncellemeleri burada takip etmek için inceleyin.</string>
     <string name="external_import_proposal_banner_review">İncele</string>
@@ -819,7 +819,7 @@
     <string name="external_import_match_confidence_a11y">Eşleşme güveni: yüzde %1$d</string>
     <string name="external_import_match_confidence_chip">%1$d%%</string>
     <string name="external_import_error_link_failed">Bu uygulama bağlanamadı — tekrar deneyin.</string>
-    <string name="external_import_error_link_network">GitHub\'a ulaşılamadı. Daha sonra tekrar deneyin.</string>
+    <string name="external_import_error_link_network">GitHub'a ulaşılamadı. Daha sonra tekrar deneyin.</string>
     <string name="external_import_error_scan_failed_default">Tarama başarısız</string>
     <string name="external_import_installer_obtainium">Obtainium</string>
     <string name="external_import_installer_fdroid">F-Droid</string>
@@ -917,16 +917,16 @@
     <string name="mirror_custom_save">Kaydet</string>
     <string name="mirror_test_button">Seçileni test et</string>
     <string name="mirror_test_in_progress">Test ediliyor…</string>
-    <string name="mirror_test_success">%1$dms\'de ulaşıldı</string>
+    <string name="mirror_test_success">%1$dms'de ulaşıldı</string>
     <string name="mirror_test_http_error">Ayna %1$d döndürdü</string>
     <string name="mirror_test_timeout">5s sonra zaman aşımı</string>
     <string name="mirror_test_dns_fail">Ana bilgisayar çözümlenemedi</string>
     <string name="mirror_test_other">Başarısız: %1$s</string>
     <string name="mirror_deploy_your_own_hint">Tüm aynalar mı çöktü? 5 dakikada kendinizinkini barındırabilirsiniz — belgelere bakın.</string>
-    <string name="mirror_removed_toast">%1$s artık kullanılamıyor, Doğrudan GitHub\'a geçildi.</string>
+    <string name="mirror_removed_toast">%1$s artık kullanılamıyor, Doğrudan GitHub'a geçildi.</string>
     <string name="mirror_digest_mismatch_error">Sağlama toplamı uyumsuzluğu — dosya değiştirilmiş olabilir</string>
     <string name="mirror_auto_suggest_title">Daha hızlı bir ayna deneyin mi?</string>
-    <string name="mirror_auto_suggest_body">Yavaş ağlardaki bazı kullanıcılar topluluk proxy\'siyle daha iyi sonuç alıyor.</string>
+    <string name="mirror_auto_suggest_body">Yavaş ağlardaki bazı kullanıcılar topluluk proxy'siyle daha iyi sonuç alıyor.</string>
     <string name="mirror_auto_suggest_pick_one">Birini seç</string>
     <string name="mirror_auto_suggest_maybe_later">Belki daha sonra</string>
     <string name="mirror_auto_suggest_dont_ask_again">Bir daha sorma</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -784,7 +784,7 @@
     <string name="external_import_card_action_more">Daha fazla eşleşme</string>
     <string name="external_import_card_action_less">Eşleşmeleri gizle</string>
     <string name="external_import_card_installer_chip">%1$s aracılığıyla yüklendi</string>
-    <string name="external_import_card_preselect_known">Bunun %1$s olduğunu düşünüyoruz · %2$d%%</string>
+    <string name="external_import_card_preselect_known">Bunun %1$s olduğunu düşünüyoruz · %2$d</string>
     <string name="external_import_card_preselect_unknown">Depo bulmak için dokun</string>
     <string name="external_import_card_expand_label">Diğer eşleşmeleri görmek için genişlet</string>
     <string name="external_import_card_collapse_label">Kartı daralt</string>
@@ -817,7 +817,7 @@
     <string name="external_import_proposal_banner_review">İncele</string>
     <string name="external_import_proposal_banner_dismiss">Kapat</string>
     <string name="external_import_match_confidence_a11y">Eşleşme güveni: yüzde %1$d</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Bu uygulama bağlanamadı — tekrar deneyin.</string>
     <string name="external_import_error_link_network">GitHub'a ulaşılamadı. Daha sonra tekrar deneyin.</string>
     <string name="external_import_error_scan_failed_default">Tarama başarısız</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -745,4 +745,191 @@
     <string name="pat_error_bad_credentials">Bu token geçersiz veya iptal edilmiş.</string>
     <string name="pat_error_insufficient_scope">Bu token gerekli izinlere sahip değil.</string>
     <string name="pat_error_generic">Token kaydedilemedi. Lütfen tekrar deneyin.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+     E10 — Apps sort
+     ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">Uygulamaları sırala</string>
+    <string name="sort_updates_first">Güncellemeler önce</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">Beta sürümleri dahil et</string>
+    <string name="channel_chip_stable_only">Yalnızca kararlı</string>
+    <string name="channel_toggle_cd">Bu uygulama için beta sürümlerini aç/kapat</string>
+    <string name="action_switch_to_stable">%1$s kararlı sürümüne geç</string>
+    <string name="stalled_project_warning_months">%1$d aydır kararlı sürüm yok</string>
+    <string name="stalled_project_warning_days">%1$d gündür kararlı sürüm yok</string>
+    <string name="stalled_project_warning_description">Etkin ön sürümler mevcut, ancak proje bir süredir kararlı bir derleme yayınlamadı. Beta sürümler kararlı bir sürüme ulaşmayabilir.</string>
+    <string name="merged_whats_changed_title">%1$s sürümünden bu yana değişenler</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">Yüklü uygulamaları içe aktar</string>
+    <string name="external_import_top_bar_back">Geri</string>
+    <string name="external_import_overflow_more">Daha fazla seçenek</string>
+    <string name="external_import_overflow_skip_remaining">Kalanları atla</string>
+    <string name="external_import_progress_scanning">Uygulamalarınız taranıyor…</string>
+    <string name="external_import_progress_auto_importing">Eşleşmeler içe aktarılıyor…</string>
+    <string name="external_import_progress_working">İşleniyor…</string>
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="one">%1$d uygulama incelendi</item>
+        <item quantity="other">%1$d uygulama incelendi</item>
+    </plurals>
+    <string name="external_import_card_action_skip">Atla</string>
+    <string name="external_import_card_action_link">Bağla</string>
+    <string name="external_import_card_action_more">Daha fazla eşleşme</string>
+    <string name="external_import_card_action_less">Eşleşmeleri gizle</string>
+    <string name="external_import_card_installer_chip">%1$s aracılığıyla yüklendi</string>
+    <string name="external_import_card_preselect_known">Bunun %1$s olduğunu düşünüyoruz · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">Depo bulmak için dokun</string>
+    <string name="external_import_card_expand_label">Diğer eşleşmeleri görmek için genişlet</string>
+    <string name="external_import_card_collapse_label">Kartı daralt</string>
+    <string name="external_import_search_icon_label">GitHub\'da ara</string>
+    <string name="external_import_search_empty">Eşleşme yok</string>
+    <string name="external_import_search_error_default">Arama başarısız</string>
+    <string name="external_import_search_placeholder_url">Bir github.com URL\'si yapıştırın veya arayın…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="one">%1$d uygulama artık takip ediliyor.</item>
+        <item quantity="other">%1$d uygulama artık takip ediliyor.</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">%1$d atlandı — Ayarlar\'dan yeniden tarama yapabilirsiniz.</string>
+    <string name="external_import_completion_action_view_all">Tümünü görüntüle</string>
+    <string name="external_import_empty_all_matched">Tümü eşleşti.\\nBağlanacak bir şey yok.</string>
+    <string name="external_import_empty_done">Tamam</string>
+    <string name="external_import_empty_no_apps_title">Bu cihazda GitHub uygulaması bulunamadı.</string>
+    <string name="external_import_empty_no_apps_body">Bu, her şeyin farklı bir mağaza aracılığıyla yüklendiği ya da yüklü uygulamalara erişimimizin olmadığı anlamına gelir.</string>
+    <string name="external_import_empty_grant_permission">İzin ver</string>
+    <string name="external_import_empty_ok">Tamam</string>
+    <string name="external_import_empty_add_manually">Başka bir mağazadan uygulama ekle</string>
+    <string name="external_import_permission_title">GitHub uygulamalarınızı bulun</string>
+    <string name="external_import_permission_body">Yüklü uygulamalarınızı tarayıp GitHub sürümleriyle eşleştirebiliriz; böylece güncellemeler ve algılama otomatik çalışır.\\n\\nBunun için hangi uygulamaların yüklü olduğunu görmemiz gerekiyor. İzin vermeden yalnızca yaklaşık 5 uygulama görebiliriz; izinle tümünü görebiliriz.\\n\\nUygulama listenizi izniniz olmadan hiçbir yere göndermiyoruz. Eşleştirme işlemi cihazınızda gerçekleşir. İsteğe bağlı sunucu araması yalnızca paket adını ve uygulama etiketini, varsa imza parmak izini, kurulum kaynağını ve uygulama manifest\'inde belirtilen GitHub depo ipucunu gönderir; yüklü uygulamaların tam listesini asla göndermez.</string>
+    <string name="external_import_permission_continue">Devam et</string>
+    <string name="external_import_permission_not_now">Şimdi değil</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="one">GitHub\'dan %1$d uygulama bulundu</item>
+        <item quantity="other">GitHub\'dan %1$d uygulama bulundu</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">Güncellemeleri burada takip etmek için inceleyin.</string>
+    <string name="external_import_proposal_banner_review">İncele</string>
+    <string name="external_import_proposal_banner_dismiss">Kapat</string>
+    <string name="external_import_match_confidence_a11y">Eşleşme güveni: yüzde %1$d</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">Bu uygulama bağlanamadı — tekrar deneyin.</string>
+    <string name="external_import_error_link_network">GitHub\'a ulaşılamadı. Daha sonra tekrar deneyin.</string>
+    <string name="external_import_error_scan_failed_default">Tarama başarısız</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">Tarayıcı</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">Bilinmeyen kaynak</string>
+    <string name="external_import_undo_linked">%1$s bağlandı.</string>
+    <string name="external_import_undo_skipped">%1$s atlandı.</string>
+    <string name="external_import_undo_action">Geri al</string>
+    <string name="external_import_undo_failed">Geri alınamadı — tekrar deneyin.</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="one">İncelenecek %1$d uygulama</item>
+        <item quantity="other">İncelenecek %1$d uygulama</item>
+    </plurals>
+    <string name="external_import_list_add_manually">Uygulamanızı görmüyor musunuz? Manuel olarak ekleyin</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="one">%1$d uygulama otomatik olarak bağlandı</item>
+        <item quantity="other">%1$d uygulama otomatik olarak bağlandı</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">Yüksek güvenle tanındılar. Bireysel eşleşmeleri her uygulamanın detaylarından geri alabilir ya da hepsini şimdi geri alabilirsiniz.</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="one">%1$d tanesi daha incelemenizi bekliyor.</item>
+        <item quantity="other">%1$d tanesi daha incelemenizi bekliyor.</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">Devam et</string>
+    <string name="external_import_auto_summary_undo_all">Tümünü geri al</string>
+    <string name="external_import_auto_summary_more_count">+%1$d daha</string>
+    <string name="external_import_rescan_menu">GitHub uygulamalarını tara</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">Bu depodan bağlantıyı kes</string>
+    <string name="details_unlink_external_app_more_options">Daha fazla seçenek</string>
+    <string name="details_unlink_external_app_dialog_title">Bu uygulamanın bağlantısı kesilsin mi?</string>
+    <string name="details_unlink_external_app_dialog_body">%1$s uygulamasını bu depodan yüklü olarak takip etmeyi bırakacağız. Uygulama cihazınızda kalır — yalnızca bağlantı kaldırılır.</string>
+    <string name="details_unlink_external_app_dialog_confirm">Bağlantıyı kes</string>
+    <string name="details_unlink_external_app_success">Bağlantı kesildi. Bir sonraki taramada eşleşme önereceğiz.</string>
+    <string name="details_unlink_external_app_failure">Bağlantı kesilemedi — tekrar deneyin.</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">Geri bildirim gönder</string>
+    <string name="feedback_title">Geri bildirim gönder</string>
+    <string name="feedback_close">Kapat</string>
+    <string name="feedback_category_label">Kategori</string>
+    <string name="feedback_category_bug">Hata</string>
+    <string name="feedback_category_feature">Özellik isteği</string>
+    <string name="feedback_category_change">Değişiklik isteği</string>
+    <string name="feedback_category_other">Diğer</string>
+    <string name="feedback_topic_label">Konu</string>
+    <string name="feedback_topic_install_update">Kurulum / Güncelleme</string>
+    <string name="feedback_topic_search">Arama &amp; Keşif</string>
+    <string name="feedback_topic_details">Depo ayrıntıları</string>
+    <string name="feedback_topic_auth">Kimlik Doğrulama &amp; Hesap</string>
+    <string name="feedback_topic_ui">Arayüz / UX</string>
+    <string name="feedback_topic_translation">Çeviri / Dil</string>
+    <string name="feedback_topic_performance">Performans</string>
+    <string name="feedback_topic_other">Diğer</string>
+    <string name="feedback_field_title">Başlık</string>
+    <string name="feedback_field_description">Açıklama</string>
+    <string name="feedback_field_steps">Yeniden oluşturma adımları</string>
+    <string name="feedback_field_expected_actual">Beklenen ve gerçekleşen</string>
+    <string name="feedback_field_use_case">Kullanım senaryosu</string>
+    <string name="feedback_field_proposed_solution">Önerilen çözüm</string>
+    <string name="feedback_field_current_behaviour">Mevcut davranış</string>
+    <string name="feedback_field_desired_behaviour">İstenen davranış</string>
+    <string name="feedback_diagnostics_header">Tanılama</string>
+    <string name="feedback_diagnostics_include">Tanılama bilgilerini dahil et</string>
+    <string name="feedback_send_via_email">E-posta gönder</string>
+    <string name="feedback_send_via_github">GitHub Issue olarak aç</string>
+    <string name="feedback_send_success_email">Teşekkürler — posta istemciniz açılıyor.</string>
+    <string name="feedback_send_success_github">Teşekkürler — tarayıcınız açılıyor.</string>
+    <string name="feedback_send_error">Geri bildirim kanalı açılamadı: %1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">İndirme Aynası</string>
+    <string name="mirror_picker_title">İndirme Aynası</string>
+    <string name="mirror_picker_description">Sürüm dosyalarını indirmek için kullanılır. GitHub API çağrıları her zaman doğrudan gider. Çoğu kullanıcı bunu Doğrudan GitHub olarak bırakmalıdır.</string>
+    <string name="mirror_section_official">Resmi</string>
+    <string name="mirror_section_community">Topluluk</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(kapalı)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">Özel ayna…</string>
+    <string name="mirror_custom_dialog_title">Özel ayna</string>
+    <string name="mirror_custom_dialog_hint">https://ayaniniz.ornek/{url}</string>
+    <string name="mirror_custom_validation_https">Şablon https:// ile başlamalıdır</string>
+    <string name="mirror_custom_validation_template">Şablon {url} ifadesini tam olarak bir kez içermelidir</string>
+    <string name="mirror_custom_save">Kaydet</string>
+    <string name="mirror_test_button">Seçileni test et</string>
+    <string name="mirror_test_in_progress">Test ediliyor…</string>
+    <string name="mirror_test_success">%1$dms\'de ulaşıldı</string>
+    <string name="mirror_test_http_error">Ayna %1$d döndürdü</string>
+    <string name="mirror_test_timeout">5s sonra zaman aşımı</string>
+    <string name="mirror_test_dns_fail">Ana bilgisayar çözümlenemedi</string>
+    <string name="mirror_test_other">Başarısız: %1$s</string>
+    <string name="mirror_deploy_your_own_hint">Tüm aynalar mı çöktü? 5 dakikada kendinizinkini barındırabilirsiniz — belgelere bakın.</string>
+    <string name="mirror_removed_toast">%1$s artık kullanılamıyor, Doğrudan GitHub\'a geçildi.</string>
+    <string name="mirror_digest_mismatch_error">Sağlama toplamı uyumsuzluğu — dosya değiştirilmiş olabilir</string>
+    <string name="mirror_auto_suggest_title">Daha hızlı bir ayna deneyin mi?</string>
+    <string name="mirror_auto_suggest_body">Yavaş ağlardaki bazı kullanıcılar topluluk proxy\'siyle daha iyi sonuç alıyor.</string>
+    <string name="mirror_auto_suggest_pick_one">Birini seç</string>
+    <string name="mirror_auto_suggest_maybe_later">Belki daha sonra</string>
+    <string name="mirror_auto_suggest_dont_ask_again">Bir daha sorma</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -762,7 +762,7 @@
     </plurals>
     <string name="external_import_completion_skipped_subline">已跳过 %1$d 个 — 您可以在设置中重新扫描。</string>
     <string name="external_import_completion_action_view_all">查看全部</string>
-    <string name="external_import_empty_all_matched">全部已关联。\\n没有需要关联的内容。</string>
+    <string name="external_import_empty_all_matched">全部已关联。\n没有需要关联的内容。</string>
     <string name="external_import_empty_done">完成</string>
     <string name="external_import_empty_no_apps_title">在此设备上未找到 GitHub 应用。</string>
     <string name="external_import_empty_no_apps_body">这意味着所有应用都通过其他商店安装，或者我们无法获取已安装应用的信息。</string>
@@ -770,7 +770,7 @@
     <string name="external_import_empty_ok">确定</string>
     <string name="external_import_empty_add_manually">从其他商店添加应用</string>
     <string name="external_import_permission_title">找到您的 GitHub 应用</string>
-    <string name="external_import_permission_body">我们可以扫描您已安装的应用并将其与 GitHub 发布版本匹配，让更新检测自动运行。\\n\\n为此，我们需要查看您安装了哪些应用。没有权限时我们只能看到约 5 个应用；有权限时可以看到全部。\\n\\n未经您的许可，我们绝不会将您的应用列表发送到任何地方。匹配过程在您的设备上进行。可选的后端查询仅发送包名和应用标签，以及（如有）签名指纹、安装来源和应用 manifest 中声明的 GitHub 仓库提示，绝不发送完整的已安装应用列表。</string>
+    <string name="external_import_permission_body">我们可以扫描您已安装的应用并将其与 GitHub 发布版本匹配，让更新检测自动运行。\n\n为此，我们需要查看您安装了哪些应用。没有权限时我们只能看到约 5 个应用；有权限时可以看到全部。\n\n未经您的许可，我们绝不会将您的应用列表发送到任何地方。匹配过程在您的设备上进行。可选的后端查询仅发送包名和应用标签，以及（如有）签名指纹、安装来源和应用 manifest 中声明的 GitHub 仓库提示，绝不发送完整的已安装应用列表。</string>
     <string name="external_import_permission_continue">继续</string>
     <string name="external_import_permission_not_now">暂不</string>
     <plurals name="external_import_proposal_banner_headline">

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -709,4 +709,187 @@
     <string name="pat_error_bad_credentials">该令牌无效或已被吊销。</string>
     <string name="pat_error_insufficient_scope">该令牌缺少所需权限。</string>
     <string name="pat_error_generic">保存令牌失败。请重试。</string>
+
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E10 — Apps sort
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="sort_apps">应用排序</string>
+    <string name="sort_updates_first">更新优先</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Pre-release channel UX (Details screen)
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="channel_chip_include_betas">包含测试版</string>
+    <string name="channel_chip_stable_only">仅稳定版</string>
+    <string name="channel_toggle_cd">切换此应用的测试版发布</string>
+    <string name="action_switch_to_stable">切换到 %1$s 稳定版</string>
+    <string name="stalled_project_warning_months">%1$d 个月内无稳定版发布</string>
+    <string name="stalled_project_warning_days">%1$d 天内无稳定版发布</string>
+    <string name="stalled_project_warning_description">目前有活跃的预发布版本，但该项目已有一段时间未发布稳定版。测试版可能不会收敛为稳定版。</string>
+    <string name="merged_whats_changed_title">自 %1$s 以来的变更</string>
+    <string name="merged_release_heading">— %1$s —</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — External import wizard
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="external_import_top_bar_title">导入已安装的应用</string>
+    <string name="external_import_top_bar_back">返回</string>
+    <string name="external_import_overflow_more">更多选项</string>
+    <string name="external_import_overflow_skip_remaining">跳过剩余</string>
+    <string name="external_import_progress_scanning">正在扫描您的应用…</string>
+    <string name="external_import_progress_auto_importing">正在导入匹配项…</string>
+    <string name="external_import_progress_working">处理中…</string>
+    <!-- Chinese uses "other" only -->
+    <plurals name="external_import_progress_subtitle_count">
+        <item quantity="other">已检查 %1$d 个应用</item>
+    </plurals>
+    <string name="external_import_card_action_skip">跳过</string>
+    <string name="external_import_card_action_link">关联</string>
+    <string name="external_import_card_action_more">更多匹配</string>
+    <string name="external_import_card_action_less">隐藏匹配</string>
+    <string name="external_import_card_installer_chip">通过 %1$s 安装</string>
+    <string name="external_import_card_preselect_known">我们认为这是 %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_unknown">点击查找仓库</string>
+    <string name="external_import_card_expand_label">展开以查看其他匹配</string>
+    <string name="external_import_card_collapse_label">收起卡片</string>
+    <string name="external_import_search_icon_label">搜索 GitHub</string>
+    <string name="external_import_search_empty">无匹配结果</string>
+    <string name="external_import_search_error_default">搜索失败</string>
+    <string name="external_import_search_placeholder_url">粘贴 github.com URL 或搜索…</string>
+    <plurals name="external_import_completion_headline">
+        <item quantity="other">现在正在追踪 %1$d 个应用。</item>
+    </plurals>
+    <string name="external_import_completion_skipped_subline">已跳过 %1$d 个 — 您可以在设置中重新扫描。</string>
+    <string name="external_import_completion_action_view_all">查看全部</string>
+    <string name="external_import_empty_all_matched">全部已关联。\\n没有需要关联的内容。</string>
+    <string name="external_import_empty_done">完成</string>
+    <string name="external_import_empty_no_apps_title">在此设备上未找到 GitHub 应用。</string>
+    <string name="external_import_empty_no_apps_body">这意味着所有应用都通过其他商店安装，或者我们无法获取已安装应用的信息。</string>
+    <string name="external_import_empty_grant_permission">授予权限</string>
+    <string name="external_import_empty_ok">确定</string>
+    <string name="external_import_empty_add_manually">从其他商店添加应用</string>
+    <string name="external_import_permission_title">找到您的 GitHub 应用</string>
+    <string name="external_import_permission_body">我们可以扫描您已安装的应用并将其与 GitHub 发布版本匹配，让更新检测自动运行。\\n\\n为此，我们需要查看您安装了哪些应用。没有权限时我们只能看到约 5 个应用；有权限时可以看到全部。\\n\\n未经您的许可，我们绝不会将您的应用列表发送到任何地方。匹配过程在您的设备上进行。可选的后端查询仅发送包名和应用标签，以及（如有）签名指纹、安装来源和应用 manifest 中声明的 GitHub 仓库提示，绝不发送完整的已安装应用列表。</string>
+    <string name="external_import_permission_continue">继续</string>
+    <string name="external_import_permission_not_now">暂不</string>
+    <plurals name="external_import_proposal_banner_headline">
+        <item quantity="other">从 GitHub 找到 %1$d 个应用</item>
+    </plurals>
+    <string name="external_import_proposal_banner_body">审阅它们以在此追踪更新。</string>
+    <string name="external_import_proposal_banner_review">审阅</string>
+    <string name="external_import_proposal_banner_dismiss">关闭</string>
+    <string name="external_import_match_confidence_a11y">匹配置信度：%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_error_link_failed">无法关联此应用 — 请重试。</string>
+    <string name="external_import_error_link_network">无法连接到 GitHub，请稍后重试。</string>
+    <string name="external_import_error_scan_failed_default">扫描失败</string>
+    <string name="external_import_installer_obtainium">Obtainium</string>
+    <string name="external_import_installer_fdroid">F-Droid</string>
+    <string name="external_import_installer_browser">浏览器</string>
+    <string name="external_import_installer_sideload">Sideload</string>
+    <string name="external_import_installer_self">GitHub Store</string>
+    <string name="external_import_installer_unknown">未知来源</string>
+    <string name="external_import_undo_linked">%1$s 已关联。</string>
+    <string name="external_import_undo_skipped">%1$s 已跳过。</string>
+    <string name="external_import_undo_action">撤销</string>
+    <string name="external_import_undo_failed">无法撤销 — 请重试。</string>
+    <plurals name="external_import_list_remaining">
+        <item quantity="other">%1$d 个应用待审阅</item>
+    </plurals>
+    <string name="external_import_list_add_manually">未看到您的应用？手动添加</string>
+    <plurals name="external_import_auto_summary_headline">
+        <item quantity="other">已自动关联 %1$d 个应用</item>
+    </plurals>
+    <string name="external_import_auto_summary_body">我们以高置信度识别了这些应用。您可以在每个应用的详情中撤销单个匹配，或立即全部撤销。</string>
+    <plurals name="external_import_auto_summary_review_hint">
+        <item quantity="other">还有 %1$d 个需要您的确认。</item>
+    </plurals>
+    <string name="external_import_auto_summary_continue">继续</string>
+    <string name="external_import_auto_summary_undo_all">全部撤销</string>
+    <string name="external_import_auto_summary_more_count">+%1$d 更多</string>
+    <string name="external_import_rescan_menu">扫描 GitHub 应用</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E1 — Details unlink dialog
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="details_unlink_external_app_menu">从此仓库取消关联</string>
+    <string name="details_unlink_external_app_more_options">更多选项</string>
+    <string name="details_unlink_external_app_dialog_title">取消关联此应用？</string>
+    <string name="details_unlink_external_app_dialog_body">我们将停止追踪 %1$s 作为从此仓库安装的应用。该应用仍保留在您的设备上 — 仅删除关联。</string>
+    <string name="details_unlink_external_app_dialog_confirm">取消关联</string>
+    <string name="details_unlink_external_app_success">已取消关联。下次扫描时将重新建议匹配。</string>
+    <string name="details_unlink_external_app_failure">无法取消关联 — 请重试。</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Feedback feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="feedback_send">发送反馈</string>
+    <string name="feedback_title">发送反馈</string>
+    <string name="feedback_close">关闭</string>
+    <string name="feedback_category_label">类别</string>
+    <string name="feedback_category_bug">缺陷</string>
+    <string name="feedback_category_feature">功能请求</string>
+    <string name="feedback_category_change">变更请求</string>
+    <string name="feedback_category_other">其他</string>
+    <string name="feedback_topic_label">主题</string>
+    <string name="feedback_topic_install_update">安装 / 更新</string>
+    <string name="feedback_topic_search">搜索 &amp; 发现</string>
+    <string name="feedback_topic_details">仓库详情</string>
+    <string name="feedback_topic_auth">认证 &amp; 账户</string>
+    <string name="feedback_topic_ui">界面 / UX</string>
+    <string name="feedback_topic_translation">翻译 / 语言</string>
+    <string name="feedback_topic_performance">性能</string>
+    <string name="feedback_topic_other">其他</string>
+    <string name="feedback_field_title">标题</string>
+    <string name="feedback_field_description">描述</string>
+    <string name="feedback_field_steps">重现步骤</string>
+    <string name="feedback_field_expected_actual">预期与实际</string>
+    <string name="feedback_field_use_case">使用场景</string>
+    <string name="feedback_field_proposed_solution">建议解决方案</string>
+    <string name="feedback_field_current_behaviour">当前行为</string>
+    <string name="feedback_field_desired_behaviour">期望行为</string>
+    <string name="feedback_diagnostics_header">诊断信息</string>
+    <string name="feedback_diagnostics_include">包含诊断信息</string>
+    <string name="feedback_send_via_email">通过邮件发送</string>
+    <string name="feedback_send_via_github">作为 GitHub Issue 打开</string>
+    <string name="feedback_send_success_email">感谢您 — 正在打开邮件客户端。</string>
+    <string name="feedback_send_success_github">感谢您 — 正在打开浏览器。</string>
+    <string name="feedback_send_error">无法打开反馈渠道：%1$s</string>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         E5 — Mirror feature
+         ═══════════════════════════════════════════════════════════════ -->
+    <string name="mirror_tweaks_entry_label">下载镜像</string>
+    <string name="mirror_picker_title">下载镜像</string>
+    <string name="mirror_picker_description">用于下载发布资源。GitHub API 调用始终直接进行。大多数用户应保持"直连 GitHub"设置。</string>
+    <string name="mirror_section_official">官方</string>
+    <string name="mirror_section_community">社区</string>
+    <string name="mirror_status_ok">%1$dms</string>
+    <string name="mirror_status_degraded">%1$dms</string>
+    <string name="mirror_status_down">(不可用)</string>
+    <string name="mirror_status_unknown">?</string>
+    <string name="mirror_custom_label">自定义镜像…</string>
+    <string name="mirror_custom_dialog_title">自定义镜像</string>
+    <string name="mirror_custom_dialog_hint">https://your-mirror.example/{url}</string>
+    <string name="mirror_custom_validation_https">模板必须以 https:// 开头</string>
+    <string name="mirror_custom_validation_template">模板必须恰好包含一次 {url}</string>
+    <string name="mirror_custom_save">保存</string>
+    <string name="mirror_test_button">测试所选</string>
+    <string name="mirror_test_in_progress">测试中…</string>
+    <string name="mirror_test_success">已在 %1$dms 内到达</string>
+    <string name="mirror_test_http_error">镜像返回 %1$d</string>
+    <string name="mirror_test_timeout">5s 后超时</string>
+    <string name="mirror_test_dns_fail">无法解析主机</string>
+    <string name="mirror_test_other">失败：%1$s</string>
+    <string name="mirror_deploy_your_own_hint">所有镜像都无法使用？您可以在 5 分钟内自行托管 — 请参阅文档。</string>
+    <string name="mirror_removed_toast">%1$s 已不再可用，已切换到直连 GitHub。</string>
+    <string name="mirror_digest_mismatch_error">校验和不匹配 — 文件可能已被篡改</string>
+    <string name="mirror_auto_suggest_title">尝试更快的镜像？</string>
+    <string name="mirror_auto_suggest_body">网络较慢的部分用户使用社区代理效果更好。</string>
+    <string name="mirror_auto_suggest_pick_one">选择一个</string>
+    <string name="mirror_auto_suggest_maybe_later">稍后再说</string>
+    <string name="mirror_auto_suggest_dont_ask_again">不再询问</string>
+
+
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -749,7 +749,7 @@
     <string name="external_import_card_action_more">更多匹配</string>
     <string name="external_import_card_action_less">隐藏匹配</string>
     <string name="external_import_card_installer_chip">通过 %1$s 安装</string>
-    <string name="external_import_card_preselect_known">我们认为这是 %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">我们认为这是 %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">点击查找仓库</string>
     <string name="external_import_card_expand_label">展开以查看其他匹配</string>
     <string name="external_import_card_collapse_label">收起卡片</string>
@@ -779,8 +779,8 @@
     <string name="external_import_proposal_banner_body">审阅它们以在此追踪更新。</string>
     <string name="external_import_proposal_banner_review">审阅</string>
     <string name="external_import_proposal_banner_dismiss">关闭</string>
-    <string name="external_import_match_confidence_a11y">匹配置信度：%1$d%%</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_a11y">匹配置信度：%1$d 百分比</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">无法关联此应用 — 请重试。</string>
     <string name="external_import_error_link_network">无法连接到 GitHub，请稍后重试。</string>
     <string name="external_import_error_scan_failed_default">扫描失败</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -784,7 +784,7 @@
     <string name="external_import_card_action_skip">Skip</string>
     <string name="external_import_card_action_link">Link</string>
     <string name="external_import_card_installer_chip">Installed via %1$s</string>
-    <string name="external_import_card_preselect_known">We think this is %1$s · %2$d%%</string>
+    <string name="external_import_card_preselect_known">We think this is %1$s · %2$d</string>
     <string name="external_import_card_preselect_unknown">Tap to find a repo</string>
     <string name="external_import_card_expand_label">Expand to see other matches</string>
     <string name="external_import_card_collapse_label">Collapse card</string>
@@ -816,7 +816,7 @@
     <string name="external_import_proposal_banner_review">Review</string>
     <string name="external_import_proposal_banner_dismiss">Dismiss</string>
     <string name="external_import_match_confidence_a11y">Match confidence: %1$d percent</string>
-    <string name="external_import_match_confidence_chip">%1$d%%</string>
+    <string name="external_import_match_confidence_chip">%1$d</string>
     <string name="external_import_error_link_failed">Couldn't link this app — try again.</string>
     <string name="external_import_error_link_network">Couldn't reach GitHub. Try again later.</string>
     <string name="external_import_error_scan_failed_default">Scan failed</string>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/CandidateCard.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/CandidateCard.kt
@@ -273,7 +273,7 @@ private fun PreselectedRow(suggestion: RepoSuggestionUi?) {
                         Res.string.external_import_card_preselect_known,
                         suggestion.ownerSlashRepo,
                         percent,
-                    ),
+                    ) + "%",
                 style = MaterialTheme.typography.bodyMedium,
                 color = contentColor,
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/RepoCandidateRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/RepoCandidateRow.kt
@@ -110,7 +110,7 @@ fun RepoCandidateRow(
                 },
         ) {
             Text(
-                text = stringResource(Res.string.external_import_match_confidence_chip, percent),
+                text = stringResource(Res.string.external_import_match_confidence_chip, percent) + "%",
                 style = MaterialTheme.typography.labelMedium,
                 color = chipFg,
                 modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),


### PR DESCRIPTION
Adds translated strings to `core:presentation` supporting several feature workstreams: the External Import wizard (E1) including the unlink dialog, Download Mirroring (E5) with mirror testing, App List sorting (E10), the Feedback reporting system, and Pre-release channel UX.

Locales updated: ES, TR, ZH-rCN, KO, FR, HI, RU, JA, BN, AR, PL, and IT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App sorting and filtering options
  * Pre-release beta channel controls
  * External app import wizard (scan, link, undo, progress/summary)
  * User feedback submission form (categories, diagnostics, send)
  * Download mirror selection, validation and testing
  * Unlink external app tracking

* **Localization**
  * Added strings and plurals across Arabic, Bengali, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Russian, Turkish, Simplified Chinese

* **Bug Fixes**
  * Standardized match-confidence display formatting (percent sign handling)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->