### PR TITLE
feat: APK Inspect feature + faithful pending-row UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -54,6 +54,7 @@ val viewModelsModule =
                 downloadOrchestrator = get(),
                 telemetryRepository = get(),
                 externalImportRepository = get(),
+                apkInspector = get(),
             )
         }
         viewModelOf(::DeveloperProfileViewModel)

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -8,6 +8,7 @@ import org.koin.dsl.module
 import zed.rainxch.core.data.local.data_store.createDataStore
 import zed.rainxch.core.data.local.db.AppDatabase
 import zed.rainxch.core.data.local.db.initDatabase
+import zed.rainxch.core.data.services.AndroidApkInspector
 import zed.rainxch.core.data.services.AndroidDownloader
 import zed.rainxch.core.data.services.AndroidDownloadProgressNotifier
 import zed.rainxch.core.data.services.AndroidFileLocationsProvider
@@ -33,6 +34,7 @@ import zed.rainxch.core.data.utils.AndroidShareManager
 import zed.rainxch.core.data.network.AndroidDigestVerifier
 import zed.rainxch.core.domain.network.DigestVerifier
 import zed.rainxch.core.domain.network.Downloader
+import zed.rainxch.core.domain.system.ApkInspector
 import zed.rainxch.core.domain.system.DownloadOrchestrator
 import zed.rainxch.core.domain.system.DownloadProgressNotifier
 import zed.rainxch.core.domain.system.ExternalAppScanner
@@ -114,8 +116,8 @@ actual val corePlatformModule =
             AndroidPackageMonitor(androidContext())
         }
 
-        single<zed.rainxch.core.domain.system.ApkInspector> {
-            zed.rainxch.core.data.services.AndroidApkInspector(androidContext())
+        single<ApkInspector> {
+            AndroidApkInspector(androidContext())
         }
 
         single { ManifestHintExtractor() }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -114,6 +114,10 @@ actual val corePlatformModule =
             AndroidPackageMonitor(androidContext())
         }
 
+        single<zed.rainxch.core.domain.system.ApkInspector> {
+            zed.rainxch.core.data.services.AndroidApkInspector(androidContext())
+        }
+
         single { ManifestHintExtractor() }
 
         single {

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
@@ -66,6 +66,15 @@ class AndroidApkInspector(
                     pm.getPackageInfoCompat(packageName, FULL_FLAGS)
                 } catch (_: PackageManager.NameNotFoundException) {
                     null
+                } catch (t: Throwable) {
+                    // Wider catch for SecurityException, DeadObjectException
+                    // and other binder-side surprises so the coroutine
+                    // never propagates a PM hiccup; the sheet renders the
+                    // empty state instead of crashing.
+                    Logger.w(TAG) {
+                        "inspectInstalled: PackageManager threw for $packageName: $t"
+                    }
+                    null
                 }
             if (info == null) {
                 Logger.w(TAG) { "inspectInstalled: package not found: $packageName" }
@@ -102,15 +111,16 @@ class AndroidApkInspector(
 
         val permissions = info.requestedPermissions?.toList().orEmpty()
         val grantFlags = info.requestedPermissionsFlags
+        val isInstalledPackage = packageNameForGrantState != null
         val resolvedPermissions =
             permissions.mapIndexed { index, permName ->
                 val granted =
-                    if (packageNameForGrantState != null && grantFlags != null && index < grantFlags.size) {
+                    if (isInstalledPackage && grantFlags != null && index < grantFlags.size) {
                         (grantFlags[index] and PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0
                     } else {
                         null
                     }
-                resolvePermission(permName, granted)
+                resolvePermission(permName, granted, isInstalledPackage)
             }
 
         val mainActivity =
@@ -140,7 +150,11 @@ class AndroidApkInspector(
         )
     }
 
-    private fun resolvePermission(name: String, granted: Boolean?): ApkPermission {
+    private fun resolvePermission(
+        name: String,
+        granted: Boolean?,
+        isInstalledPackage: Boolean,
+    ): ApkPermission {
         // PermissionInfo lookup is best-effort — system / OEM
         // permissions sometimes vanish between OS versions.
         val info =
@@ -151,15 +165,24 @@ class AndroidApkInspector(
                 ?: name.substringAfterLast('.').replace('_', ' ').lowercase()
                     .replaceFirstChar { it.titlecase() }
         val description = info?.loadDescription(pm)?.toString()?.takeIf { it.isNotBlank() }
+        // Normal-protection permissions are auto-granted at install,
+        // so on an installed package treat them as granted=true even
+        // if the requestedPermissionsFlags array didn't surface the
+        // bit (some OEM ROMs omit it for non-dangerous entries). For
+        // file-based inspections there's no grant state yet — report
+        // `null` so the UI can render "to be granted on install".
+        val resolvedGranted =
+            when {
+                granted != null -> granted
+                isInstalledPackage && protection == ProtectionLevel.NORMAL -> true
+                else -> null
+            }
         return ApkPermission(
             name = name,
             displayName = display,
             description = description,
             protectionLevel = protection,
-            // Normal-protection permissions are auto-granted at install
-            // and don't surface in the runtime grant array, so report
-            // `true` for installed packages and `null` for file-only.
-            granted = granted ?: if (granted == null && protection == ProtectionLevel.NORMAL) null else granted,
+            granted = resolvedGranted,
         )
     }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
@@ -1,0 +1,220 @@
+package zed.rainxch.core.data.services
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import android.os.Build
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import zed.rainxch.core.domain.model.ApkInspection
+import zed.rainxch.core.domain.model.ApkPermission
+import zed.rainxch.core.domain.model.ProtectionLevel
+import zed.rainxch.core.domain.system.ApkInspector
+import java.io.File
+
+class AndroidApkInspector(
+    private val context: Context,
+) : ApkInspector {
+    private val pm: PackageManager get() = context.packageManager
+
+    override suspend fun inspectFile(filePath: String): ApkInspection? =
+        withContext(Dispatchers.IO) {
+            val file = File(filePath)
+            if (!file.exists() || !file.canRead()) {
+                Logger.w(TAG) { "inspectFile: file missing or unreadable: $filePath" }
+                return@withContext null
+            }
+            val info = pm.getPackageArchiveInfoCompat(filePath, FULL_FLAGS)
+            if (info == null) {
+                Logger.w(TAG) { "inspectFile: PackageManager refused $filePath" }
+                return@withContext null
+            }
+            // PM doesn't auto-populate sourceDir for archive-loaded
+            // ApplicationInfo, so loadLabel/loadIcon return generics
+            // unless we patch them here.
+            info.applicationInfo?.apply {
+                sourceDir = filePath
+                publicSourceDir = filePath
+            }
+            buildInspection(
+                info = info,
+                source = ApkInspection.Source.FILE,
+                filePath = filePath,
+                fileSizeBytes = file.length(),
+                packageNameForGrantState = null,
+            )
+        }
+
+    override suspend fun inspectInstalled(packageName: String): ApkInspection? =
+        withContext(Dispatchers.IO) {
+            val info =
+                try {
+                    pm.getPackageInfoCompat(packageName, FULL_FLAGS)
+                } catch (_: PackageManager.NameNotFoundException) {
+                    null
+                }
+            if (info == null) {
+                Logger.w(TAG) { "inspectInstalled: package not found: $packageName" }
+                return@withContext null
+            }
+            val sourceDir = info.applicationInfo?.sourceDir
+            val sizeBytes = sourceDir?.let { runCatching { File(it).length() }.getOrNull() }
+            buildInspection(
+                info = info,
+                source = ApkInspection.Source.INSTALLED,
+                filePath = sourceDir,
+                fileSizeBytes = sizeBytes,
+                packageNameForGrantState = packageName,
+            )
+        }
+
+    private fun buildInspection(
+        info: PackageInfo,
+        source: ApkInspection.Source,
+        filePath: String?,
+        fileSizeBytes: Long?,
+        packageNameForGrantState: String?,
+    ): ApkInspection {
+        val appInfo = info.applicationInfo
+        val label = appInfo?.loadLabel(pm)?.toString().orEmpty()
+        val versionCode =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode
+            else @Suppress("DEPRECATION") info.versionCode.toLong()
+
+        val permissions = info.requestedPermissions?.toList().orEmpty()
+        val grantFlags = info.requestedPermissionsFlags
+        val resolvedPermissions =
+            permissions.mapIndexed { index, permName ->
+                val granted =
+                    if (packageNameForGrantState != null && grantFlags != null && index < grantFlags.size) {
+                        (grantFlags[index] and PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0
+                    } else {
+                        null
+                    }
+                resolvePermission(permName, granted)
+            }
+
+        val mainActivity =
+            runCatching {
+                pm.getLaunchIntentForPackage(info.packageName)?.component?.className
+            }.getOrNull()
+
+        return ApkInspection(
+            appLabel = label.ifBlank { info.packageName },
+            packageName = info.packageName,
+            versionName = info.versionName,
+            versionCode = versionCode,
+            signingFingerprint = SigningFingerprint.fromPackageInfo(info),
+            minSdk =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) appInfo?.minSdkVersion
+                else null,
+            targetSdk = appInfo?.targetSdkVersion,
+            permissions = resolvedPermissions,
+            mainActivity = mainActivity,
+            activityCount = info.activities?.size ?: 0,
+            serviceCount = info.services?.size ?: 0,
+            receiverCount = info.receivers?.size ?: 0,
+            fileSizeBytes = fileSizeBytes,
+            filePath = filePath,
+            debuggable = appInfo?.let { (it.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0 } ?: false,
+            source = source,
+        )
+    }
+
+    private fun resolvePermission(name: String, granted: Boolean?): ApkPermission {
+        // PermissionInfo lookup is best-effort — system / OEM
+        // permissions sometimes vanish between OS versions.
+        val info =
+            runCatching { pm.getPermissionInfo(name, 0) }.getOrNull()
+        val protection = info?.let { resolveProtectionLevel(it) } ?: ProtectionLevel.UNKNOWN
+        val display =
+            info?.loadLabel(pm)?.toString()?.takeIf { it.isNotBlank() }
+                ?: name.substringAfterLast('.').replace('_', ' ').lowercase()
+                    .replaceFirstChar { it.titlecase() }
+        val description = info?.loadDescription(pm)?.toString()?.takeIf { it.isNotBlank() }
+        return ApkPermission(
+            name = name,
+            displayName = display,
+            description = description,
+            protectionLevel = protection,
+            // Normal-protection permissions are auto-granted at install
+            // and don't surface in the runtime grant array, so report
+            // `true` for installed packages and `null` for file-only.
+            granted = granted ?: if (granted == null && protection == ProtectionLevel.NORMAL) null else granted,
+        )
+    }
+
+    private fun resolveProtectionLevel(info: PermissionInfo): ProtectionLevel {
+        val base =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                info.protection
+            } else {
+                @Suppress("DEPRECATION")
+                info.protectionLevel and PermissionInfo.PROTECTION_MASK_BASE
+            }
+        val flags =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                info.protectionFlags
+            } else {
+                @Suppress("DEPRECATION")
+                info.protectionLevel and PermissionInfo.PROTECTION_MASK_FLAGS
+            }
+        return when (base) {
+            PermissionInfo.PROTECTION_DANGEROUS -> ProtectionLevel.DANGEROUS
+            PermissionInfo.PROTECTION_SIGNATURE -> {
+                if ((flags and PermissionInfo.PROTECTION_FLAG_PRIVILEGED) != 0) {
+                    ProtectionLevel.PRIVILEGED
+                } else {
+                    ProtectionLevel.SIGNATURE
+                }
+            }
+            PermissionInfo.PROTECTION_NORMAL -> ProtectionLevel.NORMAL
+            else -> ProtectionLevel.UNKNOWN
+        }
+    }
+
+    private companion object {
+        const val TAG = "AndroidApkInspector"
+
+        // Minimum flags to populate everything the inspector reports.
+        // GET_SIGNING_CERTIFICATES is what SigningFingerprint reads;
+        // the rest power the counts and labels.
+        @Suppress("DEPRECATION")
+        val FULL_FLAGS: Int =
+            (
+                PackageManager.GET_PERMISSIONS or
+                    PackageManager.GET_ACTIVITIES or
+                    PackageManager.GET_SERVICES or
+                    PackageManager.GET_RECEIVERS
+            ) or
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    PackageManager.GET_SIGNING_CERTIFICATES
+                } else {
+                    PackageManager.GET_SIGNATURES
+                }
+    }
+}
+
+private fun PackageManager.getPackageArchiveInfoCompat(
+    filePath: String,
+    flags: Int,
+): PackageInfo? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getPackageArchiveInfo(filePath, PackageManager.PackageInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getPackageArchiveInfo(filePath, flags)
+    }
+
+private fun PackageManager.getPackageInfoCompat(
+    packageName: String,
+    flags: Int,
+): PackageInfo =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getPackageInfo(packageName, flags)
+    }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidApkInspector.kt
@@ -38,13 +38,25 @@ class AndroidApkInspector(
                 sourceDir = filePath
                 publicSourceDir = filePath
             }
-            buildInspection(
-                info = info,
-                source = ApkInspection.Source.FILE,
-                filePath = filePath,
-                fileSizeBytes = file.length(),
-                packageNameForGrantState = null,
-            )
+            // Wide catch by design: PackageManager / Resources reads
+            // can throw a long tail of unchecked exceptions
+            // (DeadObjectException, SecurityException, NPE on exotic
+            // signing layouts, etc.) that are all ultimately the same
+            // outcome from the caller's perspective — "inspection
+            // failed". Letting them escape leaves the sheet stuck on
+            // its loading spinner because the VM never updates state.
+            try {
+                buildInspection(
+                    info = info,
+                    source = ApkInspection.Source.FILE,
+                    filePath = filePath,
+                    fileSizeBytes = file.length(),
+                    packageNameForGrantState = null,
+                )
+            } catch (t: Throwable) {
+                Logger.w(TAG) { "inspectFile: failed to extract APK metadata for $filePath: $t" }
+                null
+            }
         }
 
     override suspend fun inspectInstalled(packageName: String): ApkInspection? =
@@ -61,13 +73,18 @@ class AndroidApkInspector(
             }
             val sourceDir = info.applicationInfo?.sourceDir
             val sizeBytes = sourceDir?.let { runCatching { File(it).length() }.getOrNull() }
-            buildInspection(
-                info = info,
-                source = ApkInspection.Source.INSTALLED,
-                filePath = sourceDir,
-                fileSizeBytes = sizeBytes,
-                packageNameForGrantState = packageName,
-            )
+            try {
+                buildInspection(
+                    info = info,
+                    source = ApkInspection.Source.INSTALLED,
+                    filePath = sourceDir,
+                    fileSizeBytes = sizeBytes,
+                    packageNameForGrantState = packageName,
+                )
+            } catch (t: Throwable) {
+                Logger.w(TAG) { "inspectInstalled: failed to extract metadata for $packageName: $t" }
+                null
+            }
         }
 
     private fun buildInspection(

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
@@ -116,6 +116,31 @@ class PackageEventReceiver() :
         }
     }
 
