### PR TITLE
fix: surface every candidate when the user manually rescans for GitHub apps

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ExternalImportRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ExternalImportRepositoryImpl.kt
@@ -76,11 +76,16 @@ class ExternalImportRepositoryImpl(
         }
     }
 
-    override suspend fun runFullScan(): ScanResult {
+    override suspend fun runFullScan(includeUnverified: Boolean): ScanResult {
         val started = nowMillis()
         val granted = scanner.isPermissionGranted()
         val rawCandidates = scanner.snapshot()
-        val candidates = rawCandidates.filter { hasPositiveEvidence(it) }
+        val candidates =
+            if (includeUnverified) {
+                rawCandidates
+            } else {
+                rawCandidates.filter { hasPositiveEvidence(it) }
+            }
         candidateSnapshot.update { candidates.associateBy { it.packageName } }
 
         val now = nowMillis()

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -259,7 +259,7 @@ class TweaksRepositoryImpl(
 
     override fun getExternalMatchSearchEnabled(): Flow<Boolean> =
         preferences.data.map { prefs ->
-            prefs[EXTERNAL_MATCH_SEARCH_ENABLED_KEY] ?: false
+            prefs[EXTERNAL_MATCH_SEARCH_ENABLED_KEY] ?: true
         }
 
     override suspend fun setExternalMatchSearchEnabled(enabled: Boolean) {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/ExternalImportRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/ExternalImportRepository.kt
@@ -13,7 +13,7 @@ interface ExternalImportRepository {
 
     suspend fun scheduleInitialScanIfNeeded()
 
-    suspend fun runFullScan(): ScanResult
+    suspend fun runFullScan(includeUnverified: Boolean = false): ScanResult
 
     suspend fun runDeltaScan(changedPackageNames: Set<String>): ScanResult
 

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -789,7 +789,9 @@
     <string name="external_import_card_action_link">Link</string>
     <string name="external_import_card_installer_chip">Installed via %1$s</string>
     <string name="external_import_card_preselect_known">We think this is %1$s · %2$d</string>
+    <string name="external_import_card_preselect_known_prefix">We think this is</string>
     <string name="external_import_card_preselect_unknown">Tap to find a repo</string>
+    <string name="external_import_card_owner_byline">by %1$s</string>
     <string name="external_import_card_expand_label">Expand to see other matches</string>
     <string name="external_import_card_collapse_label">Collapse card</string>
     <string name="external_import_search_icon_label">Search GitHub</string>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/ExternalImportViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/ExternalImportViewModel.kt
@@ -203,7 +203,7 @@ class ExternalImportViewModel(
             try {
                 _state.update { it.copy(phase = ImportPhase.Scanning, errorMessage = null) }
 
-                externalImportRepository.runFullScan()
+                externalImportRepository.runFullScan(includeUnverified = true)
 
                 val candidates = externalImportRepository.pendingCandidatesFlow().first()
                 candidatesByPackage = candidates.associateBy { it.packageName }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/CandidateCard.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/CandidateCard.kt
@@ -46,8 +46,10 @@ import zed.rainxch.githubstore.core.presentation.res.external_import_card_action
 import zed.rainxch.githubstore.core.presentation.res.external_import_card_collapse_label
 import zed.rainxch.githubstore.core.presentation.res.external_import_card_expand_label
 import zed.rainxch.githubstore.core.presentation.res.external_import_card_installer_chip
-import zed.rainxch.githubstore.core.presentation.res.external_import_card_preselect_known
+import zed.rainxch.githubstore.core.presentation.res.external_import_card_owner_byline
+import zed.rainxch.githubstore.core.presentation.res.external_import_card_preselect_known_prefix
 import zed.rainxch.githubstore.core.presentation.res.external_import_card_preselect_unknown
+import zed.rainxch.githubstore.core.presentation.res.external_import_match_confidence_chip
 
 @Composable
 fun CandidateCard(
@@ -267,17 +269,48 @@ private fun PreselectedRow(suggestion: RepoSuggestionUi?) {
             )
         } else {
             val percent = (suggestion.confidence * 100).roundToInt().coerceIn(0, 100)
-            Text(
-                text =
-                    stringResource(
-                        Res.string.external_import_card_preselect_known,
-                        suggestion.ownerSlashRepo,
-                        percent,
-                    ) + "%",
-                style = MaterialTheme.typography.bodyMedium,
-                color = contentColor,
+            Column(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-            )
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.external_import_card_preselect_known_prefix),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor,
+                )
+                Text(
+                    text = suggestion.repo,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(
+                            Res.string.external_import_card_owner_byline,
+                            suggestion.owner,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = contentColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    Text(
+                        text = stringResource(
+                            Res.string.external_import_match_confidence_chip,
+                            percent,
+                        ) + "%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor,
+                    )
+                }
+            }
         }
     }
 }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/RepoCandidateRow.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/components/RepoCandidateRow.kt
@@ -30,6 +30,7 @@ import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.apps.presentation.import.model.RepoSuggestionUi
 import zed.rainxch.apps.presentation.import.model.SuggestionSource
 import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.external_import_card_owner_byline
 import zed.rainxch.githubstore.core.presentation.res.external_import_match_confidence_a11y
 import zed.rainxch.githubstore.core.presentation.res.external_import_match_confidence_chip
 
@@ -63,10 +64,20 @@ fun RepoCandidateRow(
     ) {
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text(
-                text = suggestion.ownerSlashRepo,
+                text = suggestion.repo,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = stringResource(
+                    Res.string.external_import_card_owner_byline,
+                    suggestion.owner,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )


### PR DESCRIPTION
## Symptom

After clearing the app's data/cache, opening **Apps → Rescan for GitHub apps** reports zero (or near-zero) candidates even though the user has many GitHub-published apps installed. Some apps occasionally surfaced (the few whose signing fingerprint happened to be in the freshly-resynced backend seed) — most didn't.

## Cause

\`ExternalImportRepositoryImpl.runFullScan\` filters \`scanner.snapshot()\` through \`hasPositiveEvidence(...)\`, which keeps a candidate only when one of the following is true:

- installer kind ∈ \`{ STORE_OBTAINIUM, STORE_FDROID }\`,
- the APK manifest carries a GitHub hint, **or**
- the signing fingerprint hits the seed table populated from \`/v1/fingerprints\`.

That gate is the right behavior for **automatic** scans (the import banner would otherwise spam every sideloaded app on the device). But it also gates the **user-initiated** rescan from the Apps screen — which is exactly when the user has implicitly accepted noise in exchange for a complete list.

After a data wipe, \`signing_fingerprints\` is empty until the next app start completes \`syncSigningFingerprintSeed\`, and even when fully synced the seed only covers backend-known repos. Apps outside the seed never surface.

## Fix

\`ExternalImportRepository.runFullScan\` gains \`includeUnverified: Boolean = false\`. The wizard's \`startScanIfIdle\` (driven by \`OnRescanForGithubApps\` from the Apps screen) now calls \`runFullScan(includeUnverified = true)\` and gets the unfiltered candidate list. Background paths (\`scheduleInitialScanIfNeeded\`) keep the default \`false\` so the import banner counter stays evidence-gated.

## Test plan

- [ ] Clear app data. Sideload a few non-store APKs. Open Apps → Rescan for GitHub apps. Wizard now lists those apps as candidates (with whatever installer-kind label the OS reports — typically \`Sideload\`). Manual link still works.
- [ ] Don't trigger manual rescan; let the app run normally. Import banner counter stays empty until something with positive evidence (Obtainium / F-Droid / manifest hint / fingerprint match) actually arrives.
- [ ] Background \`runDeltaScan\` (the per-package broadcast path) still uses \`hasPositiveEvidence\` directly — unchanged, still strict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI-initiated external import scans now include unverified candidates for broader results.
  * Candidate cards updated to show a distinct repo name, owner byline, and a separate confidence chip.

* **Chores**
  * Scan API now accepts an explicit flag to control inclusion of unverified candidates (default remains conservative).

* **Bug Fixes / Tweaks**
  * External match search preference now defaults to enabled when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->