### PR TITLE
fix: stop direct/mirror download race from clobbering destination file

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
@@ -21,6 +21,9 @@ import java.net.Authenticator
 import java.net.InetSocketAddress
 import java.net.PasswordAuthentication
 import java.net.Proxy
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -29,7 +32,7 @@ class AndroidDownloader(
     private val files: FileLocationsProvider,
 ) : Downloader {
     private val activeDownloads = ConcurrentHashMap<String, Call>()
-    private val activeFileNames = ConcurrentHashMap<String, String>()
+    private val idsByName = ConcurrentHashMap<String, MutableSet<String>>()
 
     private fun buildClient(): OkHttpClient {
         Authenticator.setDefault(null)
@@ -111,17 +114,16 @@ class AndroidDownloader(
                 "Invalid file name: $rawName"
             }
 
-            check(!activeFileNames.containsKey(safeName)) {
-                "A download for '$safeName' is already in progress"
-            }
-
             val downloadId = UUID.randomUUID().toString()
 
             val destination = File(dir, safeName)
-            if (destination.exists()) {
-                Logger.d { "Deleting existing file before download: ${destination.absolutePath}" }
-                destination.delete()
-            }
+            // Each attempt writes to its own temp file so MultiSourceDownloader's
+            // direct/mirror race cannot have two jobs trampling the same path
+            // (see issue: "File not ready after download" with custom mirror).
+            // Temp lives in the same dir so the final rename stays on one FS
+            // and ATOMIC_MOVE works.
+            val tempFile = File(dir, "$safeName.part-$downloadId")
+            if (tempFile.exists()) tempFile.delete()
 
             Logger.d { "Starting download: $url (id=$downloadId)" }
 
@@ -129,7 +131,7 @@ class AndroidDownloader(
             val call = client.newCall(request)
 
             activeDownloads[downloadId] = call
-            activeFileNames[safeName] = downloadId
+            idsByName.computeIfAbsent(safeName) { ConcurrentHashMap.newKeySet() }.add(downloadId)
 
             try {
                 call.execute().use { response ->
@@ -142,7 +144,7 @@ class AndroidDownloader(
                     val total = if (contentLength > 0) contentLength else null
 
                     body.byteStream().use { input ->
-                        destination.outputStream().use { output ->
+                        tempFile.outputStream().use { output ->
                             val buffer = ByteArray(8192)
                             var downloaded: Long = 0
                             var bytesRead: Int
@@ -156,25 +158,48 @@ class AndroidDownloader(
                         }
                     }
 
-                    if (destination.exists() && destination.length() > 0) {
-                        Logger.d { "Download complete: ${destination.absolutePath}" }
-                        val finalDownloaded = destination.length()
-                        val finalPercent =
-                            if (total != null) ((finalDownloaded * 100L) / total).toInt() else 100
-                        emit(DownloadProgress(finalDownloaded, total, finalPercent))
-                    } else {
-                        throw IllegalStateException("File not ready after download: ${destination.absolutePath}")
+                    if (!tempFile.exists() || tempFile.length() <= 0) {
+                        throw IllegalStateException(
+                            "Download produced empty file: ${tempFile.absolutePath} (contentLength=$contentLength)",
+                        )
                     }
+
+                    moveAtomic(tempFile, destination)
+
+                    Logger.d { "Download complete: ${destination.absolutePath}" }
+                    val finalDownloaded = destination.length()
+                    val finalPercent =
+                        if (total != null) ((finalDownloaded * 100L) / total).toInt() else 100
+                    emit(DownloadProgress(finalDownloaded, total, finalPercent))
                 }
             } catch (e: Exception) {
-                destination.delete()
+                tempFile.delete()
                 Logger.e(e) { "Download failed" }
                 throw e
             } finally {
                 activeDownloads.remove(downloadId)
-                activeFileNames.remove(safeName)
+                idsByName.computeIfPresent(safeName) { _, set ->
+                    set.remove(downloadId)
+                    if (set.isEmpty()) null else set
+                }
             }
         }.flowOn(Dispatchers.IO)
+
+    private fun moveAtomic(source: File, target: File) {
+        try {
+            Files.move(
+                source.toPath(),
+                target.toPath(),
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            // Fallback for filesystems without atomic-move support — still
+            // safer than writing directly to target because the partial bytes
+            // were never visible at `target` until this step.
+            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
 
     override suspend fun saveToFile(
         url: String,
@@ -219,28 +244,24 @@ class AndroidDownloader(
 
     override suspend fun cancelDownload(fileName: String): Boolean =
         withContext(Dispatchers.IO) {
+            // Cancel every in-flight download for this fileName — MultiSource
+            // races run direct + mirror in parallel under the same logical
+            // name, so a single-id lookup would leave one of them running.
+            val ids = idsByName.remove(fileName)?.toList().orEmpty()
+            if (ids.isEmpty()) return@withContext false
+
             var cancelled = false
-
-            val downloadId = activeFileNames[fileName]
-            if (downloadId != null) {
-                activeDownloads[downloadId]?.let { call: Call ->
-                    if (!call.isCanceled()) {
-                        call.cancel()
-                        cancelled = true
-                    }
-                    activeDownloads.remove(downloadId)
-                }
-                activeFileNames.remove(fileName)
-
-                // Only delete the file if we cancelled an active download (incomplete file)
-                if (cancelled) {
-                    val file = File(files.appDownloadsDir(), fileName)
-                    if (file.exists()) {
-                        file.delete()
-                    }
+            for (id in ids) {
+                val call = activeDownloads.remove(id) ?: continue
+                if (!call.isCanceled()) {
+                    call.cancel()
+                    cancelled = true
                 }
             }
-
+            // No destination delete: the flow's catch handles its own temp
+            // file. The final destination is only written via atomic-rename
+            // on success, so it's either a prior valid download (keep) or
+            // doesn't exist yet.
             cancelled
         }
 }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopDownloader.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopDownloader.kt
@@ -20,6 +20,9 @@ import java.net.Authenticator
 import java.net.InetSocketAddress
 import java.net.PasswordAuthentication
 import java.net.Proxy
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -27,7 +30,7 @@ class DesktopDownloader(
     private val files: FileLocationsProvider,
 ) : Downloader {
     private val activeDownloads = ConcurrentHashMap<String, Call>()
-    private val nameToId = ConcurrentHashMap<String, String>()
+    private val idsByName = ConcurrentHashMap<String, MutableSet<String>>()
 
     private fun buildClient(): OkHttpClient {
         Authenticator.setDefault(null)
@@ -101,22 +104,19 @@ class DesktopDownloader(
             }
 
             val downloadId = UUID.randomUUID().toString()
-            val previous = nameToId.putIfAbsent(safeName, downloadId)
-            if (previous != null) {
-                throw IllegalStateException("A download for '$safeName' is already in progress")
-            }
 
             val destination = File(dir, safeName)
-            if (destination.exists()) {
-                Logger.d { "Deleting existing file before download: ${destination.absolutePath}" }
-                destination.delete()
-            }
+            // Each attempt writes to its own temp file so MultiSourceDownloader's
+            // direct/mirror race cannot have two jobs trampling the same path.
+            val tempFile = File(dir, "$safeName.part-$downloadId")
+            if (tempFile.exists()) tempFile.delete()
 
             Logger.d { "Starting download: $url" }
 
             val request = Request.Builder().url(url).build()
             val call = client.newCall(request)
             activeDownloads[downloadId] = call
+            idsByName.computeIfAbsent(safeName) { ConcurrentHashMap.newKeySet() }.add(downloadId)
 
             try {
                 call.execute().use { response ->
@@ -129,7 +129,7 @@ class DesktopDownloader(
                     val total = if (contentLength > 0) contentLength else null
 
                     body.byteStream().use { input ->
-                        destination.outputStream().use { output ->
+                        tempFile.outputStream().use { output ->
                             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
                             var downloaded: Long = 0
                             var bytesRead: Int
@@ -143,25 +143,45 @@ class DesktopDownloader(
                         }
                     }
 
-                    if (destination.exists() && destination.length() > 0) {
-                        Logger.d { "Download complete: ${destination.absolutePath}" }
-                        val finalDownloaded = destination.length()
-                        val finalPercent =
-                            if (total != null) ((finalDownloaded * 100L) / total).toInt() else 100
-                        emit(DownloadProgress(finalDownloaded, total, finalPercent))
-                    } else {
-                        throw IllegalStateException("File not ready after download: ${destination.absolutePath}")
+                    if (!tempFile.exists() || tempFile.length() <= 0) {
+                        throw IllegalStateException(
+                            "Download produced empty file: ${tempFile.absolutePath} (contentLength=$contentLength)",
+                        )
                     }
+
+                    moveAtomic(tempFile, destination)
+
+                    Logger.d { "Download complete: ${destination.absolutePath}" }
+                    val finalDownloaded = destination.length()
+                    val finalPercent =
+                        if (total != null) ((finalDownloaded * 100L) / total).toInt() else 100
+                    emit(DownloadProgress(finalDownloaded, total, finalPercent))
                 }
             } catch (e: Exception) {
-                destination.delete()
+                tempFile.delete()
                 Logger.e(e) { "Download failed" }
                 throw e
             } finally {
                 activeDownloads.remove(downloadId)
-                nameToId.remove(safeName)
+                idsByName.computeIfPresent(safeName) { _, set ->
+                    set.remove(downloadId)
+                    if (set.isEmpty()) null else set
+                }
             }
         }.flowOn(Dispatchers.IO)
+
+    private fun moveAtomic(source: File, target: File) {
+        try {
+            Files.move(
+                source.toPath(),
+                target.toPath(),
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
 
     override suspend fun saveToFile(
         url: String,
@@ -200,27 +220,20 @@ class DesktopDownloader(
 
     override suspend fun cancelDownload(fileName: String): Boolean =
         withContext(Dispatchers.IO) {
-            var cancelled = false
-            val downloadId = nameToId[fileName]
-            if (downloadId != null) {
-                activeDownloads[downloadId]?.let { call ->
-                    if (!call.isCanceled()) {
-                        call.cancel()
-                        cancelled = true
-                    }
-                }
-                activeDownloads.remove(downloadId)
-                nameToId.remove(fileName)
+            // Cancel every in-flight download for this fileName — MultiSource
+            // races run direct + mirror in parallel under the same logical
+            // name, so a single-id lookup would leave one of them running.
+            val ids = idsByName.remove(fileName)?.toList().orEmpty()
+            if (ids.isEmpty()) return@withContext false
 
-                // Only delete the file if we cancelled an active download (incomplete file)
-                if (cancelled) {
-                    val file = File(files.userDownloadsDir(), fileName)
-                    if (file.exists()) {
-                        file.delete()
-                    }
+            var cancelled = false
+            for (id in ids) {
+                val call = activeDownloads.remove(id) ?: continue
+                if (!call.isCanceled()) {
+                    call.cancel()
+                    cancelled = true
                 }
             }
-
             cancelled
         }
 


### PR DESCRIPTION
## Summary

Users with a custom download mirror configured were hitting `Error: file not ready after download: <path>` on installs.

`MultiSourceDownloaderImpl` races a `direct` download against a `mirror` download, both calling `Downloader.download(url, suggestedFileName)` with the same `suggestedFileName`. Both `AndroidDownloader` and `DesktopDownloader` resolved that name to the **same** destination `File` and wrote to it directly. Two consequences:

1. The non-atomic `containsKey` + `put` guard in `AndroidDownloader` let both jobs proceed concurrently and write to the same path.
2. When the loser was cancelled, its `catch` block ran `destination.delete()` — which removed the winner's just-written file *before* the winner's post-write `destination.exists() && length() > 0` check, throwing `"File not ready after download"`.

This change makes each attempt write to its own per-`downloadId` temp file (`<safeName>.part-<downloadId>`), then atomic-rename to the final destination on success. Loser cleanup deletes only its own temp; the winner's destination is never touched by the other job.

While here:
- Drop the `"already in progress"` guard in both downloaders — `MultiSourceDownloader` legitimately runs two parallel attempts under the same logical name; the temp-file uniqueness now makes the guard unnecessary.
- Switch the per-fileName tracking map to hold a *set* of in-flight `downloadId`s. `cancelDownload(fileName)` now cancels every active call for that name (it previously cancelled only one of the two race participants).
- Stop `cancelDownload` from blindly deleting the destination file — with atomic-rename, the destination only exists when a download has already succeeded; deleting it would wipe a perfectly valid prior download.
- Tighten the empty-file check error to include `contentLength` so future zero-byte responses are easier to diagnose.

## Test plan

- [ ] With a custom download mirror configured (Profile → Proxy → Download mirror), install several apps. Previously failed with `"File not ready after download"`; should now succeed.
- [ ] Without a mirror configured, regular installs still work.
- [ ] Cancel an in-progress download from the UI; the partially-written temp file (`*.part-*`) is removed and a prior successful download with the same filename is retained.
- [ ] Re-install/update an app that already exists in the downloads dir; new bytes replace the old file via atomic move.
- [ ] Desktop builds (Windows/macOS/Linux): downloads still work end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved download reliability with atomic file operations and validation to prevent incomplete files
* Enhanced support for concurrent downloads of the same file
* Better cleanup of failed download attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->