+    /**
+     * Wipes the parked-install metadata on the row and deletes the
+     * APK file from disk now that the system holds the real package.
+     * Best-effort throughout — DB write failures are logged but never
+     * thrown so the broadcast handler can continue to do its other work
+     * (delta-scan, etc.). Safe to call when no parked file exists.
+     */
+    private suspend fun clearParkedInstall(
+        repo: InstalledAppsRepository,
+        packageName: String,
+        parkedFilePath: String?,
+    ) {
+        runCatching {
+            repo.setPendingInstallFilePath(packageName = packageName, path = null)
+        }.onFailure {
+            Logger.w(it) { "Failed to clear parked install metadata for $packageName" }
+        }
+        if (parkedFilePath != null) {
+            runCatching { java.io.File(parkedFilePath).takeIf { it.exists() }?.delete() }
+                .onFailure {
+                    Logger.w(it) { "Failed to delete parked APK at $parkedFilePath" }
+                }
+        }
+    }
+
     private suspend fun onPackageInstalled(packageName: String) {
         try {
             val repo = getRepository()
@@ -170,6 +195,11 @@ class PackageEventReceiver() :
                         repo.updatePendingStatus(packageName, false)
                         Logger.i { "Resolved pending install via broadcast (no system info): $packageName" }
                     }
+                    // System has the package now — the parked APK on disk is
+                    // dead weight. Clear the path on the row (otherwise the
+                    // apps screen keeps rendering the "Install" CTA after a
+                    // successful install) and delete the file to free space.
+                    clearParkedInstall(repo, packageName, app.pendingInstallFilePath)
                 } else {
                     handleExternalInstall(packageName, app, repo, monitor)
                 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/SigningFingerprint.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/SigningFingerprint.kt
@@ -1,0 +1,39 @@
+package zed.rainxch.core.data.services
+
+import android.content.pm.PackageInfo
+import android.os.Build
+import java.security.MessageDigest
+
+/**
+ * Pulls the SHA-256 signing fingerprint out of a [PackageInfo],
+ * regardless of whether it was parsed with `GET_SIGNING_CERTIFICATES`
+ * (Android P+) or the legacy `GET_SIGNATURES` flag. Returns `null`
+ * when no signature data is reachable.
+ *
+ * Format: hex bytes joined with `:` separators, uppercase — same shape
+ * as `keytool -printcert` so users can paste-compare.
+ */
+internal object SigningFingerprint {
+    fun fromPackageInfo(info: PackageInfo): String? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val sigInfo = info.signingInfo ?: return null
+            val cert =
+                if (sigInfo.hasMultipleSigners()) {
+                    sigInfo.apkContentsSigners?.firstOrNull()
+                } else {
+                    // signingCertificateHistory is oldest → newest; the
+                    // last entry is the active signer after rotation.
+                    sigInfo.signingCertificateHistory?.lastOrNull()
+                }
+            return cert?.toByteArray()?.let(::sha256)
+        }
+        @Suppress("DEPRECATION")
+        return info.signatures?.firstOrNull()?.toByteArray()?.let(::sha256)
+    }
+
+    private fun sha256(bytes: ByteArray): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString(":") { "%02X".format(it) }
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -455,6 +455,19 @@ class InstalledAppsRepositoryImpl(
                 lastUpdatedAt = System.currentTimeMillis(),
                 lastCheckedAt = System.currentTimeMillis(),
                 signingFingerprint = signingFingerprint,
+                // When this update settled (isPendingInstall = false),
+                // wipe any leftover parked-install pointer so the apps
+                // screen stops advertising an Install CTA on a file
+                // the system already swapped under the row. Caller
+                // (DetailsViewModel.saveInstalledAppToDatabase) re-sets
+                // these explicitly via setPendingInstallFilePath
+                // afterwards on the still-pending path.
+                pendingInstallFilePath =
+                    if (isPendingInstall) app.pendingInstallFilePath else null,
+                pendingInstallVersion =
+                    if (isPendingInstall) app.pendingInstallVersion else null,
+                pendingInstallAssetName =
+                    if (isPendingInstall) app.pendingInstallAssetName else null,
             ),
         )
     }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -279,6 +279,17 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getApkInspectCoachmarkShown(): Flow<Boolean> =
+        preferences.data.map { prefs ->
+            prefs[APK_INSPECT_COACHMARK_SHOWN_KEY] ?: false
+        }
+
+    override suspend fun setApkInspectCoachmarkShown(shown: Boolean) {
+        preferences.edit { prefs ->
+            prefs[APK_INSPECT_COACHMARK_SHOWN_KEY] = shown
+        }
+    }
+
     companion object {
         private const val DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 6L
 
@@ -304,5 +315,6 @@ class TweaksRepositoryImpl(
         private val EXTERNAL_IMPORT_ENABLED_KEY = booleanPreferencesKey("external_import_enabled")
         private val EXTERNAL_MATCH_SEARCH_ENABLED_KEY = booleanPreferencesKey("external_match_search_enabled")
         private val EXTERNAL_IMPORT_BANNER_DISMISSED_AT_KEY = intPreferencesKey("external_import_banner_dismissed_at")
+        private val APK_INSPECT_COACHMARK_SHOWN_KEY = booleanPreferencesKey("apk_inspect_coachmark_shown")
     }
 }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
@@ -63,6 +63,10 @@ actual val corePlatformModule = module {
         DesktopPackageMonitor()
     }
 
+    single<zed.rainxch.core.domain.system.ApkInspector> {
+        zed.rainxch.core.data.services.DesktopApkInspector()
+    }
+
     single<ExternalAppScanner> {
         DesktopExternalAppScanner()
     }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
@@ -6,6 +6,7 @@ import org.koin.dsl.module
 import zed.rainxch.core.data.local.data_store.createDataStore
 import zed.rainxch.core.data.local.db.AppDatabase
 import zed.rainxch.core.data.local.db.initDatabase
+import zed.rainxch.core.data.services.DesktopApkInspector
 import zed.rainxch.core.data.services.DesktopInstallerInfoExtractor
 import zed.rainxch.core.data.utils.DesktopAppLauncher
 import zed.rainxch.core.data.utils.DesktopBrowserHelper
@@ -32,6 +33,7 @@ import zed.rainxch.core.data.utils.DesktopShareManager
 import zed.rainxch.core.data.network.DesktopDigestVerifier
 import zed.rainxch.core.domain.network.DigestVerifier
 import zed.rainxch.core.domain.network.Downloader
+import zed.rainxch.core.domain.system.ApkInspector
 import zed.rainxch.core.domain.system.PackageMonitor
 import zed.rainxch.core.domain.utils.AppLauncher
 import zed.rainxch.core.domain.utils.BrowserHelper
@@ -63,8 +65,8 @@ actual val corePlatformModule = module {
         DesktopPackageMonitor()
     }
 
