### PR TITLE
fix: resolve stuck 'preparing to install' after self-update (#478)

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -150,6 +150,10 @@
                 <action android:name="android.intent.action.PACKAGE_FULLY_REMOVED" />
                 <data android:scheme="package" />
             </intent-filter>
+            <!-- Self-update detection: MY_PACKAGE_REPLACED has no data scheme -->
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
         </receiver>
 
         <!-- Cancel action fired from the download progress notification (#373) -->

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
@@ -145,7 +145,16 @@ class GithubStoreApp : Application() {
                 val selfPackageName = packageName
                 val existing = repo.getAppByPackage(selfPackageName)
 
-                if (existing != null) return@launch
+                if (existing != null) {
+                    // After a self-update the old process is killed before
+                    // ACTION_PACKAGE_REPLACED can be delivered to our own
+                    // receiver, so isPendingInstall stays true. Resolve it
+                    // here at the earliest startup opportunity.
+                    if (existing.isPendingInstall) {
+                        resolveSelfPendingInstall(existing, repo)
+                    }
+                    return@launch
+                }
 
                 val packageMonitor = get<PackageMonitor>()
                 val systemInfo = packageMonitor.getInstalledPackageInfo(selfPackageName)
@@ -196,6 +205,39 @@ class GithubStoreApp : Application() {
             } catch (e: Exception) {
                 Logger.e(e) { "GitHub Store App: Failed to register self as installed app" }
             }
+        }
+    }
+
+    /**
+     * Resolves a stale `isPendingInstall` flag for the app's own
+     * database row. Called on every cold start when the row exists
+     * and still has the flag set — the typical scenario after a
+     * successful self-update where the broadcast path missed.
+     */
+    private suspend fun resolveSelfPendingInstall(
+        existing: InstalledApp,
+        repo: InstalledAppsRepository,
+    ) {
+        try {
+            val packageMonitor = get<PackageMonitor>()
+            val systemInfo = packageMonitor.getInstalledPackageInfo(packageName)
+            if (systemInfo != null) {
+                val latestVersionCode = existing.latestVersionCode ?: 0L
+                repo.updateApp(
+                    existing.copy(
+                        isPendingInstall = false,
+                        installedVersionName = systemInfo.versionName,
+                        installedVersionCode = systemInfo.versionCode,
+                        isUpdateAvailable = latestVersionCode > systemInfo.versionCode,
+                    ),
+                )
+                Logger.i { "Resolved self-update pending install: ${systemInfo.versionName} (code=${systemInfo.versionCode})" }
+            } else {
+                repo.updatePendingStatus(packageName, false)
+                Logger.i { "Resolved self-update pending install (no system info)" }
+            }
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to resolve self-update pending install" }
         }
     }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
@@ -86,7 +86,15 @@ class PackageEventReceiver() :
         context: Context?,
         intent: Intent?,
     ) {
-        val packageName = intent?.data?.schemeSpecificPart ?: return
+        // MY_PACKAGE_REPLACED has no data URI — the target is the
+        // receiving app itself. Fall back to the context's package name.
+        val packageName = intent?.data?.schemeSpecificPart
+            ?: if (intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+                context?.packageName
+            } else {
+                null
+            }
+            ?: return
 
         Logger.d { "PackageEventReceiver: ${intent.action} for $packageName" }
 
@@ -94,6 +102,7 @@ class PackageEventReceiver() :
             when (intent.action) {
                 Intent.ACTION_PACKAGE_ADDED,
                 Intent.ACTION_PACKAGE_REPLACED,
+                Intent.ACTION_MY_PACKAGE_REPLACED,
                 -> {
                     scope.launch { onPackageInstalled(packageName) }
                 }
@@ -357,6 +366,7 @@ class PackageEventReceiver() :
                 addAction(Intent.ACTION_PACKAGE_ADDED)
                 addAction(Intent.ACTION_PACKAGE_REPLACED)
                 addAction(Intent.ACTION_PACKAGE_FULLY_REMOVED)
+                addAction(Intent.ACTION_MY_PACKAGE_REPLACED)
                 addDataScheme("package")
             }
     }


### PR DESCRIPTION
## Problem
After GitHub Store updates itself, the install status permanently shows "preparing to install" because Android does **not** deliver `ACTION_PACKAGE_REPLACED` to the app's own receivers. The existing `registerSelfAsInstalledApp()` returned early when the DB row already existed, never clearing the stale `isPendingInstall = true` flag.

## Fix (3-layered)

### 1. `GithubStoreApp.registerSelfAsInstalledApp()`
When the existing DB row has `isPendingInstall = true`, a new `resolveSelfPendingInstall()` method queries the system PackageManager, updates version info, and clears the pending flag. Runs in `Application.onCreate()` — the earliest startup point.

### 2. `PackageEventReceiver`
Added `ACTION_MY_PACKAGE_REPLACED` handling — Android's dedicated broadcast for self-updates (guaranteed delivery to the updated app). Since `MY_PACKAGE_REPLACED` carries no data URI, `onReceive()` falls back to `context.packageName`.

### 3. `AndroidManifest.xml`
Added a separate `<intent-filter>` for `MY_PACKAGE_REPLACED` (without the `package` data scheme, since this broadcast doesn't use one).

The existing `SyncInstalledAppsUseCase` remains as a third safety net.

Closes #478

---
[Warp conversation](https://app.warp.dev/conversation/9d2c1ebd-d44f-4c3f-8265-051ec7924a4c)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app self-update detection and properly clears stale pending-install states during startup after device updates.

* **Improvements**
  * Enhanced handling of app replacement events to better synchronize installation status with device state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->