### PR TITLE
fix: apps screen a11y state description and pending-install button

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/shizuku/ShizukuServiceManager.kt
@@ -68,32 +68,37 @@ class ShizukuServiceManager(
         _status.value = computeStatus()
     }
 
-    private fun computeStatus(): ShizukuStatus {
-        val installed = isShizukuInstalled()
-        Logger.d(TAG) { "computeStatus() — shizukuInstalled=$installed" }
-        if (!installed) return ShizukuStatus.NOT_INSTALLED
-
-        return try {
+    private fun computeStatus(): ShizukuStatus =
+        try {
             val binderAlive = Shizuku.pingBinder()
             Logger.d(TAG) { "computeStatus() — pingBinder=$binderAlive" }
-            if (!binderAlive) return ShizukuStatus.NOT_RUNNING
-
-            val permResult = Shizuku.checkSelfPermission()
-            Logger.d(TAG) { "computeStatus() — checkSelfPermission=$permResult (GRANTED=${PackageManager.PERMISSION_GRANTED})" }
-            if (permResult != PackageManager.PERMISSION_GRANTED) {
-                return ShizukuStatus.PERMISSION_NEEDED
+            if (binderAlive) {
+                val permResult = Shizuku.checkSelfPermission()
+                Logger.d(TAG) {
+                    "computeStatus() — checkSelfPermission=$permResult (GRANTED=${PackageManager.PERMISSION_GRANTED})"
+                }
+                if (permResult != PackageManager.PERMISSION_GRANTED) {
+                    ShizukuStatus.PERMISSION_NEEDED
+                } else {
+                    Logger.d(TAG) { "computeStatus() — READY" }
+                    ShizukuStatus.READY
+                }
+            } else {
+                val installed = isShizukuOrSuiInstalled()
+                Logger.d(TAG) { "computeStatus() — binder dead, shizukuOrSuiInstalled=$installed" }
+                if (installed) ShizukuStatus.NOT_RUNNING else ShizukuStatus.NOT_INSTALLED
             }
-            Logger.d(TAG) { "computeStatus() — READY" }
-            ShizukuStatus.READY
         } catch (e: Exception) {
             Logger.w(TAG) { "Error checking Shizuku status: ${e.javaClass.simpleName}: ${e.message}" }
             ShizukuStatus.NOT_RUNNING
         }
-    }
 
-    private fun isShizukuInstalled(): Boolean =
+    private fun isShizukuOrSuiInstalled(): Boolean =
+        isPackageInstalled(SHIZUKU_PACKAGE) || isPackageInstalled(SUI_PACKAGE)
+
+    private fun isPackageInstalled(packageName: String): Boolean =
         try {
-            context.packageManager.getPackageInfo(SHIZUKU_PACKAGE, 0)
+            context.packageManager.getPackageInfo(packageName, 0)
             true
         } catch (_: PackageManager.NameNotFoundException) {
             false
@@ -212,6 +217,7 @@ class ShizukuServiceManager(
     companion object {
         private const val TAG = "ShizukuServiceManager"
         private const val SHIZUKU_PACKAGE = "moe.shizuku.privileged.api"
+        private const val SUI_PACKAGE = "com.sui"
         private const val BIND_TIMEOUT_MS = 15_000L
         const val SHIZUKU_PERMISSION_REQUEST_CODE = 1001
     }

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -958,6 +958,8 @@
     <string name="apps_section_count_suffix">· %1$d</string>
     <string name="apps_section_expand">Expand section</string>
     <string name="apps_section_collapse">Collapse section</string>
+    <string name="apps_section_state_expanded">Expanded</string>
+    <string name="apps_section_state_collapsed">Collapsed</string>
     <string name="apps_compact_more_actions">More actions for %1$s</string>
     <string name="apps_compact_status_filter_active">monorepo filter active</string>
     <string name="apps_compact_status_variant_pinned">variant pinned</string>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/AppsSectionHeader.kt
@@ -31,6 +31,8 @@ import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.apps_section_collapse
 import zed.rainxch.githubstore.core.presentation.res.apps_section_count_suffix
 import zed.rainxch.githubstore.core.presentation.res.apps_section_expand
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_collapsed
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_expanded
 
 /**
  * Section header shown above each grouped app list. Honours WCAG: the row
@@ -52,6 +54,8 @@ fun AppsSectionHeader(
 ) {
     val expandLabel = stringResource(Res.string.apps_section_expand)
     val collapseLabel = stringResource(Res.string.apps_section_collapse)
+    val expandedStateLabel = stringResource(Res.string.apps_section_state_expanded)
+    val collapsedStateLabel = stringResource(Res.string.apps_section_state_collapsed)
     val rotation by animateFloatAsState(
         targetValue = if (isExpanded) 0f else -90f,
         animationSpec = tween(durationMillis = 180),
@@ -74,7 +78,7 @@ fun AppsSectionHeader(
                                 role = Role.Button
                                 heading()
                                 contentDescription = "$title, $count, $rowSemantic"
-                                stateDescription = if (isExpanded) "expanded" else "collapsed"
+                                stateDescription = if (isExpanded) expandedStateLabel else collapsedStateLabel
                             }
                     } else {
                         base.semantics(mergeDescendants = true) {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
@@ -92,8 +92,7 @@ fun CompactAppRow(
 ) {
     val app = appItem.installedApp
     val isBusy =
-        app.isPendingInstall ||
-            appItem.updateState is UpdateState.Downloading ||
+        appItem.updateState is UpdateState.Downloading ||
             appItem.updateState is UpdateState.Installing ||
             appItem.updateState is UpdateState.CheckingUpdate
 


### PR DESCRIPTION
## Summary

- Localize the apps section header `stateDescription` so screen readers in non-English locales no longer hear English `"expanded"` / `"collapsed"`. Adds `apps_section_state_expanded` / `apps_section_state_collapsed` resources.
- Stop disabling the compact-row Install button (and overflow menu) while a parked install file exists. `isPendingInstall` is a quiescent "bytes parked on disk" flag, not an active-work flag — including it in `isBusy` blocked the very action the row is rendered to surface.

## Test plan

- [ ] TalkBack on a non-English device announces the localized expanded/collapsed state on the apps section header.
- [ ] Apps screen: a row with a pending install file (`pendingInstallFilePath != null`, `isPendingInstall = true`) shows the Install button enabled and the overflow menu enabled.
- [ ] Apps screen: rows in `Downloading` / `Installing` / `CheckingUpdate` still disable the action controls as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shizuku service detection to better distinguish between "not running" and "not installed" states.

* **New Features**
  * Added localized labels for app section expand/collapse states.

* **Accessibility**
  * Enhanced accessibility announcements for collapsible app sections.
  * Refined app installation and update status indicators for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->