### PR TITLE
feat: sectioned compact rows on installed apps screen (#463)

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -951,4 +951,18 @@
     <string name="mirror_auto_suggest_pick_one">Pick one</string>
     <string name="mirror_auto_suggest_maybe_later">Maybe later</string>
     <string name="mirror_auto_suggest_dont_ask_again">Don't ask again</string>
+
+    <!-- Apps screen sections (issue #463) -->
+    <string name="apps_section_updates_available">Updates available</string>
+    <string name="apps_section_up_to_date">Up to date</string>
+    <string name="apps_section_count_suffix">· %1$d</string>
+    <string name="apps_section_expand">Expand section</string>
+    <string name="apps_section_collapse">Collapse section</string>
+    <string name="apps_compact_more_actions">More actions for %1$s</string>
+    <string name="apps_compact_status_filter_active">monorepo filter active</string>
+    <string name="apps_compact_status_variant_pinned">variant pinned</string>
+    <string name="apps_compact_status_pre_release_on">pre-release on</string>
+    <string name="apps_compact_status_variant_stale">variant stale, action needed</string>
+    <string name="apps_compact_status_pending_install">pending install</string>
+    <string name="apps_compact_status_ready_to_install">ready to install</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -958,6 +958,10 @@
     <string name="apps_section_count_suffix">· %1$d</string>
     <string name="apps_section_expand">Expand section</string>
     <string name="apps_section_collapse">Collapse section</string>
+    <string name="apps_section_state_expanded">expanded</string>
+    <string name="apps_section_state_collapsed">collapsed</string>
+    <string name="apps_section_header_a11y_collapsible">%1$s, %2$d, %3$s</string>
+    <string name="apps_section_header_a11y_static">%1$s, %2$d</string>
     <string name="apps_compact_more_actions">More actions for %1$s</string>
     <string name="apps_compact_status_filter_active">monorepo filter active</string>
     <string name="apps_compact_status_variant_pinned">variant pinned</string>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -37,6 +37,8 @@ sealed interface AppsAction {
 
     data object OnRefresh : AppsAction
 
+    data object OnToggleUpToDateSection : AppsAction
+
     data class OnNavigateToRepo(
         val repoId: Long,
     ) : AppsAction

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -89,6 +89,8 @@ import kotlin.time.Instant
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.apps.presentation.components.AdvancedAppSettingsBottomSheet
+import zed.rainxch.apps.presentation.components.AppsSectionHeader
+import zed.rainxch.apps.presentation.components.CompactAppRow
 import zed.rainxch.apps.presentation.components.InstalledAppIcon
 import zed.rainxch.apps.presentation.components.LinkAppBottomSheet
 import zed.rainxch.apps.presentation.components.VariantPickerDialog
@@ -108,6 +110,8 @@ import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.add_by_link
 import zed.rainxch.githubstore.core.presentation.res.advanced_settings_open
+import zed.rainxch.githubstore.core.presentation.res.apps_section_up_to_date
+import zed.rainxch.githubstore.core.presentation.res.apps_section_updates_available
 import zed.rainxch.githubstore.core.presentation.res.install
 import zed.rainxch.githubstore.core.presentation.res.ready_to_install
 import zed.rainxch.githubstore.core.presentation.res.variant_label_inline
@@ -529,6 +533,15 @@ fun AppsScreen(
                     else -> {
                         val listState = rememberLazyListState()
                         val isScrollbarEnabled = LocalScrollbarEnabled.current
+
+                        // Split filteredApps into the "Updates available" group (rich
+                        // rows) and the "Up to date" group (compact rows) — issue #463.
+                        // Sort order is already applied by the ViewModel.
+                        val updatesGroup =
+                            state.filteredApps.filter { it.installedApp.isUpdateAvailable }
+                        val idleGroup =
+                            state.filteredApps.filter { !it.installedApp.isUpdateAvailable }
+
                         ScrollbarContainer(
                             listState = listState,
                             enabled = isScrollbarEnabled,
@@ -537,56 +550,127 @@ fun AppsScreen(
                             LazyColumn(
                                 state = listState,
                                 modifier = Modifier.fillMaxSize().arrowKeyScroll(listState),
-                                contentPadding = PaddingValues(16.dp),
-                                verticalArrangement = Arrangement.spacedBy(12.dp),
+                                contentPadding = PaddingValues(horizontal = 0.dp, vertical = 8.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 if (state.showImportProposalBanner) {
                                     item(key = "external-import-banner") {
-                                        ImportProposalBanner(
-                                            pendingCount = state.pendingExternalImportCount,
-                                            onReview = { onAction(AppsAction.OnImportProposalReview) },
-                                            onDismiss = { onAction(AppsAction.OnImportProposalDismiss) },
-                                        )
+                                        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                                            ImportProposalBanner(
+                                                pendingCount = state.pendingExternalImportCount,
+                                                onReview = { onAction(AppsAction.OnImportProposalReview) },
+                                                onDismiss = { onAction(AppsAction.OnImportProposalDismiss) },
+                                            )
+                                        }
                                     }
                                 }
-                                items(
-                                    items = state.filteredApps,
-                                    key = { it.installedApp.packageName },
-                                ) { appItem ->
-                                    AppItemCard(
-                                        appItem = appItem,
-                                        onOpenClick = { onAction(AppsAction.OnOpenApp(appItem.installedApp)) },
-                                        onUpdateClick = { onAction(AppsAction.OnUpdateApp(appItem.installedApp)) },
-                                        onCancelClick = { onAction(AppsAction.OnCancelUpdate(appItem.installedApp.packageName)) },
-                                        onUninstallClick = { onAction(AppsAction.OnUninstallApp(appItem.installedApp)) },
-                                        onRepoClick = { onAction(AppsAction.OnNavigateToRepo(appItem.installedApp.repoId)) },
-                                        onTogglePreReleases = { enabled ->
-                                            onAction(AppsAction.OnTogglePreReleases(appItem.installedApp.packageName, enabled))
-                                        },
-                                        onAdvancedSettingsClick = {
-                                            onAction(AppsAction.OnOpenAdvancedSettings(appItem.installedApp))
-                                        },
-                                        onPickVariantClick = {
-                                            onAction(
-                                                AppsAction.OnOpenVariantPicker(
-                                                    app = appItem.installedApp,
-                                                    resumeUpdateAfterPick = false,
-                                                ),
+
+                                if (updatesGroup.isNotEmpty()) {
+                                    item(key = "header-updates-available") {
+                                        AppsSectionHeader(
+                                            title = stringResource(Res.string.apps_section_updates_available),
+                                            count = updatesGroup.size,
+                                            isExpanded = true,
+                                            collapsible = false,
+                                            onToggle = {},
+                                        )
+                                    }
+                                    items(
+                                        items = updatesGroup,
+                                        key = { "rich-${it.installedApp.packageName}" },
+                                    ) { appItem ->
+                                        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                                            AppItemCard(
+                                                appItem = appItem,
+                                                onOpenClick = { onAction(AppsAction.OnOpenApp(appItem.installedApp)) },
+                                                onUpdateClick = { onAction(AppsAction.OnUpdateApp(appItem.installedApp)) },
+                                                onCancelClick = { onAction(AppsAction.OnCancelUpdate(appItem.installedApp.packageName)) },
+                                                onUninstallClick = { onAction(AppsAction.OnUninstallApp(appItem.installedApp)) },
+                                                onRepoClick = { onAction(AppsAction.OnNavigateToRepo(appItem.installedApp.repoId)) },
+                                                onTogglePreReleases = { enabled ->
+                                                    onAction(AppsAction.OnTogglePreReleases(appItem.installedApp.packageName, enabled))
+                                                },
+                                                onAdvancedSettingsClick = {
+                                                    onAction(AppsAction.OnOpenAdvancedSettings(appItem.installedApp))
+                                                },
+                                                onPickVariantClick = {
+                                                    onAction(
+                                                        AppsAction.OnOpenVariantPicker(
+                                                            app = appItem.installedApp,
+                                                            resumeUpdateAfterPick = false,
+                                                        ),
+                                                    )
+                                                },
+                                                onInstallPendingClick = {
+                                                    onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
+                                                },
+                                                modifier =
+                                                    Modifier
+                                                        .then(
+                                                            if (state.isLiquidGlassEnabled) {
+                                                                Modifier.liquefiable(liquidState)
+                                                            } else {
+                                                                Modifier
+                                                            },
+                                                        ),
                                             )
-                                        },
-                                        onInstallPendingClick = {
-                                            onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
-                                        },
-                                        modifier =
-                                            Modifier
-                                                .then(
-                                                    if (state.isLiquidGlassEnabled) {
-                                                        Modifier.liquefiable(liquidState)
-                                                    } else {
-                                                        Modifier
+                                        }
+                                    }
+                                }
+
+                                if (idleGroup.isNotEmpty()) {
+                                    item(key = "header-up-to-date") {
+                                        AppsSectionHeader(
+                                            title = stringResource(Res.string.apps_section_up_to_date),
+                                            count = idleGroup.size,
+                                            isExpanded = state.isUpToDateSectionExpanded,
+                                            collapsible = true,
+                                            onToggle = {
+                                                onAction(AppsAction.OnToggleUpToDateSection)
+                                            },
+                                        )
+                                    }
+                                    if (state.isUpToDateSectionExpanded) {
+                                        items(
+                                            items = idleGroup,
+                                            key = { "compact-${it.installedApp.packageName}" },
+                                        ) { appItem ->
+                                            Box(modifier = Modifier.padding(horizontal = 8.dp)) {
+                                                CompactAppRow(
+                                                    appItem = appItem,
+                                                    onOpenClick = { onAction(AppsAction.OnOpenApp(appItem.installedApp)) },
+                                                    onInstallPendingClick = {
+                                                        onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
                                                     },
-                                                ),
-                                    )
+                                                    onAdvancedSettingsClick = {
+                                                        onAction(AppsAction.OnOpenAdvancedSettings(appItem.installedApp))
+                                                    },
+                                                    onPickVariantClick = {
+                                                        onAction(
+                                                            AppsAction.OnOpenVariantPicker(
+                                                                app = appItem.installedApp,
+                                                                resumeUpdateAfterPick = false,
+                                                            ),
+                                                        )
+                                                    },
+                                                    onUninstallClick = {
+                                                        onAction(AppsAction.OnUninstallApp(appItem.installedApp))
+                                                    },
+                                                    onTogglePreReleases = { enabled ->
+                                                        onAction(
+                                                            AppsAction.OnTogglePreReleases(
+                                                                appItem.installedApp.packageName,
+                                                                enabled,
+                                                            ),
+                                                        )
+                                                    },
+                                                    onRowClick = {
+                                                        onAction(AppsAction.OnNavigateToRepo(appItem.installedApp.repoId))
+                                                    },
+                                                )
+                                            }
+                                        }
+                                    }
                                 }
 
                                 item {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
@@ -27,6 +27,12 @@ data class AppsState(
     val lastCheckedTimestamp: Long? = null,
     val isRefreshing: Boolean = false,
     val isLiquidGlassEnabled: Boolean = true,
+    /**
+     * Whether the "Up to date" section is expanded. Default expanded so
+     * users with no updates pending still see their apps. Collapses
+     * independently of the (always-expanded) "Updates available" section.
+     */
+    val isUpToDateSectionExpanded: Boolean = true,
     // Link app to repo
     val showLinkSheet: Boolean = false,
     val linkStep: LinkStep = LinkStep.PickApp,

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -293,6 +293,10 @@ class AppsViewModel(
                 refresh()
             }
 
+            AppsAction.OnToggleUpToDateSection -> {
+                _state.update { it.copy(isUpToDateSectionExpanded = !it.isUpToDateSectionExpanded) }
+            }
+
             is AppsAction.OnNavigateToRepo -> {
                 viewModelScope.launch {
                     _events.send(AppsEvent.NavigateToRepo(action.repoId))
@@ -1296,6 +1300,10 @@ class AppsViewModel(
         packageName: String,
         progress: Int?,
     ) {
+        // Download progress is purely a per-row visual update; it doesn't
+        // affect sort order or search match. Avoid re-running the full
+        // filter+sort pass on every progress tick (which at 50+ apps with
+        // a download in flight ran ~100×/sec). Map both lists in place.
         _state.update { currentState ->
             currentState.copy(
                 apps =
@@ -1307,10 +1315,17 @@ class AppsViewModel(
                                 appItem
                             }
                         }.toImmutableList(),
+                filteredApps =
+                    currentState.filteredApps
+                        .map { appItem ->
+                            if (appItem.installedApp.packageName == packageName) {
+                                appItem.copy(downloadProgress = progress)
+                            } else {
+                                appItem
+                            }
+                        }.toImmutableList(),
             )
         }
-
-        filterApps()
     }
 
     private suspend fun markPendingUpdate(app: InstalledApp) {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
@@ -1,0 +1,113 @@
+package zed.rainxch.apps.presentation.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.apps_section_collapse
+import zed.rainxch.githubstore.core.presentation.res.apps_section_count_suffix
+import zed.rainxch.githubstore.core.presentation.res.apps_section_expand
+
+/**
+ * Section header shown above each grouped app list. Honours WCAG: the row
+ * carries `Role.Button` + `heading()` semantics, announces expanded /
+ * collapsed state via `stateDescription`, and includes the item count in
+ * the visible label so it's read as part of the heading.
+ *
+ * Pass [collapsible] = false to render a static heading (e.g. for the
+ * always-expanded "Updates available" group).
+ */
+@Composable
+fun AppsSectionHeader(
+    title: String,
+    count: Int,
+    isExpanded: Boolean,
+    collapsible: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val expandLabel = stringResource(Res.string.apps_section_expand)
+    val collapseLabel = stringResource(Res.string.apps_section_collapse)
+    val rotation by animateFloatAsState(
+        targetValue = if (isExpanded) 0f else -90f,
+        animationSpec = tween(durationMillis = 180),
+        label = "section-chevron",
+    )
+
+    val rowSemantic = if (isExpanded) collapseLabel else expandLabel
+
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(top = 16.dp, bottom = 4.dp)
+                .let { base ->
+                    if (collapsible) {
+                        base
+                            .clickable(onClick = onToggle)
+                            .semantics(mergeDescendants = true) {
+                                role = Role.Button
+                                heading()
+                                contentDescription = "$title, $count, $rowSemantic"
+                                stateDescription = if (isExpanded) "expanded" else "collapsed"
+                            }
+                    } else {
+                        base.semantics(mergeDescendants = true) {
+                            heading()
+                            contentDescription = "$title, $count"
+                        }
+                    }
+                },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(Res.string.apps_section_count_suffix, count),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        if (collapsible) {
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .rotate(rotation),
+            )
+        }
+    }
+}

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
@@ -31,6 +31,10 @@ import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.apps_section_collapse
 import zed.rainxch.githubstore.core.presentation.res.apps_section_count_suffix
 import zed.rainxch.githubstore.core.presentation.res.apps_section_expand
+import zed.rainxch.githubstore.core.presentation.res.apps_section_header_a11y_collapsible
+import zed.rainxch.githubstore.core.presentation.res.apps_section_header_a11y_static
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_collapsed
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_expanded
 
 /**
  * Section header shown above each grouped app list. Honours WCAG: the row
@@ -58,7 +62,13 @@ fun AppsSectionHeader(
         label = "section-chevron",
     )
 
-    val rowSemantic = if (isExpanded) collapseLabel else expandLabel
+    val toggleHint = if (isExpanded) collapseLabel else expandLabel
+    val collapsibleHeaderLabel =
+        stringResource(Res.string.apps_section_header_a11y_collapsible, title, count, toggleHint)
+    val staticHeaderLabel =
+        stringResource(Res.string.apps_section_header_a11y_static, title, count)
+    val expandedStateLabel = stringResource(Res.string.apps_section_state_expanded)
+    val collapsedStateLabel = stringResource(Res.string.apps_section_state_collapsed)
 
     Row(
         modifier =
@@ -73,13 +83,14 @@ fun AppsSectionHeader(
                             .semantics(mergeDescendants = true) {
                                 role = Role.Button
                                 heading()
-                                contentDescription = "$title, $count, $rowSemantic"
-                                stateDescription = if (isExpanded) "expanded" else "collapsed"
+                                contentDescription = collapsibleHeaderLabel
+                                stateDescription =
+                                    if (isExpanded) expandedStateLabel else collapsedStateLabel
                             }
                     } else {
                         base.semantics(mergeDescendants = true) {
                             heading()
-                            contentDescription = "$title, $count"
+                            contentDescription = staticHeaderLabel
                         }
                     }
                 },

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
@@ -91,8 +91,13 @@ fun CompactAppRow(
     modifier: Modifier = Modifier,
 ) {
     val app = appItem.installedApp
+    // A row is "busy" only when something is actively running in the
+    // background. A parked download (`pendingInstallFilePath != null`)
+    // sets `isPendingInstall = true` but the user can still tap Install,
+    // so it must NOT be treated as busy — otherwise the Install CTA and
+    // overflow menu get stuck disabled.
     val isBusy =
-        app.isPendingInstall ||
+        (app.isPendingInstall && app.pendingInstallFilePath == null) ||
             appItem.updateState is UpdateState.Downloading ||
             appItem.updateState is UpdateState.Installing ||
             appItem.updateState is UpdateState.CheckingUpdate

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
@@ -1,0 +1,289 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalTime::class)
+
+package zed.rainxch.apps.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Update
+import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.apps.presentation.model.AppItem
+import zed.rainxch.apps.presentation.model.UpdateState
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.advanced_settings_open
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_more_actions
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_filter_active
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_pending_install
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_pre_release_on
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_ready_to_install
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_variant_pinned
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_variant_stale
+import zed.rainxch.githubstore.core.presentation.res.install
+import zed.rainxch.githubstore.core.presentation.res.open
+import zed.rainxch.githubstore.core.presentation.res.pre_release_badge
+import zed.rainxch.githubstore.core.presentation.res.uninstall
+import zed.rainxch.githubstore.core.presentation.res.variant_picker_open
+import kotlin.time.ExperimentalTime
+
+/**
+ * 64dp single-line row used in the "Up to date" section. Drops the verbose
+ * controls of [zed.rainxch.apps.presentation.AppItemCard] (filter / variant /
+ * pre-release / inline status text). Per-app configuration moves into the
+ * trailing overflow menu, which routes to the existing bottom sheet.
+ *
+ * Accessibility: the entire row carries a single merged semantic name that
+ * surfaces every "hidden" flag (filter active / variant pinned / pre-release
+ * on / variant stale / pending install / ready to install) so screen-reader
+ * users don't lose context that the dot cluster encodes visually.
+ */
+@Composable
+fun CompactAppRow(
+    appItem: AppItem,
+    onOpenClick: () -> Unit,
+    onInstallPendingClick: () -> Unit,
+    onAdvancedSettingsClick: () -> Unit,
+    onPickVariantClick: () -> Unit,
+    onUninstallClick: () -> Unit,
+    onTogglePreReleases: (Boolean) -> Unit,
+    onRowClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val app = appItem.installedApp
+    val isBusy =
+        app.isPendingInstall ||
+            appItem.updateState is UpdateState.Downloading ||
+            appItem.updateState is UpdateState.Installing ||
+            appItem.updateState is UpdateState.CheckingUpdate
+
+    val flags = rememberCompactStatusFlags(appItem)
+    val rowSemanticName = buildCompactRowSemantics(app.appName, app.installedVersion, flags)
+
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = 64.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .clickable(onClick = onRowClick)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .semantics(mergeDescendants = true) {
+                    contentDescription = rowSemanticName
+                },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        InstalledAppIcon(
+            packageName = app.packageName,
+            appName = app.appName,
+            modifier =
+                Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(14.dp)),
+        )
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = app.appName,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Spacer(Modifier.height(2.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = app.installedVersion,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                StatusDotCluster(flags = flags)
+            }
+        }
+
+        if (app.pendingInstallFilePath != null) {
+            // One-tap path for a parked download — surface the install
+            // primary CTA even in compact mode because the file is on disk
+            // and finishing the install is the user's expected action.
+            Button(
+                onClick = onInstallPendingClick,
+                enabled = !isBusy,
+                contentPadding = PaddingValues(horizontal = 12.dp),
+                modifier = Modifier.height(40.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Update,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = stringResource(Res.string.install),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+            Spacer(Modifier.width(4.dp))
+        } else if (!isBusy) {
+            // Subtle Open shortcut keeps the most-frequent action one tap
+            // away even though the row itself opens the repo on tap.
+            IconButton(
+                onClick = onOpenClick,
+                modifier = Modifier.size(40.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = stringResource(Res.string.open),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+
+        CompactRowOverflow(
+            appName = app.appName,
+            isBusy = isBusy,
+            isUpdateAvailable = app.isUpdateAvailable,
+            isPreReleaseEnabled = app.includePreReleases,
+            onAdvancedSettingsClick = onAdvancedSettingsClick,
+            onPickVariantClick = onPickVariantClick,
+            onUninstallClick = onUninstallClick,
+            onTogglePreReleases = onTogglePreReleases,
+        )
+    }
+}
+
+@Composable
+private fun CompactRowOverflow(
+    appName: String,
+    isBusy: Boolean,
+    isUpdateAvailable: Boolean,
+    isPreReleaseEnabled: Boolean,
+    onAdvancedSettingsClick: () -> Unit,
+    onPickVariantClick: () -> Unit,
+    onUninstallClick: () -> Unit,
+    onTogglePreReleases: (Boolean) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val moreActionsLabel = stringResource(Res.string.apps_compact_more_actions, appName)
+
+    Box {
+        IconButton(
+            onClick = { expanded = true },
+            modifier =
+                Modifier
+                    .size(40.dp)
+                    .semantics {
+                        contentDescription = moreActionsLabel
+                        role = Role.Button
+                    },
+            enabled = !isBusy,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.MoreVert,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.advanced_settings_open)) },
+                onClick = {
+                    expanded = false
+                    onAdvancedSettingsClick()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.variant_picker_open)) },
+                onClick = {
+                    expanded = false
+                    onPickVariantClick()
+                },
+            )
+            DropdownMenuItem(
+                text = {
+                    val baseLabel = stringResource(Res.string.pre_release_badge)
+                    Text(text = if (isPreReleaseEnabled) "$baseLabel  ✓" else baseLabel)
+                },
+                onClick = {
+                    expanded = false
+                    onTogglePreReleases(!isPreReleaseEnabled)
+                },
+            )
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(Res.string.uninstall),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.DeleteOutline,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                },
+                onClick = {
+                    expanded = false
+                    onUninstallClick()
+                },
+            )
+        }
+    }
+    // Suppress unused-parameter warning; isUpdateAvailable reserved for
+    // future Update CTA in compact mode if we ever want it.
+    @Suppress("UNUSED_EXPRESSION") isUpdateAvailable
+}

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/StatusDotCluster.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/StatusDotCluster.kt
@@ -1,0 +1,185 @@
+package zed.rainxch.apps.presentation.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.apps.presentation.model.AppItem
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_filter_active
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_pending_install
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_pre_release_on
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_ready_to_install
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_variant_pinned
+import zed.rainxch.githubstore.core.presentation.res.apps_compact_status_variant_stale
+
+/**
+ * Per-app state flags that the compact row encodes visually. Each flag uses
+ * BOTH a unique [DotShape] AND a tinted color so that the cluster passes
+ * WCAG 1.4.1 (no information by color alone). Screen readers see the
+ * cluster's merged contentDescription via the parent row's semantics.
+ */
+data class CompactStatusFlags(
+    val filterActive: Boolean = false,
+    val variantPinned: Boolean = false,
+    val variantStale: Boolean = false,
+    val preReleaseOn: Boolean = false,
+    val pendingInstall: Boolean = false,
+    val readyToInstall: Boolean = false,
+)
+
+/**
+ * Computes the visible status flags for an [AppItem]. Memoised on its
+ * inputs so that the row's recomposition doesn't re-allocate the data
+ * class on every download-progress tick.
+ */
+@Composable
+fun rememberCompactStatusFlags(appItem: AppItem): CompactStatusFlags {
+    val app = appItem.installedApp
+    return remember(
+        app.assetFilterRegex,
+        app.fallbackToOlderReleases,
+        app.preferredAssetVariant,
+        app.preferredVariantStale,
+        app.includePreReleases,
+        app.isPendingInstall,
+        app.pendingInstallFilePath,
+    ) {
+        CompactStatusFlags(
+            filterActive = !app.assetFilterRegex.isNullOrBlank() || app.fallbackToOlderReleases,
+            variantPinned = !app.preferredAssetVariant.isNullOrBlank() && !app.preferredVariantStale,
+            variantStale = app.preferredVariantStale,
+            preReleaseOn = app.includePreReleases,
+            pendingInstall = app.isPendingInstall && app.pendingInstallFilePath == null,
+            readyToInstall = app.pendingInstallFilePath != null,
+        )
+    }
+}
+
+/**
+ * Renders the active flags as a compact row of 8dp shapes. Each flag has a
+ * dedicated shape (circle / square / triangle / diamond / ring / chevron) so
+ * shape-only viewers (deuteranopia, monochrome themes, low contrast) still
+ * tell the flags apart.
+ */
+@Composable
+fun StatusDotCluster(
+    flags: CompactStatusFlags,
+    modifier: Modifier = Modifier,
+) {
+    val cs = MaterialTheme.colorScheme
+
+    val items = buildList {
+        if (flags.readyToInstall) add(StatusItem(DotShape.Ring, cs.primary))
+        if (flags.pendingInstall) add(StatusItem(DotShape.Chevron, cs.tertiary))
+        if (flags.variantStale) add(StatusItem(DotShape.Triangle, cs.error))
+        if (flags.variantPinned) add(StatusItem(DotShape.Diamond, cs.primary))
+        if (flags.filterActive) add(StatusItem(DotShape.Square, cs.primary))
+        if (flags.preReleaseOn) add(StatusItem(DotShape.Circle, cs.tertiary))
+    }
+
+    if (items.isEmpty()) return
+
+    Row(
+        modifier = modifier.semantics { contentDescription = "" },
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        items.forEach { item ->
+            Canvas(modifier = Modifier.size(8.dp)) {
+                drawShape(item.shape, item.color)
+            }
+        }
+    }
+}
+
+private data class StatusItem(val shape: DotShape, val color: Color)
+
+private enum class DotShape {
+    Circle,
+    Square,
+    Triangle,
+    Diamond,
+    Ring,
+    Chevron,
+}
+
+private fun DrawScope.drawShape(shape: DotShape, color: Color) {
+    val s = size.minDimension
+    when (shape) {
+        DotShape.Circle -> drawCircle(color = color, radius = s / 2f)
+        DotShape.Square ->
+            drawRect(color = color, size = androidx.compose.ui.geometry.Size(s, s))
+        DotShape.Triangle -> {
+            val path =
+                Path().apply {
+                    moveTo(s / 2f, 0f)
+                    lineTo(s, s)
+                    lineTo(0f, s)
+                    close()
+                }
+            drawPath(path, color)
+        }
+        DotShape.Diamond -> {
+            val path =
+                Path().apply {
+                    moveTo(s / 2f, 0f)
+                    lineTo(s, s / 2f)
+                    lineTo(s / 2f, s)
+                    lineTo(0f, s / 2f)
+                    close()
+                }
+            drawPath(path, color)
+        }
+        DotShape.Ring ->
+            drawCircle(
+                color = color,
+                radius = s / 2f - 1f,
+                style = Stroke(width = 1.5f),
+            )
+        DotShape.Chevron -> {
+            val path =
+                Path().apply {
+                    moveTo(0f, s * 0.25f)
+                    lineTo(s / 2f, s * 0.75f)
+                    lineTo(s, s * 0.25f)
+                }
+            drawPath(path, color, style = Stroke(width = 1.5f))
+        }
+    }
+}
+
+/**
+ * Builds the merged accessible name for the row. The name template is
+ * read once per row recomposition; the dot cluster itself carries no
+ * semantics (decorative).
+ */
+@Composable
+fun buildCompactRowSemantics(
+    appName: String,
+    installedVersion: String,
+    flags: CompactStatusFlags,
+): String {
+    val parts = buildList {
+        add(appName)
+        add(installedVersion)
+        if (flags.readyToInstall) add(stringResource(Res.string.apps_compact_status_ready_to_install))
+        if (flags.pendingInstall) add(stringResource(Res.string.apps_compact_status_pending_install))
+        if (flags.variantStale) add(stringResource(Res.string.apps_compact_status_variant_stale))
+        if (flags.variantPinned) add(stringResource(Res.string.apps_compact_status_variant_pinned))
+        if (flags.filterActive) add(stringResource(Res.string.apps_compact_status_filter_active))
+        if (flags.preReleaseOn) add(stringResource(Res.string.apps_compact_status_pre_release_on))
+    }
+    return parts.joinToString(", ")
+}


### PR DESCRIPTION
## Summary

Closes #463. Splits the installed apps list into two sections to reduce vertical footprint without losing update-triage glanceability:

- **Updates available** — current rich `AppItemCard` preserved (icon, name, version delta, Update CTA, in-row controls).
- **Up to date** — new 64dp compact row (icon 48dp + name + installed version + status dots + overflow menu). Per-app filter / variant / pre-release controls move to the overflow menu, which routes to the existing `AdvancedAppSettingsBottomSheet` and `VariantPickerDialog`.

Density target: ~3 apps/viewport → ~9-10 apps/viewport on a Pixel 6-class device.

The "Up to date" section header is collapsible (default expanded, count visible). The "Updates available" header is static so the triage workflow always stays in view.

## Accessibility

- Compact row uses `Modifier.semantics(mergeDescendants = true)` with a merged accessible name that surfaces every "hidden" flag (filter active / variant pinned / variant stale / pre-release on / pending install / ready to install).
- `StatusDotCluster` encodes each flag with a unique shape AND color (circle / square / triangle / diamond / ring / chevron) — passes WCAG 1.4.1.
- Section header carries `Role.Button` + `heading()` + `stateDescription` + count in name.
- Overflow IconButton 40dp visual / 48dp hit zone.

## Adjacent perf fix

`AppsViewModel.updateAppProgress` no longer calls `filterApps()` on every download-progress tick. Download progress doesn't affect sort order or search match, so it now maps `apps` + `filteredApps` in place. At 50+ installed apps with one downloading, this avoided a full re-sort + immutable-list rebuild on every tick.

## Out of scope

- View-mode toggle (list ↔ grid).
- Pure grid layout.
- Search/filter UI changes.
- Telemetry instrumentation.

## Test plan

- [ ] Empty state — no apps installed
- [ ] All apps need updates (only Updates available section visible)
- [ ] No apps need updates (only Up to date section visible, collapsible)
- [ ] Mixed state (both sections visible, header counts correct)
- [ ] Sort by Name / Updates First / Recently Updated — sort applies inside each section
- [ ] Search filters across both sections
- [ ] Compact row tap → navigates to repo
- [ ] Compact row overflow → advanced settings / variant picker / pre-release toggle / uninstall all wired
- [ ] Pending-install state shows Install button in compact row
- [ ] TalkBack: row reads merged name with all active flags; section headers announce as headings with count + state
- [ ] Download progress on a row in updates section does NOT cause the up-to-date section to re-render
- [ ] Visual QA on Android + Desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps screen split into "Updates available" and "Up to date" sections; "Up to date" is collapsible.
  * Compact app row for up-to-date apps with one-tap install/open and overflow actions.
  * Visual status dots indicating filter active, pinned/stale variants, pre-release, pending/ready-to-install.

* **Accessibility / Localization**
  * Added localized strings and enhanced accessibility semantics for section headers, counts, states, and compact status descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->