### PR TITLE
feat: support multiple installed apps per repository (monorepo)

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -150,6 +150,10 @@
                 <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED" />
                 <data android:scheme="package" />
             </intent-filter>
+            <!-- Self-update detection: MY_PACKAGE_REPLACED has no data scheme -->
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
         </receiver>
 
         <!-- Cancel action fired from the download progress notification (#373) -->

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
@@ -145,7 +145,16 @@ class GithubStoreApp : Application() {
                 val selfPackageName = packageName
                 val existing = repo.getAppByPackage(selfPackageName)
 
-                if (existing != null) return@launch
+                if (existing != null) {
+                    // After a self-update the old process is killed before
+                    // ACTION_PACKAGE_REPLACED can be delivered to our own
+                    // receiver, so isPendingInstall stays true. Resolve it
+                    // here at the earliest startup opportunity.
+                    if (existing.isPendingInstall) {
+                        resolveSelfPendingInstall(existing, repo)
+                    }
+                    return@launch
+                }
 
                 val packageMonitor = get<PackageMonitor>()
                 val systemInfo = packageMonitor.getInstalledPackageInfo(selfPackageName)
@@ -196,6 +205,39 @@ class GithubStoreApp : Application() {
             } catch (e: Exception) {
                 Logger.e(e) { "GitHub Store App: Failed to register self as installed app" }
             }
+        }
+    }
+
+    /**
+     * Resolves a stale `isPendingInstall` flag for the app's own
+     * database row. Called on every cold start when the row exists
+     * and still has the flag set — the typical scenario after a
+     * successful self-update where the broadcast path missed.
+     */
+    private suspend fun resolveSelfPendingInstall(
+        existing: InstalledApp,
+        repo: InstalledAppsRepository,
+    ) {
+        try {
+            val packageMonitor = get<PackageMonitor>()
+            val systemInfo = packageMonitor.getInstalledPackageInfo(packageName)
+            if (systemInfo != null) {
+                val latestVersionCode = existing.latestVersionCode ?: 0L
+                repo.updateApp(
+                    existing.copy(
+                        isPendingInstall = false,
+                        installedVersionName = systemInfo.versionName,
+                        installedVersionCode = systemInfo.versionCode,
+                        isUpdateAvailable = latestVersionCode > systemInfo.versionCode,
+                    ),
+                )
+                Logger.i { "Resolved self-update pending install: ${systemInfo.versionName} (code=${systemInfo.versionCode})" }
+            } else {
+                repo.updatePendingStatus(packageName, false)
+                Logger.i { "Resolved self-update pending install (no system info)" }
+            }
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to resolve self-update pending install" }
         }
     }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
@@ -86,7 +86,15 @@ class PackageEventReceiver() :
         context: Context?,
         intent: Intent?,
     ) {
-        val packageName = intent?.data?.schemeSpecificPart ?: return
+        // MY_PACKAGE_REPLACED has no data URI — the target is the
+        // receiving app itself. Fall back to the context's package name.
+        val packageName = intent?.data?.schemeSpecificPart
+            ?: if (intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+                context?.packageName
+            } else {
+                null
+            }
+            ?: return
 
         Logger.d { "PackageEventReceiver: ${intent.action} for $packageName" }
 
@@ -94,6 +102,7 @@ class PackageEventReceiver() :
             when (intent.action) {
                 Intent.ACTION_PACKAGE_ADDED,
                 Intent.ACTION_PACKAGE_REPLACED,
+                Intent.ACTION_MY_PACKAGE_REPLACED,
                 -> {
                     scope.launch { onPackageInstalled(packageName) }
                 }
@@ -357,6 +366,7 @@ class PackageEventReceiver() :
                 addAction(Intent.ACTION_PACKAGE_ADDED)
                 addAction(Intent.ACTION_PACKAGE_REPLACED)
                 addAction(Intent.ACTION_PACKAGE_FULLY_REMOVED)
+                addAction(Intent.ACTION_MY_PACKAGE_REPLACED)
                 addDataScheme("package")
             }
     }


### PR DESCRIPTION
## Summary
Remove the one-repo-to-one-app assumption that prevented installing and tracking multiple apps from the same GitHub repository.

Closes #471, Closes #420

## Problem
Repos that ship multiple distinct apps in their releases (e.g. `ente-io/ente` ships Auth + Photos + Locker, Proton ships Mail + VPN + Drive) could only have one app tracked. Installing a second app from the same repo was blocked, and update checking only tracked the first installed asset.

## What Changed
**Core layer (DAO + Repository):**
- Added `getAppsByRepoId()` and `getAppsByRepoIdAsFlow()` list-returning queries to `InstalledAppDao` alongside existing single-returning queries
- Added matching methods to `InstalledAppsRepository` interface and implementation

**Badge/status across all screens:**
- Home, Search, DevProfile: `associateBy { it.repoId }` → `groupBy { it.repoId }` so installed/update badges reflect *any* tracked app per repo
- Favourites & Starred: switched to list queries for install status

**Details screen:**
- Added `installedApps: List<InstalledApp>` to `DetailsState`
- `loadInitial()` fetches all installed apps via `getAppsByRepoId()`
- `observeInstalledApp()` uses `getAppsByRepoIdAsFlow()`, picks primary by `assetFilterRegex` match

## What Already Worked (no changes needed)
- Background update checker (`checkForUpdates` per package name)
- Export/import (keyed by `packageName`)
- Advanced settings sheet (asset filter regex + fallback toggle)
- DB schema (PK is `packageName`, not `repoId`)

## Follow-up Work
- **Multi-app indicator UI**: Show collapsible section in Details when `installedApps.size > 1`, listing each tracked app
- **SmartInstallButton enhancement**: Show "N apps tracked" indicator for monorepo repos

## Test with
- `ente-io/ente` (ships auth, photos, locker)
- `AChep/keyguard-app` (multiple APK variants)
- `nicehash/NiceHashQuickMiner` (multiple tools)

---
[Warp conversation](https://app.warp.dev/conversation/9f15c1c4-19c5-4ffd-b0fb-410c788e0ee4)
[Implementation plan](https://app.warp.dev/drive/notebook/f2bUfWf2TeKWtRqLsvy9xD)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for repositories containing multiple application packages (monorepos)
  * Enhanced self-update detection mechanisms for improved app refresh handling

* **Documentation**
  * Added comprehensive architectural documentation and project structure guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->