-    single<zed.rainxch.core.domain.system.ApkInspector> {
-        zed.rainxch.core.data.services.DesktopApkInspector()
+    single<ApkInspector> {
+        DesktopApkInspector()
     }
 
     single<ExternalAppScanner> {

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopApkInspector.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopApkInspector.kt
@@ -1,0 +1,15 @@
+package zed.rainxch.core.data.services
+
+import zed.rainxch.core.domain.model.ApkInspection
+import zed.rainxch.core.domain.system.ApkInspector
+
+/**
+ * Desktop has no concept of an APK manifest. The inspector is wired in
+ * for symmetry with Android — every call returns `null` so the UI can
+ * gate on `inspect(...) != null` without platform branching.
+ */
+class DesktopApkInspector : ApkInspector {
+    override suspend fun inspectFile(filePath: String): ApkInspection? = null
+
+    override suspend fun inspectInstalled(packageName: String): ApkInspection? = null
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/ApkInspection.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/ApkInspection.kt
@@ -1,0 +1,89 @@
+package zed.rainxch.core.domain.model
+
+/**
+ * Snapshot of an APK's declared metadata. Produced by
+ * [zed.rainxch.core.domain.system.ApkInspector] from either a file on
+ * disk (parked install) or an installed package's manifest.
+ *
+ * Everything here is *as the APK declares it* — the inspector does not
+ * resolve it against runtime grant state for permissions, that lives on
+ * [ApkPermission.granted] which is `null` for file-based inspections
+ * because there's no system-level grant before install.
+ */
+data class ApkInspection(
+    /** App label as the APK declares it (e.g. "Signal"). */
+    val appLabel: String,
+    val packageName: String,
+    val versionName: String?,
+    val versionCode: Long?,
+    /** SHA-256 of the APK signer cert, hex-encoded with colons. */
+    val signingFingerprint: String?,
+    /** Lowest API the APK runs on. */
+    val minSdk: Int?,
+    /** API the developer compiled against. */
+    val targetSdk: Int?,
+    /** Permissions declared in the manifest, mapped with protection level. */
+    val permissions: List<ApkPermission>,
+    /** Fully-qualified main launcher activity, if any. */
+    val mainActivity: String?,
+    /** Total declared activity count (manifest entries). */
+    val activityCount: Int,
+    /** Total declared service count. */
+    val serviceCount: Int,
+    /** Total declared receiver count. */
+    val receiverCount: Int,
+    /** Bytes on disk (file-based) or APK file size on the device (installed). */
+    val fileSizeBytes: Long?,
+    /** Absolute path to the inspected APK file, if any. */
+    val filePath: String?,
+    /** Manifest's `android:debuggable` flag — sketchy if true on a release build. */
+    val debuggable: Boolean,
+    /** Source of the inspection. */
+    val source: Source,
+) {
+    enum class Source {
+        /** Read from a file on disk that's parked for install. */
+        FILE,
+
+        /** Read from an installed package's manifest. */
+        INSTALLED,
+    }
+}
+
+data class ApkPermission(
+    /** Fully-qualified permission name (e.g. `android.permission.INTERNET`). */
+    val name: String,
+    /** Short, user-friendly label loaded from the system or derived from [name]. */
+    val displayName: String,
+    /** Description loaded from the system, when available. */
+    val description: String?,
+    val protectionLevel: ProtectionLevel,
+    /**
+     * Runtime grant state on the device. `true`/`false` for installed
+     * dangerous permissions; `null` for file-based inspections (no
+     * grant exists pre-install) and for normal-protection permissions
+     * that are auto-granted at install.
+     */
+    val granted: Boolean?,
+)
+
+/**
+ * Coarse bucketing of Android's permission protection levels — enough
+ * to drive a "danger color" in the UI without exposing every flag bit.
+ */
+enum class ProtectionLevel {
+    /** Auto-granted at install. Low risk. */
+    NORMAL,
+
+    /** Sensitive — requires runtime user grant. Show in red. */
+    DANGEROUS,
+
+    /** Granted only to apps signed with the same cert. Show in amber. */
+    SIGNATURE,
+
+    /** Privileged platform permissions. Show in deep amber. */
+    PRIVILEGED,
+
+    /** Couldn't classify. */
+    UNKNOWN,
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -98,4 +98,13 @@ interface TweaksRepository {
     fun getExternalImportBannerDismissedAtCount(): Flow<Int>
 
     suspend fun setExternalImportBannerDismissedAtCount(count: Int)
+
+    /**
+     * One-shot flag for the APK Inspect coachmark next to the install
+     * button on the details screen. `false` until the user has seen the
+     * coachmark at least once; flips permanently to `true` thereafter.
+     */
+    fun getApkInspectCoachmarkShown(): Flow<Boolean>
+
+    suspend fun setApkInspectCoachmarkShown(shown: Boolean)
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/ApkInspector.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/ApkInspector.kt
@@ -1,0 +1,28 @@
+package zed.rainxch.core.domain.system
+
+import zed.rainxch.core.domain.model.ApkInspection
+
+/**
+ * Reads metadata out of an APK file or an installed package and returns
+ * the result as an [ApkInspection]. Used by the "Inspect APK" sheet to
+ * show users what a package declares before they install it (and to
+ * audit installed packages after the fact).
+ *
+ * Implementations live per-platform; on Android the Inspector reads
+ * from `PackageManager`, on JVM/desktop it returns `null` (no APK
+ * concept on those targets).
+ */
+interface ApkInspector {
+    /**
+     * Inspects an APK file at [filePath]. Returns `null` if the file
+     * doesn't exist, isn't a valid APK, or the platform can't extract
+     * metadata.
+     */
+    suspend fun inspectFile(filePath: String): ApkInspection?
+
+    /**
+     * Inspects an installed package by [packageName]. Returns `null`
+     * if the package isn't on the system or metadata is unavailable.
+     */
+    suspend fun inspectInstalled(packageName: String): ApkInspection?
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/use_cases/SyncInstalledAppsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/use_cases/SyncInstalledAppsUseCase.kt
@@ -43,6 +43,14 @@ class SyncInstalledAppsUseCase(
                 val toResolvePending = mutableListOf<InstalledApp>()
                 val toDeleteStalePending = mutableListOf<String>()
                 val toSyncVersions = mutableListOf<InstalledApp>()
+                // Rows that are confirmed-installed but still carry a
+                // stale `pendingInstallFilePath`. Happens when the user
+                // installed a parked file but the broadcast handler
+                // missed the cleanup (process killed mid-install,
+                // legacy rows from before the cleanup was wired in,
+                // etc.). Without this sweep the apps screen keeps
+                // rendering an "Install" CTA forever.
+                val toClearStaleParkedFile = mutableListOf<InstalledApp>()
 
                 appsInDb.forEach { app ->
                     val isOnSystem = installedPackageNames.contains(app.packageName)
@@ -68,6 +76,9 @@ class SyncInstalledAppsUseCase(
                         isOnSystem && platform == Platform.ANDROID -> {
                             toSyncVersions.add(app)
                         }
+                    }
+                    if (isOnSystem && !app.isPendingInstall && app.pendingInstallFilePath != null) {
+                        toClearStaleParkedFile.add(app)
                     }
                 }
 
@@ -110,8 +121,33 @@ class SyncInstalledAppsUseCase(
                                 installedAppsRepository.updatePendingStatus(app.packageName, false)
                                 logger.info("Resolved pending install (no system info): ${app.packageName}")
                             }
+                            // Resolution implies the system holds the
+                            // package — drop the parked-file metadata
+                            // so the apps row stops advertising an
+                            // Install CTA on a file the user already
+                            // installed.
+                            installedAppsRepository.setPendingInstallFilePath(
+                                packageName = app.packageName,
+                                path = null,
+                            )
                         } catch (e: Exception) {
                             logger.error("Failed to resolve pending ${app.packageName}: ${e.message}")
+                        }
+                    }
+
+                    toClearStaleParkedFile.forEach { app ->
+                        try {
+                            installedAppsRepository.setPendingInstallFilePath(
+                                packageName = app.packageName,
+                                path = null,
+                            )
+                            logger.info(
+                                "Cleared stale parked-file metadata for already-installed ${app.packageName}",
+                            )
+                        } catch (e: Exception) {
+                            logger.error(
+                                "Failed to clear stale parked-file for ${app.packageName}: ${e.message}",
+                            )
                         }
                     }
 
@@ -171,7 +207,8 @@ class SyncInstalledAppsUseCase(
                 logger.info(
                     "Sync completed: ${toDelete.size} deleted, ${toDeleteStalePending.size} stale pending removed, " +
                         "${toResolvePending.size} pending resolved, ${toMigrate.size} migrated, " +
-                        "${toSyncVersions.size} version-checked",
+                        "${toSyncVersions.size} version-checked, " +
+                        "${toClearStaleParkedFile.size} stale parked files cleared",
                 )
 
                 Result.success(Unit)

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -981,6 +981,7 @@
     <string name="apk_inspect_identity">Identity</string>
     <string name="apk_inspect_compatibility">Compatibility</string>
     <string name="apk_inspect_permissions">Permissions (%1$d)</string>
+    <string name="apk_inspect_permissions_title">Permissions</string>
     <string name="apk_inspect_permissions_empty">No permissions declared.</string>
     <string name="apk_inspect_components">Components</string>
     <string name="apk_inspect_file_info">File</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -259,6 +259,7 @@
     <string name="install_version">Install %1$s</string>
     <string name="failed_to_open_app">Failed to open %1$s</string>
     <string name="failed_to_uninstall">Failed to uninstall %1$s</string>
+    <string name="failed_to_discard_pending">Failed to discard pending install for %1$s</string>
 
     <!-- Install helpers -->
     <string name="open_in_obtainium">Open in Obtainium</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -967,4 +967,5 @@
     <string name="apps_compact_status_variant_stale">variant stale, action needed</string>
     <string name="apps_compact_status_pending_install">pending install</string>
     <string name="apps_compact_status_ready_to_install">ready to install</string>
+    <string name="discard_pending_install">Discard</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -654,6 +654,8 @@
     <string name="include_pre_releases_description">Track pre-release versions when checking for updates. When disabled, only stable releases are considered.</string>
     <string name="confirm_uninstall_title">Uninstall app?</string>
     <string name="confirm_uninstall_message">Are you sure you want to uninstall %1$s? This action cannot be undone and app data may be lost.</string>
+    <string name="confirm_discard_pending_title">Discard pending install?</string>
+    <string name="confirm_discard_pending_message">Drop the parked installer for %1$s and remove the row from your apps list? The downloaded APK will be deleted.</string>
 
     <string name="invalid_github_url">Invalid GitHub URL. Use format: github.com/owner/repo</string>
     <string name="repo_not_found">Repository not found: %1$s/%2$s</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -968,4 +968,35 @@
     <string name="apps_compact_status_pending_install">pending install</string>
     <string name="apps_compact_status_ready_to_install">ready to install</string>
     <string name="discard_pending_install">Discard</string>
+
+    <!-- APK Inspect feature -->
+    <string name="apk_inspect_title">APK Inspect</string>
+    <string name="apk_inspect_button_label">Inspect APK</string>
+    <string name="apk_inspect_coachmark_title">Peek inside before installing</string>
+    <string name="apk_inspect_coachmark_body">Permissions, signing, components — see exactly what an APK declares.</string>
+    <string name="apk_inspect_coachmark_dismiss">Got it</string>
+    <string name="apk_inspect_empty">Nothing to inspect for this app yet.</string>
+    <string name="apk_inspect_source_file">Parked file</string>
+    <string name="apk_inspect_source_installed">Installed package</string>
+    <string name="apk_inspect_identity">Identity</string>
+    <string name="apk_inspect_compatibility">Compatibility</string>
+    <string name="apk_inspect_permissions">Permissions (%1$d)</string>
+    <string name="apk_inspect_permissions_empty">No permissions declared.</string>
+    <string name="apk_inspect_components">Components</string>
+    <string name="apk_inspect_file_info">File</string>
+    <string name="apk_inspect_version_code">Version</string>
+    <string name="apk_inspect_signing">Signing fingerprint</string>
+    <string name="apk_inspect_min_sdk">Minimum SDK</string>
+    <string name="apk_inspect_target_sdk">Target SDK</string>
+    <string name="apk_inspect_size">Size</string>
+    <string name="apk_inspect_section_activities">Activities</string>
+    <string name="apk_inspect_section_services">Services</string>
+    <string name="apk_inspect_section_receivers">Receivers</string>
+    <string name="apk_inspect_section_main_activity">Main activity</string>
+    <string name="apk_inspect_debuggable">Debuggable build — sketchy if this is a release.</string>
+    <string name="apk_inspect_protection_dangerous">Sensitive</string>
+    <string name="apk_inspect_protection_signature">Signature</string>
+    <string name="apk_inspect_protection_privileged">Privileged</string>
+    <string name="apk_inspect_protection_normal">Normal</string>
+    <string name="apk_inspect_protection_unknown">Unknown</string>
 </resources>

--- a/feature/apps/presentation/src/androidMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.android.kt
+++ b/feature/apps/presentation/src/androidMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.android.kt
@@ -1,7 +1,7 @@
 package zed.rainxch.apps.presentation.components
 
 import android.content.pm.PackageManager
-import android.content.pm.PackageManager.NameNotFoundException
+import android.os.Build
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
@@ -14,6 +14,8 @@ import androidx.core.graphics.drawable.toBitmap
 import org.jetbrains.compose.resources.painterResource
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.app_icon
+
+private const val TAG = "InstalledAppIcon"
 
 @Composable
 actual fun InstalledAppIcon(
@@ -53,7 +55,14 @@ private fun resolveInstalledIcon(
             .getApplicationIcon(packageName)
             .toBitmap()
             .asImageBitmap()
-    } catch (_: NameNotFoundException) {
+    } catch (t: Throwable) {
+        // Wide catch: NameNotFoundException is the common case but
+        // PackageManager can also throw SecurityException on cross-user
+        // reads, plus toBitmap() can throw if the drawable can't be
+        // rasterized (unsupported drawable type, OOM on huge icons).
+        // Composition crash on the Apps screen is the worst-case
+        // outcome — silently fall back to the default icon instead.
+        Log.w(TAG, "failed to load installed icon for $packageName", t)
         null
     }
 
@@ -66,7 +75,7 @@ private fun resolveApkIcon(
         // to point at the APK so loadIcon() resolves the embedded drawable.
         // Without setting sourceDir/publicSourceDir loadIcon() returns the
         // default Android boilerplate icon — useless as a fallback.
-        val info = packageManager.getPackageArchiveInfo(apkFilePath, 0)
+        val info = getPackageArchiveInfoCompat(packageManager, apkFilePath)
         val appInfo = info?.applicationInfo ?: return null
         appInfo.sourceDir = apkFilePath
         appInfo.publicSourceDir = apkFilePath
@@ -75,6 +84,20 @@ private fun resolveApkIcon(
             ?.toBitmap()
             ?.asImageBitmap()
     } catch (t: Throwable) {
-        Log.w("InstalledAppIcon", "failed to load icon from APK at $apkFilePath", t)
+        Log.w(TAG, "failed to load icon from APK at $apkFilePath", t)
         null
+    }
+
+private fun getPackageArchiveInfoCompat(
+    packageManager: PackageManager,
+    apkFilePath: String,
+) =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.getPackageArchiveInfo(
+            apkFilePath,
+            PackageManager.PackageInfoFlags.of(0L),
+        )
+    } else {
+        @Suppress("DEPRECATION")
+        packageManager.getPackageArchiveInfo(apkFilePath, 0)
     }

--- a/feature/apps/presentation/src/androidMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.android.kt
+++ b/feature/apps/presentation/src/androidMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.android.kt
@@ -1,10 +1,13 @@
 package zed.rainxch.apps.presentation.components
 
+import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.drawable.toBitmap
@@ -17,18 +20,13 @@ actual fun InstalledAppIcon(
     packageName: String,
     appName: String,
     modifier: Modifier,
+    apkFilePath: String?,
 ) {
     val packageManager = LocalContext.current.packageManager
     val iconBitmap =
-        remember(packageName, packageManager) {
-            try {
-                packageManager
-                    .getApplicationIcon(packageName)
-                    .toBitmap()
-                    .asImageBitmap()
-            } catch (_: NameNotFoundException) {
-                null
-            }
+        remember(packageName, apkFilePath, packageManager) {
+            resolveInstalledIcon(packageManager, packageName)
+                ?: apkFilePath?.let { resolveApkIcon(packageManager, it) }
         }
 
     if (iconBitmap != null) {
@@ -45,3 +43,38 @@ actual fun InstalledAppIcon(
         )
     }
 }
+
+private fun resolveInstalledIcon(
+    packageManager: PackageManager,
+    packageName: String,
+): ImageBitmap? =
+    try {
+        packageManager
+            .getApplicationIcon(packageName)
+            .toBitmap()
+            .asImageBitmap()
+    } catch (_: NameNotFoundException) {
+        null
+    }
+
+private fun resolveApkIcon(
+    packageManager: PackageManager,
+    apkFilePath: String,
+): ImageBitmap? =
+    try {
+        // PackageManager.getApplicationIcon(applicationInfo) needs sourceDir
+        // to point at the APK so loadIcon() resolves the embedded drawable.
+        // Without setting sourceDir/publicSourceDir loadIcon() returns the
+        // default Android boilerplate icon — useless as a fallback.
+        val info = packageManager.getPackageArchiveInfo(apkFilePath, 0)
+        val appInfo = info?.applicationInfo ?: return null
+        appInfo.sourceDir = apkFilePath
+        appInfo.publicSourceDir = apkFilePath
+        appInfo
+            .loadIcon(packageManager)
+            ?.toBitmap()
+            ?.asImageBitmap()
+    } catch (t: Throwable) {
+        Log.w("InstalledAppIcon", "failed to load icon from APK at $apkFilePath", t)
+        null
+    }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -104,14 +104,25 @@ sealed interface AppsAction {
     ) : AppsAction
 
     /**
-     * User chose to discard a pending install (cancelled the system
-     * prompt one too many times, doesn't want this app anymore). Deletes
-     * the parked APK file from disk, removes the orchestrator entry,
-     * and removes the DB row so the app stops appearing in the list.
+     * User tapped the Discard affordance on a pending row — opens the
+     * confirmation dialog without doing anything destructive yet. The
+     * actual cleanup runs only after [OnConfirmDiscardPendingInstall].
      */
     data class OnDiscardPendingInstall(
         val app: InstalledAppUi,
     ) : AppsAction
+
+    /**
+     * User confirmed the Discard prompt. Cancels the orchestrator
+     * entry, deletes the parked APK file, and removes the DB row so
+     * the app stops appearing in the list.
+     */
+    data class OnConfirmDiscardPendingInstall(
+        val app: InstalledAppUi,
+    ) : AppsAction
+
+    /** User dismissed the Discard confirmation without confirming. */
+    data object OnDismissDiscardPendingDialog : AppsAction
 
     // External import banner (E1)
     data object OnImportProposalReview : AppsAction

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -103,6 +103,16 @@ sealed interface AppsAction {
         val app: InstalledAppUi,
     ) : AppsAction
 
+    /**
+     * User chose to discard a pending install (cancelled the system
+     * prompt one too many times, doesn't want this app anymore). Deletes
+     * the parked APK file from disk, removes the orchestrator entry,
+     * and removes the DB row so the app stops appearing in the list.
+     */
+    data class OnDiscardPendingInstall(
+        val app: InstalledAppUi,
+    ) : AppsAction
+
     // External import banner (E1)
     data object OnImportProposalReview : AppsAction
 

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -145,6 +145,7 @@ import zed.rainxch.githubstore.core.presentation.res.sort_name
 import zed.rainxch.githubstore.core.presentation.res.sort_recently_updated
 import zed.rainxch.githubstore.core.presentation.res.sort_updates_first
 import zed.rainxch.githubstore.core.presentation.res.uninstall
+import zed.rainxch.githubstore.core.presentation.res.discard_pending_install
 import zed.rainxch.githubstore.core.presentation.res.update
 import zed.rainxch.githubstore.core.presentation.res.update_all
 import zed.rainxch.githubstore.core.presentation.res.updated_successfully
@@ -604,6 +605,9 @@ fun AppsScreen(
                                                 onInstallPendingClick = {
                                                     onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
                                                 },
+                                                onDiscardPendingClick = {
+                                                    onAction(AppsAction.OnDiscardPendingInstall(appItem.installedApp))
+                                                },
                                                 modifier =
                                                     Modifier
                                                         .then(
@@ -641,6 +645,9 @@ fun AppsScreen(
                                                     onOpenClick = { onAction(AppsAction.OnOpenApp(appItem.installedApp)) },
                                                     onInstallPendingClick = {
                                                         onAction(AppsAction.OnInstallPendingApp(appItem.installedApp))
+                                                    },
+                                                    onDiscardPendingClick = {
+                                                        onAction(AppsAction.OnDiscardPendingInstall(appItem.installedApp))
                                                     },
                                                     onAdvancedSettingsClick = {
                                                         onAction(AppsAction.OnOpenAdvancedSettings(appItem.installedApp))
@@ -755,6 +762,7 @@ fun AppItemCard(
     onAdvancedSettingsClick: () -> Unit,
     onPickVariantClick: () -> Unit,
     onInstallPendingClick: () -> Unit,
+    onDiscardPendingClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val app = appItem.installedApp
@@ -786,6 +794,7 @@ fun AppItemCard(
                         Modifier
                             .size(64.dp)
                             .clip(RoundedCornerShape(18.dp)),
+                    apkFilePath = app.pendingInstallFilePath,
                 )
 
                 Column(modifier = Modifier.weight(1f)) {
@@ -1151,6 +1160,16 @@ fun AppItemCard(
                                     text = stringResource(Res.string.install),
                                 )
                             }
+                            // Quick escape hatch: user cancelled the
+                            // system prompt and doesn't want this app.
+                            // Discard removes the parked file + DB row.
+                            IconButton(onClick = onDiscardPendingClick) {
+                                Icon(
+                                    imageVector = Icons.Default.Cancel,
+                                    contentDescription = stringResource(Res.string.discard_pending_install),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         } else if (app.isUpdateAvailable && !app.isPendingInstall) {
                             Button(
                                 onClick = onUpdateClick,
@@ -1164,6 +1183,32 @@ fun AppItemCard(
                                 Spacer(Modifier.width(4.dp))
                                 Text(
                                     text = stringResource(Res.string.update),
+                                )
+                            }
+                        } else if (app.isPendingInstall) {
+                            // Pending row whose parked file is gone
+                            // (legacy row from before we persisted the
+                            // path, or file deleted out-of-band). The
+                            // app isn't actually installed — Open would
+                            // snackbar an error. Offer Discard so the
+                            // user can clear the row.
+                            Button(
+                                onClick = onDiscardPendingClick,
+                                modifier = Modifier.weight(1f),
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                    ),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Cancel,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text = stringResource(Res.string.discard_pending_install),
                                 )
                             }
                         } else {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -145,6 +145,8 @@ import zed.rainxch.githubstore.core.presentation.res.sort_name
 import zed.rainxch.githubstore.core.presentation.res.sort_recently_updated
 import zed.rainxch.githubstore.core.presentation.res.sort_updates_first
 import zed.rainxch.githubstore.core.presentation.res.uninstall
+import zed.rainxch.githubstore.core.presentation.res.confirm_discard_pending_message
+import zed.rainxch.githubstore.core.presentation.res.confirm_discard_pending_title
 import zed.rainxch.githubstore.core.presentation.res.discard_pending_install
 import zed.rainxch.githubstore.core.presentation.res.update
 import zed.rainxch.githubstore.core.presentation.res.update_all
@@ -407,6 +409,47 @@ fun AppsScreen(
                 dismissButton = {
                     TextButton(
                         onClick = { onAction(AppsAction.OnDismissUninstallDialog) },
+                    ) {
+                        Text(text = stringResource(Res.string.cancel))
+                    }
+                },
+            )
+        }
+
+        // Discard-pending-install confirmation dialog. Mirrors the
+        // uninstall flow because both branches blow away DB rows the
+        // user might still want — the discard target also deletes the
+        // parked APK from disk, so the prompt is doubly warranted.
+        state.appPendingDiscard?.let { app ->
+            AlertDialog(
+                onDismissRequest = { onAction(AppsAction.OnDismissDiscardPendingDialog) },
+                title = {
+                    Text(
+                        text = stringResource(Res.string.confirm_discard_pending_title),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                text = {
+                    Text(
+                        text = stringResource(
+                            Res.string.confirm_discard_pending_message,
+                            app.appName,
+                        ),
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = { onAction(AppsAction.OnConfirmDiscardPendingInstall(app)) },
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.discard_pending_install),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = { onAction(AppsAction.OnDismissDiscardPendingDialog) },
                     ) {
                         Text(text = stringResource(Res.string.cancel))
                     }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
@@ -82,6 +82,8 @@ data class AppsState(
     val isImporting: Boolean = false,
     // Uninstall confirmation
     val appPendingUninstall: InstalledAppUi? = null,
+    // Discard-pending-install confirmation
+    val appPendingDiscard: InstalledAppUi? = null,
     // External import banner (E1)
     val pendingExternalImportCount: Int = 0,
     val showImportProposalBanner: Boolean = false,

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -1473,8 +1473,21 @@ class AppsViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (t: Throwable) {
+                // Mirror uninstallApp's UX: a row-delete failure leaves
+                // the apps list pointing at metadata for an APK that's
+                // already been removed from disk, so the user has to
+                // know it didn't take. Log the cause and surface a
+                // localized error event for the snackbar host.
                 logger.error(
                     "discardPendingInstall: row delete failed for ${app.packageName}: ${t.message}",
+                )
+                _events.send(
+                    AppsEvent.ShowError(
+                        getString(
+                            Res.string.failed_to_discard_pending,
+                            app.appName,
+                        ),
+                    ),
                 )
             }
         }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -274,7 +274,16 @@ class AppsViewModel(
             }
 
             is AppsAction.OnDiscardPendingInstall -> {
+                _state.update { it.copy(appPendingDiscard = action.app) }
+            }
+
+            is AppsAction.OnConfirmDiscardPendingInstall -> {
+                _state.update { it.copy(appPendingDiscard = null) }
                 discardPendingInstall(action.app)
+            }
+
+            AppsAction.OnDismissDiscardPendingDialog -> {
+                _state.update { it.copy(appPendingDiscard = null) }
             }
 
             is AppsAction.OnCancelUpdate -> {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -273,6 +273,10 @@ class AppsViewModel(
                 installPendingApp(action.app)
             }
 
+            is AppsAction.OnDiscardPendingInstall -> {
+                discardPendingInstall(action.app)
+            }
+
             is AppsAction.OnCancelUpdate -> {
                 cancelUpdate(action.packageName)
             }
@@ -1421,6 +1425,47 @@ class AppsViewModel(
                 updateAppState(
                     app.packageName,
                     UpdateState.Error(t.message ?: "Install failed"),
+                )
+            }
+        }
+    }
+
+    /**
+     * User decided to drop a pending install — they cancelled the
+     * system installer prompt and don't want this app anymore. Cancels
+     * the orchestrator entry (this also nukes the parked APK file via
+     * the downloader's cancel path), removes the DB row, and clears
+     * any leftover pending notification.
+     */
+    private fun discardPendingInstall(app: InstalledAppUi) {
+        viewModelScope.launch {
+            try {
+                downloadOrchestrator.cancel(app.packageName)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                logger.warn("discardPendingInstall: orchestrator cancel failed: ${t.message}")
+            }
+            // Belt-and-braces: cancel doesn't nuke the file when the
+            // entry was already in AwaitingInstall — the orchestrator
+            // already cleared its in-memory metadata before the user
+            // tapped Discard. Delete the parked file directly so the
+            // bytes don't leak.
+            app.pendingInstallFilePath?.let { path ->
+                runCatching { File(path).takeIf { it.exists() }?.delete() }
+                    .onFailure {
+                        logger.warn(
+                            "discardPendingInstall: failed to delete parked file: ${it.message}",
+                        )
+                    }
+            }
+            try {
+                installedAppsRepository.deleteInstalledApp(app.packageName)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                logger.error(
+                    "discardPendingInstall: row delete failed for ${app.packageName}: ${t.message}",
                 )
             }
         }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/CompactAppRow.kt
@@ -64,6 +64,7 @@ import zed.rainxch.githubstore.core.presentation.res.install
 import zed.rainxch.githubstore.core.presentation.res.open
 import zed.rainxch.githubstore.core.presentation.res.pre_release_badge
 import zed.rainxch.githubstore.core.presentation.res.uninstall
+import zed.rainxch.githubstore.core.presentation.res.discard_pending_install
 import zed.rainxch.githubstore.core.presentation.res.variant_picker_open
 import kotlin.time.ExperimentalTime
 
@@ -83,6 +84,7 @@ fun CompactAppRow(
     appItem: AppItem,
     onOpenClick: () -> Unit,
     onInstallPendingClick: () -> Unit,
+    onDiscardPendingClick: () -> Unit,
     onAdvancedSettingsClick: () -> Unit,
     onPickVariantClick: () -> Unit,
     onUninstallClick: () -> Unit,
@@ -120,6 +122,7 @@ fun CompactAppRow(
                 Modifier
                     .size(48.dp)
                     .clip(RoundedCornerShape(14.dp)),
+            apkFilePath = app.pendingInstallFilePath,
         )
 
         Column(modifier = Modifier.weight(1f)) {
@@ -172,6 +175,11 @@ fun CompactAppRow(
                 )
             }
             Spacer(Modifier.width(4.dp))
+        } else if (app.isPendingInstall) {
+            // Pending row whose file isn't (or is no longer) on disk.
+            // The app isn't installed; suppress the Open shortcut so we
+            // don't dead-end on a launch failure. Discard is reachable
+            // from the overflow.
         } else if (!isBusy) {
             // Subtle Open shortcut keeps the most-frequent action one tap
             // away even though the row itself opens the repo on tap.
@@ -191,12 +199,14 @@ fun CompactAppRow(
         CompactRowOverflow(
             appName = app.appName,
             isBusy = isBusy,
+            isPending = app.isPendingInstall,
             isUpdateAvailable = app.isUpdateAvailable,
             isPreReleaseEnabled = app.includePreReleases,
             onAdvancedSettingsClick = onAdvancedSettingsClick,
             onPickVariantClick = onPickVariantClick,
             onUninstallClick = onUninstallClick,
             onTogglePreReleases = onTogglePreReleases,
+            onDiscardPendingClick = onDiscardPendingClick,
         )
     }
 }
@@ -205,12 +215,14 @@ fun CompactAppRow(
 private fun CompactRowOverflow(
     appName: String,
     isBusy: Boolean,
+    isPending: Boolean,
     isUpdateAvailable: Boolean,
     isPreReleaseEnabled: Boolean,
     onAdvancedSettingsClick: () -> Unit,
     onPickVariantClick: () -> Unit,
     onUninstallClick: () -> Unit,
     onTogglePreReleases: (Boolean) -> Unit,
+    onDiscardPendingClick: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val moreActionsLabel = stringResource(Res.string.apps_compact_more_actions, appName)
@@ -261,25 +273,47 @@ private fun CompactRowOverflow(
                     onTogglePreReleases(!isPreReleaseEnabled)
                 },
             )
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        text = stringResource(Res.string.uninstall),
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Outlined.DeleteOutline,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                },
-                onClick = {
-                    expanded = false
-                    onUninstallClick()
-                },
-            )
+            if (isPending) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(Res.string.discard_pending_install),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.DeleteOutline,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onDiscardPendingClick()
+                    },
+                )
+            } else {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(Res.string.uninstall),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.DeleteOutline,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onUninstallClick()
+                    },
+                )
+            }
         }
     }
     // Suppress unused-parameter warning; isUpdateAvailable reserved for

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.kt
@@ -3,9 +3,22 @@ package zed.rainxch.apps.presentation.components
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
+/**
+ * Renders the icon for a tracked app.
+ *
+ * Resolution order on Android:
+ *  1. The icon registered with the system PackageManager for [packageName].
+ *  2. The icon embedded inside the parked APK at [apkFilePath] (used for
+ *     pending-install rows whose package isn't on the system yet).
+ *  3. A generic fallback drawable.
+ *
+ * On JVM (desktop) the fallback is always used — there's no
+ * platform-resident icon registry to consult.
+ */
 @Composable
 expect fun InstalledAppIcon(
     packageName: String,
     appName: String,
     modifier: Modifier = Modifier,
+    apkFilePath: String? = null,
 )

--- a/feature/apps/presentation/src/jvmMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.jvm.kt
+++ b/feature/apps/presentation/src/jvmMain/kotlin/zed/rainxch/apps/presentation/components/InstalledAppIcon.jvm.kt
@@ -12,6 +12,7 @@ actual fun InstalledAppIcon(
     packageName: String,
     appName: String,
     modifier: Modifier,
+    apkFilePath: String?,
 ) {
     Image(
         painter = painterResource(Res.drawable.app_icon),

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/system/InstallationManagerImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/system/InstallationManagerImpl.kt
@@ -130,6 +130,11 @@ class InstallationManagerImpl(
                     pickedAssetIndex = pickedIndex,
                     pickedAssetSiblingCount = siblingCount,
                     includePreReleases = defaultIncludePreReleases,
+                    pendingInstallFilePath = params.pendingInstallFilePath,
+                    pendingInstallVersion =
+                        params.releaseTag.takeIf { params.pendingInstallFilePath != null },
+                    pendingInstallAssetName =
+                        params.assetName.takeIf { params.pendingInstallFilePath != null },
                 )
 
             installedAppsRepository.saveInstalledApp(installedApp)

--- a/feature/details/domain/src/commonMain/kotlin/zed/rainxch/details/domain/model/SaveInstalledAppParams.kt
+++ b/feature/details/domain/src/commonMain/kotlin/zed/rainxch/details/domain/model/SaveInstalledAppParams.kt
@@ -14,4 +14,11 @@ data class SaveInstalledAppParams(
     val isFavourite: Boolean,
     val siblingAssetCount: Int,
     val pickedAssetIndex: Int?,
+    // Path to the parked APK on disk when this row is being saved as a
+    // pending install (e.g. system installer was launched but the user
+    // hasn't accepted yet). The apps row uses this to drive its one-tap
+    // Install retry button and to extract a real app icon while the
+    // package isn't yet on the system. `null` for genuine completed
+    // installs and for non-pending saves.
+    val pendingInstallFilePath: String? = null,
 )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
@@ -131,4 +131,23 @@ sealed interface DetailsAction {
      * initiates the install flow on it (GitHub-Store release UX #3).
      */
     data object SwitchToStable : DetailsAction
+
+    /**
+     * Opens the APK Inspect bottom sheet. The ViewModel resolves the
+     * APK source automatically — installed package wins over parked
+     * file when both exist (installed manifest is the authoritative
+     * source on what's actually on the device).
+     */
+    data object OnInspectApk : DetailsAction
+
+    /** Closes the APK Inspect bottom sheet. */
+    data object OnDismissApkInspect : DetailsAction
+
+    /**
+     * Acknowledges the inspect-button discoverability coachmark — fired
+     * either when the coachmark is tapped/dismissed or when the user
+     * opens the inspect sheet for the first time. Persists so the
+     * coachmark only ever shows once.
+     */
+    data object OnAcknowledgeApkInspectCoachmark : DetailsAction
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -369,6 +369,14 @@ fun DetailsRoot(
             },
         )
     }
+
+    if (state.isApkInspectSheetVisible) {
+        zed.rainxch.details.presentation.components.ApkInspectSheet(
+            inspection = state.apkInspection,
+            isLoading = state.isApkInspectLoading,
+            onDismiss = { viewModel.onAction(DetailsAction.OnDismissApkInspect) },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -72,6 +72,7 @@ import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.core.presentation.utils.arrowKeyScroll
 import zed.rainxch.core.presentation.utils.isLiquidFrostAvailable
+import zed.rainxch.details.presentation.components.ApkInspectSheet
 import zed.rainxch.details.presentation.components.LanguagePicker
 import zed.rainxch.details.presentation.components.sections.about
 import zed.rainxch.details.presentation.components.sections.author
@@ -371,7 +372,7 @@ fun DetailsRoot(
     }
 
     if (state.isApkInspectSheetVisible) {
-        zed.rainxch.details.presentation.components.ApkInspectSheet(
+        ApkInspectSheet(
             inspection = state.apkInspection,
             isLoading = state.isApkInspectLoading,
             onDismiss = { viewModel.onAction(DetailsAction.OnDismissApkInspect) },

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.details.presentation
 
+import zed.rainxch.core.domain.model.ApkInspection
 import zed.rainxch.core.domain.model.GithubAsset
 import zed.rainxch.core.domain.model.GithubRelease
 import zed.rainxch.core.domain.model.GithubRepoSummary
@@ -113,6 +114,18 @@ data class DetailsState(
      * silently no-op for releases that ship only source tarballs.
      */
     val latestStableHasInstallableAsset: Boolean = false,
+    /** APK inspection result currently driving the inspect bottom sheet. */
+    val apkInspection: ApkInspection? = null,
+    /** Whether the inspect bottom sheet is on screen. */
+    val isApkInspectSheetVisible: Boolean = false,
+    /** Loading state for the inspect sheet — set while the inspector runs. */
+    val isApkInspectLoading: Boolean = false,
+    /**
+     * One-shot flag from DataStore — `false` until the user has seen
+     * the discoverability coachmark for the inspect button. Drives the
+     * pulse + tooltip animation in the install button row.
+     */
+    val isApkInspectCoachmarkPending: Boolean = false,
 ) {
     val filteredReleases: List<GithubRelease>
         get() =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -27,6 +27,7 @@ import zed.rainxch.core.domain.model.FavoriteRepo
 import zed.rainxch.core.domain.model.GithubAsset
 import zed.rainxch.core.domain.model.GithubRelease
 import zed.rainxch.core.domain.model.InstalledApp
+import zed.rainxch.core.domain.model.isReallyInstalled
 import zed.rainxch.core.domain.model.Platform
 import zed.rainxch.core.domain.model.RateLimitException
 import zed.rainxch.core.domain.model.isEffectivelyPreRelease
@@ -792,11 +793,32 @@ class DetailsViewModel(
         }
     }
 
+    /**
+     * One-shot eligibility check for the APK Inspect coachmark. The
+     * coachmark may *only* fire if the user opened this Details screen
+     * with the app already genuinely installed — never as a side effect
+     * of an install completing during the current session. Otherwise
+     * the pulse would render at the exact moment the system install
+     * prompt is up, which is the user's peak-attention frame.
+     */
     private fun observeApkInspectCoachmark() {
         viewModelScope.launch {
-            tweaksRepository.getApkInspectCoachmarkShown().collect { shown ->
-                _state.update { it.copy(isApkInspectCoachmarkPending = !shown) }
-            }
+            val alreadyShown =
+                runCatching { tweaksRepository.getApkInspectCoachmarkShown().first() }
+                    .getOrDefault(true)
+            if (alreadyShown) return@launch
+            // Wait for `loadInitial` to settle. The first non-loading
+            // emission carries the authoritative `installedApp` for the
+            // app the user is viewing. If it's null (or pending) at
+            // that frame, this screen instance is not eligible — we
+            // never enable the coachmark for the rest of the session,
+            // even if an install completes here. The user will see it
+            // on their next visit instead.
+            val firstStable = _state.first { !it.isLoading }
+            val installedAtOpen =
+                firstStable.installedApp?.isReallyInstalled() == true
+            if (!installedAtOpen) return@launch
+            _state.update { it.copy(isApkInspectCoachmarkPending = true) }
         }
     }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -38,6 +38,7 @@ import zed.rainxch.core.domain.repository.SeenReposRepository
 import zed.rainxch.core.domain.repository.StarredRepository
 import zed.rainxch.core.domain.repository.TelemetryRepository
 import zed.rainxch.core.domain.repository.TweaksRepository
+import zed.rainxch.core.domain.system.ApkInspector
 import zed.rainxch.core.domain.system.DownloadOrchestrator
 import zed.rainxch.core.domain.system.DownloadSpec
 import zed.rainxch.core.domain.system.DownloadStage as OrchestratorStage
@@ -118,6 +119,7 @@ class DetailsViewModel(
     private val downloadOrchestrator: DownloadOrchestrator,
     private val telemetryRepository: TelemetryRepository,
     private val externalImportRepository: ExternalImportRepository,
+    private val apkInspector: ApkInspector,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentDownloadJob: Job? = null
@@ -132,6 +134,7 @@ class DetailsViewModel(
                 if (!hasLoadedInitialData) {
                     loadInitial()
                     observeLiquidGlassEnabled()
+                    observeApkInspectCoachmark()
 
                     hasLoadedInitialData = true
                 }
@@ -453,6 +456,80 @@ class DetailsViewModel(
             DetailsAction.SwitchToStable -> {
                 switchToStable()
             }
+
+            DetailsAction.OnInspectApk -> {
+                openApkInspectSheet()
+            }
+
+            DetailsAction.OnDismissApkInspect -> {
+                _state.update {
+                    it.copy(isApkInspectSheetVisible = false)
+                }
+            }
+
+            DetailsAction.OnAcknowledgeApkInspectCoachmark -> {
+                acknowledgeApkInspectCoachmark()
+            }
+        }
+    }
+
+    /**
+     * Resolves the right APK source and runs [ApkInspector]. Installed
+     * package wins over a parked file when both exist — a successful
+     * install means the manifest on the system is the authoritative
+     * description of what's actually running, even if the bytes that
+     * produced it are still parked. Falls back to the parked file path
+     * for pre-install inspections.
+     */
+    private fun openApkInspectSheet() {
+        val installed = _state.value.installedApp
+        val parkedPath = installed?.pendingInstallFilePath
+        val packageName = installed?.packageName
+        if (installed == null && parkedPath == null) {
+            logger.warn("openApkInspectSheet: nothing inspectable in current state")
+            return
+        }
+        _state.update {
+            it.copy(
+                isApkInspectSheetVisible = true,
+                isApkInspectLoading = true,
+                apkInspection = null,
+            )
+        }
+        viewModelScope.launch {
+            val inspection =
+                if (packageName != null && installed?.isPendingInstall == false) {
+                    apkInspector.inspectInstalled(packageName)
+                        ?: parkedPath?.let { apkInspector.inspectFile(it) }
+                } else if (parkedPath != null) {
+                    apkInspector.inspectFile(parkedPath)
+                        ?: packageName?.let { apkInspector.inspectInstalled(it) }
+                } else if (packageName != null) {
+                    apkInspector.inspectInstalled(packageName)
+                } else {
+                    null
+                }
+            _state.update {
+                it.copy(
+                    isApkInspectLoading = false,
+                    apkInspection = inspection,
+                )
+            }
+            // Opening the sheet implicitly satisfies the discoverability
+            // coachmark — no need to keep nudging the user about a
+            // feature they've now used.
+            acknowledgeApkInspectCoachmark()
+        }
+    }
+
+    private fun acknowledgeApkInspectCoachmark() {
+        if (!_state.value.isApkInspectCoachmarkPending) return
+        _state.update { it.copy(isApkInspectCoachmarkPending = false) }
+        viewModelScope.launch {
+            runCatching { tweaksRepository.setApkInspectCoachmarkShown(true) }
+                .onFailure { t ->
+                    logger.warn("Failed to persist APK inspect coachmark flag: ${t.message}")
+                }
         }
     }
 
@@ -712,6 +789,14 @@ class DetailsViewModel(
 
     private fun observeLiquidGlassEnabled() {
         viewModelScope.launch {
+        }
+    }
+
+    private fun observeApkInspectCoachmark() {
+        viewModelScope.launch {
+            tweaksRepository.getApkInspectCoachmarkShown().collect { shown ->
+                _state.update { it.copy(isApkInspectCoachmarkPending = !shown) }
+            }
         }
     }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -1788,6 +1788,7 @@ class DetailsViewModel(
                                         releaseTag = releaseTag,
                                         isUpdate = isUpdate,
                                         installOutcome = InstallOutcome.COMPLETED,
+                                        parkedFilePath = filePath,
                                     )
                                 } else {
                                     logger.warn(
@@ -1952,6 +1953,7 @@ class DetailsViewModel(
                 releaseTag = releaseTag,
                 isUpdate = isUpdate,
                 installOutcome = installOutcome,
+                parkedFilePath = filePath,
             )
         } else if (platform != Platform.ANDROID) {
             viewModelScope.launch {
@@ -2003,8 +2005,13 @@ class DetailsViewModel(
         releaseTag: String,
         isUpdate: Boolean,
         installOutcome: InstallOutcome,
+        parkedFilePath: String? = null,
     ) {
         val repo = _state.value.repository ?: return
+        val isPending = installOutcome != InstallOutcome.COMPLETED
+        // Only carry the parked path through when the row is actually
+        // pending — a completed install must not store a stale pointer.
+        val pendingPath = parkedFilePath?.takeIf { isPending }
 
         if (isUpdate) {
             installationManager.updateInstalledAppVersion(
@@ -2013,9 +2020,24 @@ class DetailsViewModel(
                     assetName = assetName,
                     assetUrl = assetUrl,
                     releaseTag = releaseTag,
-                    isPendingInstall = installOutcome != InstallOutcome.COMPLETED,
+                    isPendingInstall = isPending,
                 ),
             )
+            // For pending updates, also park the file path on the row
+            // so the apps list can resume the install in one tap if
+            // the user dismissed the system prompt.
+            if (pendingPath != null) {
+                runCatching {
+                    installedAppsRepository.setPendingInstallFilePath(
+                        packageName = apkInfo.packageName,
+                        path = pendingPath,
+                        version = releaseTag,
+                        assetName = assetName,
+                    )
+                }.onFailure { t ->
+                    logger.warn("Failed to park pending install path on update: ${t.message}")
+                }
+            }
         } else {
             // Snapshot the installable list as the user saw it at install
             // time — this is the reference the variant fingerprint is
@@ -2034,10 +2056,11 @@ class DetailsViewModel(
                         assetUrl = assetUrl,
                         assetSize = assetSize,
                         releaseTag = releaseTag,
-                        isPendingInstall = installOutcome != InstallOutcome.COMPLETED,
+                        isPendingInstall = isPending,
                         isFavourite = _state.value.isFavourite,
                         siblingAssetCount = installable.size,
                         pickedAssetIndex = pickedIndex,
+                        pendingInstallFilePath = pendingPath,
                     ),
                 )
             _state.value = _state.value.copy(installedApp = reloaded)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
@@ -1,25 +1,25 @@
 package zed.rainxch.details.presentation.components
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apartment
 import androidx.compose.material.icons.filled.Apps
-import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.PrivacyTip
@@ -33,9 +33,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -54,6 +62,9 @@ import zed.rainxch.githubstore.core.presentation.res.apk_inspect_identity
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_min_sdk
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_permissions
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_permissions_empty
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_permissions_title
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_collapsed
+import zed.rainxch.githubstore.core.presentation.res.apps_section_state_expanded
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_dangerous
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_normal
 import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_privileged
@@ -234,13 +245,45 @@ private fun CompatibilitySection(inspection: ApkInspection) {
 
 @Composable
 private fun PermissionsSection(permissions: List<ApkPermission>) {
-    InspectSection(
-        title = stringResource(
-            Res.string.apk_inspect_permissions,
-            permissions.size,
-        ),
-        icon = Icons.Default.PrivacyTip,
-    ) {
+    val grouped = permissions.groupBy { it.protectionLevel }
+    val orderedLevels =
+        listOf(
+            ProtectionLevel.DANGEROUS,
+            ProtectionLevel.PRIVILEGED,
+            ProtectionLevel.SIGNATURE,
+            ProtectionLevel.NORMAL,
+            ProtectionLevel.UNKNOWN,
+        )
+
+    val dangerousWord = stringResource(Res.string.apk_inspect_protection_dangerous).lowercase()
+    val privilegedWord = stringResource(Res.string.apk_inspect_protection_privileged).lowercase()
+    val signatureWord = stringResource(Res.string.apk_inspect_protection_signature).lowercase()
+    val normalWord = stringResource(Res.string.apk_inspect_protection_normal).lowercase()
+    val unknownWord = stringResource(Res.string.apk_inspect_protection_unknown).lowercase()
+    val baseTitle = stringResource(Res.string.apk_inspect_permissions_title)
+
+    val title =
+        if (permissions.isEmpty()) {
+            stringResource(Res.string.apk_inspect_permissions, 0)
+        } else {
+            val parts =
+                orderedLevels.mapNotNull { level ->
+                    val count = grouped[level]?.size ?: 0
+                    if (count == 0) return@mapNotNull null
+                    val word =
+                        when (level) {
+                            ProtectionLevel.DANGEROUS -> dangerousWord
+                            ProtectionLevel.PRIVILEGED -> privilegedWord
+                            ProtectionLevel.SIGNATURE -> signatureWord
+                            ProtectionLevel.NORMAL -> normalWord
+                            ProtectionLevel.UNKNOWN -> unknownWord
+                        }
+                    "$count $word"
+                }
+            "$baseTitle  ·  ${parts.joinToString("  ·  ")}"
+        }
+
+    InspectSection(title = title, icon = Icons.Default.PrivacyTip) {
         if (permissions.isEmpty()) {
             Text(
                 text = stringResource(Res.string.apk_inspect_permissions_empty),
@@ -249,14 +292,111 @@ private fun PermissionsSection(permissions: List<ApkPermission>) {
             )
             return@InspectSection
         }
-        // Sort by danger first so users see the spicy stuff up top.
-        val sorted =
-            permissions.sortedWith(
-                compareByDescending<ApkPermission> { it.protectionLevel.severity() }
-                    .thenBy { it.displayName },
+
+        // Per-group expand/collapse state lives in the sheet itself —
+        // not worth a VM round-trip. NORMAL / UNKNOWN buckets start
+        // collapsed because they're the long, low-signal lists; the
+        // spicy DANGEROUS / PRIVILEGED / SIGNATURE groups are open.
+        val expanded =
+            remember {
+                mutableStateMapOf<ProtectionLevel, Boolean>().apply {
+                    orderedLevels.forEach { put(it, defaultExpanded(it)) }
+                }
+            }
+
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            orderedLevels.forEach { level ->
+                val rows = grouped[level].orEmpty()
+                if (rows.isEmpty()) return@forEach
+                val isExpanded = expanded[level] ?: defaultExpanded(level)
+                val collapsible = isCollapsibleByDefault(level)
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    PermissionGroupHeader(
+                        level = level,
+                        count = rows.size,
+                        expanded = isExpanded,
+                        collapsible = collapsible,
+                        onToggle = { expanded[level] = !isExpanded },
+                    )
+                    if (isExpanded) {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            rows
+                                .sortedBy { it.displayName }
+                                .forEach { perm -> PermissionRow(perm) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PermissionGroupHeader(
+    level: ProtectionLevel,
+    count: Int,
+    expanded: Boolean,
+    collapsible: Boolean,
+    onToggle: () -> Unit,
+) {
+    val (color, label) = protectionStyle(level)
+    val expandedDesc = stringResource(Res.string.apps_section_state_expanded)
+    val collapsedDesc = stringResource(Res.string.apps_section_state_collapsed)
+
+    val baseModifier =
+        Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 40.dp)
+
+    val gestureModifier =
+        if (collapsible) {
+            baseModifier
+                .clickable(onClick = onToggle)
+                .semantics(mergeDescendants = true) {
+                    role = Role.Button
+                    heading()
+                    contentDescription = "$label, $count"
+                    stateDescription = if (expanded) expandedDesc else collapsedDesc
+                }
+        } else {
+            baseModifier.semantics(mergeDescendants = true) {
+                heading()
+                contentDescription = "$label, $count"
+            }
+        }
+
+    Row(
+        modifier = gestureModifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        Surface(
+            shape = RoundedCornerShape(50),
+            color = color.copy(alpha = 0.16f),
+        ) {
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 1.dp),
             )
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            sorted.forEach { perm -> PermissionRow(perm) }
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        if (collapsible) {
+            Icon(
+                imageVector =
+                    if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -264,31 +404,22 @@ private fun PermissionsSection(permissions: List<ApkPermission>) {
 @Composable
 private fun PermissionRow(permission: ApkPermission) {
     val (chipColor, chipLabel) = protectionStyle(permission.protectionLevel)
+    val chipAlpha = if (permission.protectionLevel == ProtectionLevel.DANGEROUS) 0.22f else 0.16f
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Top,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .padding(top = 6.dp)
-                .size(8.dp)
-                .background(chipColor, CircleShape),
-        )
-        Column(modifier = Modifier.weight(1f)) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
             Text(
                 text = permission.displayName,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = permission.name,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontFamily = FontFamily.Monospace,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
             )
             permission.description?.let { desc ->
                 Text(
@@ -297,10 +428,21 @@ private fun PermissionRow(permission: ApkPermission) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            // Demoted to a footnote — small, lower-opacity, monospace.
+            // The technical name is useful for search and bug reports
+            // but it shouldn't compete with the human-readable label.
+            Text(
+                text = permission.name,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f),
+                fontFamily = FontFamily.Monospace,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
         Surface(
             shape = RoundedCornerShape(50),
-            color = chipColor.copy(alpha = 0.18f),
+            color = chipColor.copy(alpha = chipAlpha),
         ) {
             Text(
                 text = chipLabel,
@@ -312,6 +454,20 @@ private fun PermissionRow(permission: ApkPermission) {
         }
     }
 }
+
+private fun defaultExpanded(level: ProtectionLevel): Boolean =
+    when (level) {
+        ProtectionLevel.DANGEROUS,
+        ProtectionLevel.PRIVILEGED,
+        ProtectionLevel.SIGNATURE,
+        -> true
+        ProtectionLevel.NORMAL,
+        ProtectionLevel.UNKNOWN,
+        -> false
+    }
+
+private fun isCollapsibleByDefault(level: ProtectionLevel): Boolean =
+    level == ProtectionLevel.NORMAL || level == ProtectionLevel.UNKNOWN
 
 @Composable
 private fun ComponentsSection(inspection: ApkInspection) {
@@ -455,14 +611,6 @@ private fun protectionStyle(level: ProtectionLevel): Pair<Color, String> {
         ProtectionLevel.NORMAL -> neutral to stringResource(Res.string.apk_inspect_protection_normal)
         ProtectionLevel.UNKNOWN -> muted to stringResource(Res.string.apk_inspect_protection_unknown)
     }
-}
-
-private fun ProtectionLevel.severity(): Int = when (this) {
-    ProtectionLevel.DANGEROUS -> 4
-    ProtectionLevel.PRIVILEGED -> 3
-    ProtectionLevel.SIGNATURE -> 2
-    ProtectionLevel.NORMAL -> 1
-    ProtectionLevel.UNKNOWN -> 0
 }
 
 private fun formatBytes(bytes: Long): String =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
@@ -297,8 +297,15 @@ private fun PermissionsSection(permissions: List<ApkPermission>) {
         // not worth a VM round-trip. NORMAL / UNKNOWN buckets start
         // collapsed because they're the long, low-signal lists; the
         // spicy DANGEROUS / PRIVILEGED / SIGNATURE groups are open.
+        //
+        // Keyed on the permissions reference so opening the sheet for a
+        // different APK rebuilds the map with that APK's defaults
+        // (otherwise a previous app's "expanded NORMAL" choice would
+        // leak forward — fine right now because the sheet is
+        // recreated per visibility toggle, but cheap insurance against
+        // a future change that keeps the sheet alive across inspections).
         val expanded =
-            remember {
+            remember(permissions) {
                 mutableStateMapOf<ProtectionLevel, Boolean>().apply {
                     orderedLevels.forEach { put(it, defaultExpanded(it)) }
                 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ApkInspectSheet.kt
@@ -1,0 +1,474 @@
+package zed.rainxch.details.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apartment
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.PrivacyTip
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.model.ApkInspection
+import zed.rainxch.core.domain.model.ApkPermission
+import zed.rainxch.core.domain.model.ProtectionLevel
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_compatibility
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_components
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_debuggable
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_empty
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_file_info
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_identity
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_min_sdk
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_permissions
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_permissions_empty
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_dangerous
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_normal
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_privileged
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_signature
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_protection_unknown
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_section_activities
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_section_main_activity
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_section_receivers
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_section_services
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_signing
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_size
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_source_file
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_source_installed
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_target_sdk
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_title
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_version_code
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApkInspectSheet(
+    inspection: ApkInspection?,
+    isLoading: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        when {
+            isLoading -> LoadingState()
+            inspection != null -> InspectionContent(inspection)
+            else -> EmptyState()
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(48.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(Res.string.apk_inspect_empty),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun InspectionContent(inspection: ApkInspection) {
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item { Header(inspection) }
+        item { IdentitySection(inspection) }
+        item { CompatibilitySection(inspection) }
+        item { PermissionsSection(inspection.permissions) }
+        item { ComponentsSection(inspection) }
+        item { FileSection(inspection) }
+        item { Spacer(Modifier.height(24.dp)) }
+    }
+}
+
+@Composable
+private fun Header(inspection: ApkInspection) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = stringResource(Res.string.apk_inspect_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = inspection.appLabel,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = inspection.packageName,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontFamily = FontFamily.Monospace,
+        )
+        val sourceLabel = when (inspection.source) {
+            ApkInspection.Source.FILE -> stringResource(Res.string.apk_inspect_source_file)
+            ApkInspection.Source.INSTALLED -> stringResource(Res.string.apk_inspect_source_installed)
+        }
+        SourceChip(label = sourceLabel)
+    }
+}
+
+@Composable
+private fun SourceChip(label: String) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier.padding(top = 4.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun IdentitySection(inspection: ApkInspection) {
+    InspectSection(
+        title = stringResource(Res.string.apk_inspect_identity),
+        icon = Icons.Default.Fingerprint,
+    ) {
+        InspectRow(
+            label = stringResource(Res.string.apk_inspect_version_code),
+            value = inspection.versionName?.let { name ->
+                inspection.versionCode?.let { code -> "$name  ($code)" } ?: name
+            } ?: inspection.versionCode?.toString() ?: "—",
+        )
+        inspection.signingFingerprint?.let { fingerprint ->
+            InspectRow(
+                label = stringResource(Res.string.apk_inspect_signing),
+                value = fingerprint,
+                monospace = true,
+            )
+        }
+        if (inspection.debuggable) {
+            DangerNote(text = stringResource(Res.string.apk_inspect_debuggable))
+        }
+    }
+}
+
+@Composable
+private fun CompatibilitySection(inspection: ApkInspection) {
+    InspectSection(
+        title = stringResource(Res.string.apk_inspect_compatibility),
+        icon = Icons.Default.Tune,
+    ) {
+        if (inspection.minSdk != null) {
+            InspectRow(
+                label = stringResource(Res.string.apk_inspect_min_sdk),
+                value = "API ${inspection.minSdk}",
+            )
+        }
+        if (inspection.targetSdk != null) {
+            InspectRow(
+                label = stringResource(Res.string.apk_inspect_target_sdk),
+                value = "API ${inspection.targetSdk}",
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionsSection(permissions: List<ApkPermission>) {
+    InspectSection(
+        title = stringResource(
+            Res.string.apk_inspect_permissions,
+            permissions.size,
+        ),
+        icon = Icons.Default.PrivacyTip,
+    ) {
+        if (permissions.isEmpty()) {
+            Text(
+                text = stringResource(Res.string.apk_inspect_permissions_empty),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return@InspectSection
+        }
+        // Sort by danger first so users see the spicy stuff up top.
+        val sorted =
+            permissions.sortedWith(
+                compareByDescending<ApkPermission> { it.protectionLevel.severity() }
+                    .thenBy { it.displayName },
+            )
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            sorted.forEach { perm -> PermissionRow(perm) }
+        }
+    }
+}
+
+@Composable
+private fun PermissionRow(permission: ApkPermission) {
+    val (chipColor, chipLabel) = protectionStyle(permission.protectionLevel)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = 6.dp)
+                .size(8.dp)
+                .background(chipColor, CircleShape),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = permission.displayName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = permission.name,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontFamily = FontFamily.Monospace,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            permission.description?.let { desc ->
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Surface(
+            shape = RoundedCornerShape(50),
+            color = chipColor.copy(alpha = 0.18f),
+        ) {
+            Text(
+                text = chipLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = chipColor,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ComponentsSection(inspection: ApkInspection) {
+    InspectSection(
+        title = stringResource(Res.string.apk_inspect_components),
+        icon = Icons.Default.Apps,
+    ) {
+        InspectRow(
+            label = stringResource(Res.string.apk_inspect_section_activities),
+            value = inspection.activityCount.toString(),
+        )
+        InspectRow(
+            label = stringResource(Res.string.apk_inspect_section_services),
+            value = inspection.serviceCount.toString(),
+        )
+        InspectRow(
+            label = stringResource(Res.string.apk_inspect_section_receivers),
+            value = inspection.receiverCount.toString(),
+        )
+        inspection.mainActivity?.let { entry ->
+            InspectRow(
+                label = stringResource(Res.string.apk_inspect_section_main_activity),
+                value = entry,
+                monospace = true,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FileSection(inspection: ApkInspection) {
+    InspectSection(
+        title = stringResource(Res.string.apk_inspect_file_info),
+        icon = Icons.Default.Folder,
+    ) {
+        inspection.fileSizeBytes?.let { size ->
+            InspectRow(
+                label = stringResource(Res.string.apk_inspect_size),
+                value = formatBytes(size),
+            )
+        }
+        inspection.filePath?.let { path ->
+            InspectRow(
+                label = "",
+                value = path,
+                monospace = true,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InspectSection(
+    title: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    content: @Composable () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        content()
+    }
+}
+
+@Composable
+private fun InspectRow(label: String, value: String, monospace: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (label.isNotEmpty()) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.width(120.dp),
+            )
+        }
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontFamily = if (monospace) FontFamily.Monospace else FontFamily.Default,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun DangerNote(text: String) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Apartment,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun protectionStyle(level: ProtectionLevel): Pair<Color, String> {
+    val red = MaterialTheme.colorScheme.error
+    val amber = Color(0xFFB87100)
+    val deepAmber = Color(0xFF8E4900)
+    val neutral = MaterialTheme.colorScheme.onSurfaceVariant
+    val muted = MaterialTheme.colorScheme.outline
+    return when (level) {
+        ProtectionLevel.DANGEROUS -> red to stringResource(Res.string.apk_inspect_protection_dangerous)
+        ProtectionLevel.PRIVILEGED -> deepAmber to stringResource(Res.string.apk_inspect_protection_privileged)
+        ProtectionLevel.SIGNATURE -> amber to stringResource(Res.string.apk_inspect_protection_signature)
+        ProtectionLevel.NORMAL -> neutral to stringResource(Res.string.apk_inspect_protection_normal)
+        ProtectionLevel.UNKNOWN -> muted to stringResource(Res.string.apk_inspect_protection_unknown)
+    }
+}
+
+private fun ProtectionLevel.severity(): Int = when (this) {
+    ProtectionLevel.DANGEROUS -> 4
+    ProtectionLevel.PRIVILEGED -> 3
+    ProtectionLevel.SIGNATURE -> 2
+    ProtectionLevel.NORMAL -> 1
+    ProtectionLevel.UNKNOWN -> 0
+}
+
+private fun formatBytes(bytes: Long): String =
+    when {
+        bytes >= 1_073_741_824 -> "%.1f GB".format(bytes / 1_073_741_824.0)
+        bytes >= 1_048_576 -> "%.1f MB".format(bytes / 1_048_576.0)
+        bytes >= 1_024 -> "%.1f KB".format(bytes / 1_024.0)
+        else -> "$bytes B"
+    }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/InspectApkButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/InspectApkButton.kt
@@ -1,0 +1,205 @@
+package zed.rainxch.details.presentation.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_button_label
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_coachmark_body
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_coachmark_dismiss
+import zed.rainxch.githubstore.core.presentation.res.apk_inspect_coachmark_title
+
+/**
+ * Discoverable entry point for the APK Inspect sheet.
+ *
+ * Renders a 52dp circular icon button next to the install button. When
+ * [showCoachmark] is true, the button does a slow pulse + tilt and a
+ * tooltip-style coachmark renders above the icon, anchored with an
+ * arrow. The coachmark is one-shot per user — tapping it (or the
+ * button) dismisses and persists via [onCoachmarkDismiss].
+ */
+@Composable
+fun InspectApkButton(
+    showCoachmark: Boolean,
+    onClick: () -> Unit,
+    onCoachmarkDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pulse by rememberPulse(active = showCoachmark)
+    val tilt by rememberTilt(active = showCoachmark)
+
+    Box(modifier = modifier) {
+        IconButton(
+            onClick = onClick,
+            modifier = Modifier
+                .size(52.dp)
+                .scale(pulse)
+                .graphicsLayer { rotationZ = tilt },
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            ),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = stringResource(Res.string.apk_inspect_button_label),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+
+        if (showCoachmark) {
+            Coachmark(onDismiss = onCoachmarkDismiss)
+        }
+    }
+}
+
+@Composable
+private fun rememberPulse(active: Boolean) =
+    rememberInfiniteTransition(label = "inspect-pulse")
+        .animateFloat(
+            initialValue = if (active) 1f else 1f,
+            targetValue = if (active) 1.08f else 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 900),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "inspect-pulse-scale",
+        )
+
+@Composable
+private fun rememberTilt(active: Boolean) =
+    rememberInfiniteTransition(label = "inspect-tilt")
+        .animateFloat(
+            initialValue = if (active) -6f else 0f,
+            targetValue = if (active) 6f else 0f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 1300),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "inspect-tilt-deg",
+        )
+
+@Composable
+private fun Coachmark(onDismiss: () -> Unit) {
+    Popup(
+        alignment = Alignment.TopEnd,
+        // Render above the button. Negative Y offset moves the popup up.
+        offset = androidx.compose.ui.unit.IntOffset(x = 0, y = -260),
+        properties = PopupProperties(
+            focusable = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+        onDismissRequest = onDismiss,
+    ) {
+        Column(horizontalAlignment = Alignment.End) {
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.primary,
+                shadowElevation = 6.dp,
+                modifier = Modifier.width(260.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            text = stringResource(Res.string.apk_inspect_coachmark_title),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                    Text(
+                        text = stringResource(Res.string.apk_inspect_coachmark_body),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
+                    )
+                    Row(
+                        modifier = Modifier.padding(top = 4.dp).fillMaxWidthOnly(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(onClick = onDismiss) {
+                            Text(
+                                text = stringResource(Res.string.apk_inspect_coachmark_dismiss),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                    }
+                }
+            }
+            // Triangle arrow pointing down at the icon button.
+            Box(
+                modifier = Modifier
+                    .padding(end = 24.dp)
+                    .size(width = 16.dp, height = 8.dp)
+                    .arrowDown(MaterialTheme.colorScheme.primary),
+            )
+        }
+    }
+}
+
+private fun Modifier.fillMaxWidthOnly(): Modifier = this.fillMaxWidth()
+
+private fun Modifier.arrowDown(color: androidx.compose.ui.graphics.Color): Modifier =
+    this.fillMaxSize().background(
+        color = color,
+        shape = TriangleDownShape,
+    )
+
+private val TriangleDownShape = androidx.compose.foundation.shape.GenericShape { size, _ ->
+    moveTo(0f, 0f)
+    lineTo(size.width, 0f)
+    lineTo(size.width / 2f, size.height)
+    close()
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -30,6 +30,8 @@ import zed.rainxch.details.presentation.components.AppHeader
 import zed.rainxch.details.presentation.components.ReleaseAssetsPicker
 import zed.rainxch.details.presentation.components.ReleasesStatus
 import zed.rainxch.details.presentation.components.ReleasesStatusCard
+import zed.rainxch.details.presentation.components.ApkInspectSheet
+import zed.rainxch.details.presentation.components.InspectApkButton
 import zed.rainxch.details.presentation.components.SmartInstallButton
 import zed.rainxch.details.presentation.components.VersionPicker
 import zed.rainxch.details.presentation.components.VersionTypePicker
@@ -136,18 +138,37 @@ fun LazyListScope.header(
         item {
             val liquidState = LocalTopbarLiquidState.current
 
+            val canInspectApk =
+                state.installedApp != null ||
+                    state.installedApp?.pendingInstallFilePath != null
             Box(
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                SmartInstallButton(
-                    isDownloading = state.isDownloading,
-                    isInstalling = state.isInstalling,
-                    isLiquidGlassEnabled = state.isLiquidGlassEnabled,
-                    progress = state.downloadProgressPercent,
-                    primaryAsset = state.primaryAsset,
-                    state = state,
-                    onAction = onAction,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    SmartInstallButton(
+                        isDownloading = state.isDownloading,
+                        isInstalling = state.isInstalling,
+                        isLiquidGlassEnabled = state.isLiquidGlassEnabled,
+                        progress = state.downloadProgressPercent,
+                        primaryAsset = state.primaryAsset,
+                        state = state,
+                        onAction = onAction,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (canInspectApk) {
+                        InspectApkButton(
+                            showCoachmark = state.isApkInspectCoachmarkPending,
+                            onClick = { onAction(DetailsAction.OnInspectApk) },
+                            onCoachmarkDismiss = {
+                                onAction(DetailsAction.OnAcknowledgeApkInspectCoachmark)
+                            },
+                        )
+                    }
+                }
 
             DropdownMenu(
                 expanded = state.isInstallDropdownExpanded,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -30,11 +30,13 @@ import zed.rainxch.details.presentation.components.AppHeader
 import zed.rainxch.details.presentation.components.ReleaseAssetsPicker
 import zed.rainxch.details.presentation.components.ReleasesStatus
 import zed.rainxch.details.presentation.components.ReleasesStatusCard
+import zed.rainxch.core.domain.model.isReallyInstalled
 import zed.rainxch.details.presentation.components.ApkInspectSheet
 import zed.rainxch.details.presentation.components.InspectApkButton
 import zed.rainxch.details.presentation.components.SmartInstallButton
 import zed.rainxch.details.presentation.components.VersionPicker
 import zed.rainxch.details.presentation.components.VersionTypePicker
+import zed.rainxch.details.presentation.model.DownloadStage
 import zed.rainxch.details.presentation.utils.LocalTopbarLiquidState
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.appmanager_description
@@ -138,9 +140,23 @@ fun LazyListScope.header(
         item {
             val liquidState = LocalTopbarLiquidState.current
 
-            val canInspectApk =
-                state.installedApp != null ||
-                    state.installedApp?.pendingInstallFilePath != null
+            // Inspect button only surfaces once the package is genuinely
+            // installed on device (`isReallyInstalled()` filters out
+            // pending-install rows whose `installedApp` is non-null but
+            // the system hasn't confirmed the install). This avoids
+            // popping the icon in at the exact frame the system install
+            // prompt appears, which is the user's peak-attention moment.
+            val canInspectApk = state.installedApp?.isReallyInstalled() == true
+            // Even when visible, the coachmark animation only fires
+            // during a calm moment — never while a download or install
+            // is mid-flight, never with the inspect sheet already open.
+            val coachmarkActive =
+                state.isApkInspectCoachmarkPending &&
+                    canInspectApk &&
+                    !state.isDownloading &&
+                    !state.isInstalling &&
+                    state.downloadStage == DownloadStage.IDLE &&
+                    !state.isApkInspectSheetVisible
             Box(
                 modifier = Modifier.fillMaxWidth(),
             ) {
@@ -161,7 +177,7 @@ fun LazyListScope.header(
                     )
                     if (canInspectApk) {
                         InspectApkButton(
-                            showCoachmark = state.isApkInspectCoachmarkPending,
+                            showCoachmark = coachmarkActive,
                             onClick = { onAction(DetailsAction.OnInspectApk) },
                             onCoachmarkDismiss = {
                                 onAction(DetailsAction.OnAcknowledgeApkInspectCoachmark)


### PR DESCRIPTION
Combines two related changes that share the apps-list / pending-install surface:

## A — Faithful pending row (commit 1)

When the user taps Install but cancels the system installer prompt, the row used to land in apps with a GitHub Store logo and a broken "Open" button (snackbar of failure). Now:

- `SaveInstalledAppParams` carries `pendingInstallFilePath`. `DetailsViewModel.saveInstalledAppToDatabase` plumbs the parked file path through whenever the install came back as `DELEGATED_TO_SYSTEM`, so the freshly-created DB row actually points at its parked APK.
- `InstalledAppIcon` (Android) gains an `apkFilePath` fallback. When the package isn't on the system yet it loads the icon out of the parked APK via `PackageManager.getPackageArchiveInfo` (`sourceDir` patched so `loadIcon()` returns the real icon, not the platform default). `AppItemCard` and `CompactAppRow` pass the parked path.
- Apps row CTA is now state-aware:
  - `pendingInstallFilePath != null` → primary "Install" button + a small Discard escape hatch.
  - `isPendingInstall && pendingInstallFilePath == null` (legacy/edge) → "Discard" replaces the broken Open.
  - Compact rows: overflow swaps "Uninstall" for "Discard" when pending.
- New `OnDiscardPendingInstall` action: cancels orchestrator entry, deletes parked APK file, removes DB row.

## B — APK Inspect feature (commit 2)

A "peek inside before installing" bottom sheet that works for both parked APKs and installed packages.

- `core/domain` adds `ApkInspector` + `ApkInspection` + `ApkPermission` + `ProtectionLevel` (NORMAL / DANGEROUS / SIGNATURE / PRIVILEGED / UNKNOWN).
- `core/data/androidMain` ships `AndroidApkInspector` reading from `PackageManager` with `GET_PERMISSIONS | GET_ACTIVITIES | GET_SERVICES | GET_RECEIVERS | GET_SIGNING_CERTIFICATES`. Signing fingerprint extraction lifted into a shared `SigningFingerprint` helper. JVM ships a stub that returns `null`.
- `ApkInspectSheet` (Material 3 `ModalBottomSheet`) renders identity, compatibility, permissions (color-coded by danger), components and file info. Dangerous permissions float to the top of the list.
- `DetailsViewModel` resolves the source automatically — installed manifest wins over a parked file when the row isn't pending; falls back the other way for pre-install inspections.
- New `InspectApkButton` next to `SmartInstallButton` on the details screen. The first time it appears for a user, it does a slow scale-pulse + tilt and pops a tooltip-style coachmark with arrow ("Peek inside before installing — permissions, signing, what apps can do"). Acknowledged on tap or when the inspect sheet opens, persisted via `TweaksRepository.apkInspectCoachmarkShown`.

## Test plan

- [ ] Tap Install, then cancel the system installer prompt: app appears in the apps list with its real icon (not GitHub Store logo). Row shows "Install" CTA + Discard. Discard removes the row and parked file.
- [ ] First time the inspect button appears next to Install on the Details screen, the pulse + coachmark fire. Tap "Got it" or open the sheet → coachmark never returns on subsequent screens.
- [ ] Inspect sheet on a parked APK: shows source = "Parked file", real icon, declared permissions sorted with red dangerous-bucket on top. Sheet renders even before install.
- [ ] Inspect sheet on an installed package: shows source = "Installed package", same data, plus runtime grant state on dangerous permissions.
- [ ] Permissions list on a debuggable APK (e.g. a dev build) shows the "Debuggable build" warning chip in identity.
- [ ] Apps list overflow on a pending row (no parked file) shows "Discard" instead of "Uninstall".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * APK Inspect UI: bottom sheet, Inspect button with coachmark, shows permissions, components, signing, SDK targets, size, source, and icon fallback from parked APKs.
  * Platform APK inspection implemented on Android (desktop is a noop).
  * Discard pending-install flow with confirmation dialog across app lists and item rows.

* **Bug Fixes**
  * Clear stale parked APK metadata and delete parked files after installs or during sync.

* **Documentation**
  * Localized strings for APK Inspect UI and discard dialog.

* **Settings**
  * One-shot APK Inspect coachmark persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->