### PR TITLE
feat: in-app What's new sheet for #459

### DIFF
--- a/build-logic/convention/src/main/kotlin/BuildKonfigConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/BuildKonfigConventionPlugin.kt
@@ -31,9 +31,11 @@ class BuildKonfigConventionPlugin : Plugin<Project> {
                         ).trim()
 
                     val versionName = libs.findVersion("projectVersionName").get().toString()
+                    val versionCode = libs.findVersion("projectVersionCode").get().toString()
 
                     buildConfigField(FieldSpec.Type.STRING, "GITHUB_CLIENT_ID", githubClientId)
                     buildConfigField(FieldSpec.Type.STRING, "VERSION_NAME", versionName)
+                    buildConfigField(FieldSpec.Type.INT, "VERSION_CODE", versionCode)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -4,10 +4,15 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
+import zed.rainxch.core.presentation.components.whatsnew.WhatsNewSheet
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ApplyAndroidSystemBars
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
@@ -20,6 +25,7 @@ import zed.rainxch.githubstore.app.desktop.KeyboardNavigationEvent
 import zed.rainxch.githubstore.app.navigation.AppNavigation
 import zed.rainxch.githubstore.app.navigation.GithubStoreGraph
 import zed.rainxch.githubstore.app.navigation.getCurrentScreen
+import zed.rainxch.githubstore.app.whatsnew.WhatsNewViewModel
 
 @Composable
 fun App(deepLinkUri: String? = null) {
@@ -130,5 +136,35 @@ fun App(deepLinkUri: String? = null) {
             isLiquidGlassEnabled = state.isLiquidGlassEnabled,
             isScrollbarEnabled = state.isScrollbarEnabled,
         )
+
+        val whatsNewViewModel: WhatsNewViewModel = koinViewModel()
+        val pendingEntry by whatsNewViewModel.pendingEntry.collectAsStateWithLifecycle()
+        val onHomeScreen = currentScreen is GithubStoreGraph.HomeScreen
+        val authSettled = !state.showSessionExpiredDialog && !onAuthScreen
+        val rateLimitCleared = !state.showRateLimitDialog
+        val canShowWhatsNew = onHomeScreen && authSettled && rateLimitCleared
+
+        var debouncedReady by remember { mutableStateOf(false) }
+        LaunchedEffect(canShowWhatsNew) {
+            if (canShowWhatsNew) {
+                delay(600)
+                debouncedReady = true
+            } else {
+                debouncedReady = false
+            }
+        }
+
+        val entryToShow = pendingEntry
+        if (entryToShow != null && canShowWhatsNew && debouncedReady) {
+            WhatsNewSheet(
+                entry = entryToShow,
+                showHistoryAction = whatsNewViewModel.hasHistory,
+                onDismiss = { whatsNewViewModel.markSeen() },
+                onViewHistory = {
+                    whatsNewViewModel.markSeen()
+                    navController.navigate(GithubStoreGraph.WhatsNewHistoryScreen)
+                },
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -9,6 +9,7 @@ import zed.rainxch.auth.presentation.AuthenticationViewModel
 import zed.rainxch.details.presentation.DetailsViewModel
 import zed.rainxch.devprofile.presentation.DeveloperProfileViewModel
 import zed.rainxch.favourites.presentation.FavouritesViewModel
+import zed.rainxch.githubstore.app.whatsnew.WhatsNewViewModel
 import zed.rainxch.home.presentation.HomeViewModel
 import zed.rainxch.profile.presentation.ProfileViewModel
 import zed.rainxch.recentlyviewed.presentation.RecentlyViewedViewModel
@@ -67,6 +68,7 @@ val viewModelsModule =
         viewModelOf(::FeedbackViewModel)
         viewModelOf(::StarredReposViewModel)
         viewModelOf(::AutoSuggestMirrorViewModel)
+        viewModelOf(::WhatsNewViewModel)
         viewModel {
             MirrorPickerViewModel(
                 mirrorRepository = get(),

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -38,6 +38,7 @@ import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
 import zed.rainxch.details.presentation.DetailsRoot
 import zed.rainxch.devprofile.presentation.DeveloperProfileRoot
 import zed.rainxch.favourites.presentation.FavouritesRoot
+import zed.rainxch.githubstore.app.whatsnew.WhatsNewViewModel
 import zed.rainxch.home.presentation.HomeRoot
 import zed.rainxch.profile.presentation.ProfileRoot
 import zed.rainxch.profile.presentation.SponsorScreen
@@ -65,6 +66,8 @@ fun AppNavigation(
 
     val appsViewModel = koinViewModel<AppsViewModel>()
     val appsState by appsViewModel.state.collectAsStateWithLifecycle()
+
+    val whatsNewViewModel = koinViewModel<WhatsNewViewModel>()
 
     CompositionLocalProvider(
         LocalBottomNavigationLiquid provides liquidState,
@@ -271,6 +274,10 @@ fun AppNavigation(
                         },
                         onNavigateToWhatsNew = {
                             navController.navigate(GithubStoreGraph.WhatsNewHistoryScreen)
+                        },
+                        onPreviewWhatsNewSheet = {
+                            whatsNewViewModel.forceShowLatest()
+                            navController.navigateUp()
                         },
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -31,6 +31,7 @@ import zed.rainxch.apps.presentation.AppsRoot
 import zed.rainxch.apps.presentation.AppsViewModel
 import zed.rainxch.apps.presentation.import.ExternalImportRoot
 import zed.rainxch.auth.presentation.AuthenticationRoot
+import zed.rainxch.core.presentation.components.whatsnew.WhatsNewHistoryScreen
 import zed.rainxch.core.presentation.locals.LocalBottomNavigationHeight
 import zed.rainxch.core.presentation.locals.LocalBottomNavigationLiquid
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
@@ -268,6 +269,9 @@ fun AppNavigation(
                         onNavigateToSponsor = {
                             navController.navigate(GithubStoreGraph.SponsorScreen)
                         },
+                        onNavigateToWhatsNew = {
+                            navController.navigate(GithubStoreGraph.WhatsNewHistoryScreen)
+                        },
                     )
                 }
 
@@ -304,6 +308,12 @@ fun AppNavigation(
                 composable<GithubStoreGraph.MirrorPickerScreen> {
                     MirrorPickerRoot(
                         onNavigateBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable<GithubStoreGraph.WhatsNewHistoryScreen> {
+                    WhatsNewHistoryScreen(
+                        onNavigateBack = { navController.navigateUp() },
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -52,4 +52,7 @@ sealed interface GithubStoreGraph {
 
     @Serializable
     data object MirrorPickerScreen : GithubStoreGraph
+
+    @Serializable
+    data object WhatsNewHistoryScreen : GithubStoreGraph
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/NavigationUtils.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/NavigationUtils.kt
@@ -19,6 +19,7 @@ fun NavBackStackEntry?.getCurrentScreen(): GithubStoreGraph? {
         route.contains("FavouritesScreen") -> GithubStoreGraph.FavouritesScreen
         route.contains("StarredReposScreen") -> GithubStoreGraph.StarredReposScreen
         route.contains("AppsScreen") -> GithubStoreGraph.AppsScreen
+        route.contains("WhatsNewHistoryScreen") -> GithubStoreGraph.WhatsNewHistoryScreen
         else -> null
     }
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
@@ -2,6 +2,7 @@ package zed.rainxch.githubstore.app.whatsnew
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,39 +15,47 @@ import zed.rainxch.core.domain.system.AppVersionInfo
 
 class WhatsNewViewModel(
     private val tweaksRepository: TweaksRepository,
+    private val appVersionInfo: AppVersionInfo,
+) : ViewModel() {
+    private val logger = Logger.withTag("WhatsNewViewModel")
+
+    private val _pendingEntry = MutableStateFlow<WhatsNewEntry?>(null)
+    val pendingEntry: StateFlow<WhatsNewEntry?> = _pendingEntry.asStateFlow()
+
     init {
         viewModelScope.launch {
-            evaluate()
+            try {
+                evaluate()
+            } catch (t: Throwable) {
+                logger.e(t) { "Failed to evaluate what's-new state" }
+            }
         }
     }
 
     private suspend fun evaluate() {
-        runCatching {
-            val current = appVersionInfo.versionCode
-            val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first()
+        val current = appVersionInfo.versionCode
+        val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first() ?: Int.MIN_VALUE
 
-            if (lastSeen == null) {
-                tweaksRepository.setLastSeenWhatsNewVersionCode(current)
-                return
-            }
+        if (lastSeen >= current) return
 
-            if (lastSeen >= current) return
-
-            val entry = WhatsNewEntries.forVersionCode(current)
-            if (entry == null || !entry.showAsSheet) {
-                tweaksRepository.setLastSeenWhatsNewVersionCode(current)
-                return
-            }
-
-            _pendingEntry.value = entry
+        val entry = WhatsNewEntries.forVersionCode(current)
+        if (entry == null || !entry.showAsSheet) {
+            tweaksRepository.setLastSeenWhatsNewVersionCode(current)
+            return
         }
+
+        _pendingEntry.value = entry
     }
 
     fun markSeen() {
         val entry = _pendingEntry.value ?: return
         _pendingEntry.value = null
         viewModelScope.launch {
-            tweaksRepository.setLastSeenWhatsNewVersionCode(entry.versionCode)
+            try {
+                tweaksRepository.setLastSeenWhatsNewVersionCode(entry.versionCode)
+            } catch (t: Throwable) {
+                logger.e(t) { "Failed to persist lastSeenWhatsNewVersionCode=${entry.versionCode}" }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
@@ -27,12 +27,7 @@ class WhatsNewViewModel(
 
     private suspend fun evaluate() {
         val current = appVersionInfo.versionCode
-        val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first()
-
-        if (lastSeen == null) {
-            tweaksRepository.setLastSeenWhatsNewVersionCode(current)
-            return
-        }
+        val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first() ?: Int.MIN_VALUE
 
         if (lastSeen >= current) return
 
@@ -51,6 +46,15 @@ class WhatsNewViewModel(
         viewModelScope.launch {
             tweaksRepository.setLastSeenWhatsNewVersionCode(entry.versionCode)
         }
+    }
+
+    fun forceShowLatest() {
+        val current = appVersionInfo.versionCode
+        val entry =
+            WhatsNewEntries.forVersionCode(current)
+                ?: WhatsNewEntries.all.firstOrNull()
+                ?: return
+        _pendingEntry.value = entry
     }
 
     val hasHistory: Boolean

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
@@ -1,0 +1,58 @@
+package zed.rainxch.githubstore.app.whatsnew
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import zed.rainxch.core.domain.model.WhatsNewEntries
+import zed.rainxch.core.domain.model.WhatsNewEntry
+import zed.rainxch.core.domain.repository.TweaksRepository
+import zed.rainxch.core.domain.system.AppVersionInfo
+
+class WhatsNewViewModel(
+    private val tweaksRepository: TweaksRepository,
+    private val appVersionInfo: AppVersionInfo,
+) : ViewModel() {
+    private val _pendingEntry = MutableStateFlow<WhatsNewEntry?>(null)
+    val pendingEntry: StateFlow<WhatsNewEntry?> = _pendingEntry.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            evaluate()
+        }
+    }
+
+    private suspend fun evaluate() {
+        val current = appVersionInfo.versionCode
+        val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first()
+
+        if (lastSeen == null) {
+            tweaksRepository.setLastSeenWhatsNewVersionCode(current)
+            return
+        }
+
+        if (lastSeen >= current) return
+
+        val entry = WhatsNewEntries.forVersionCode(current)
+        if (entry == null || !entry.showAsSheet) {
+            tweaksRepository.setLastSeenWhatsNewVersionCode(current)
+            return
+        }
+
+        _pendingEntry.value = entry
+    }
+
+    fun markSeen() {
+        val entry = _pendingEntry.value ?: return
+        _pendingEntry.value = null
+        viewModelScope.launch {
+            tweaksRepository.setLastSeenWhatsNewVersionCode(entry.versionCode)
+        }
+    }
+
+    val hasHistory: Boolean
+        get() = WhatsNewEntries.all.size > 1
+}

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
@@ -14,11 +14,6 @@ import zed.rainxch.core.domain.system.AppVersionInfo
 
 class WhatsNewViewModel(
     private val tweaksRepository: TweaksRepository,
-    private val appVersionInfo: AppVersionInfo,
-) : ViewModel() {
-    private val _pendingEntry = MutableStateFlow<WhatsNewEntry?>(null)
-    val pendingEntry: StateFlow<WhatsNewEntry?> = _pendingEntry.asStateFlow()
-
     init {
         viewModelScope.launch {
             evaluate()
@@ -26,18 +21,25 @@ class WhatsNewViewModel(
     }
 
     private suspend fun evaluate() {
-        val current = appVersionInfo.versionCode
-        val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first() ?: Int.MIN_VALUE
+        runCatching {
+            val current = appVersionInfo.versionCode
+            val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first()
 
-        if (lastSeen >= current) return
+            if (lastSeen == null) {
+                tweaksRepository.setLastSeenWhatsNewVersionCode(current)
+                return
+            }
 
-        val entry = WhatsNewEntries.forVersionCode(current)
-        if (entry == null || !entry.showAsSheet) {
-            tweaksRepository.setLastSeenWhatsNewVersionCode(current)
-            return
+            if (lastSeen >= current) return
+
+            val entry = WhatsNewEntries.forVersionCode(current)
+            if (entry == null || !entry.showAsSheet) {
+                tweaksRepository.setLastSeenWhatsNewVersionCode(current)
+                return
+            }
+
+            _pendingEntry.value = entry
         }
-
-        _pendingEntry.value = entry
     }
 
     fun markSeen() {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -21,6 +21,7 @@ import zed.rainxch.core.data.cache.CacheManager
 import zed.rainxch.core.data.data_source.TokenStore
 import zed.rainxch.core.data.download.MultiSourceDownloaderImpl
 import zed.rainxch.core.data.download.SlowDownloadDetectorImpl
+import zed.rainxch.core.data.services.BuildKonfigAppVersionInfo
 import zed.rainxch.core.data.services.DefaultDownloadOrchestrator
 import zed.rainxch.core.data.data_source.impl.DefaultTokenStore
 import zed.rainxch.core.data.local.db.AppDatabase
@@ -65,6 +66,7 @@ import zed.rainxch.core.domain.model.ProxyConfig
 import zed.rainxch.core.domain.model.ProxyScope
 import zed.rainxch.core.domain.network.ProxyTester
 import zed.rainxch.core.domain.network.SlowDownloadDetector
+import zed.rainxch.core.domain.system.AppVersionInfo
 import zed.rainxch.core.domain.system.DownloadOrchestrator
 import zed.rainxch.core.domain.system.ExternalAppScanner
 import zed.rainxch.core.domain.system.MultiSourceDownloader
@@ -133,6 +135,10 @@ val coreModule =
             TweaksRepositoryImpl(
                 preferences = get(),
             )
+        }
+
+        single<AppVersionInfo> {
+            BuildKonfigAppVersionInfo()
         }
 
         single<MirrorApiClient> {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -290,6 +290,20 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getLastSeenWhatsNewVersionCode(): Flow<Int?> =
+        preferences.data.map { prefs ->
+            prefs[LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY]
+        }
+
+    override suspend fun setLastSeenWhatsNewVersionCode(versionCode: Int) {
+        preferences.edit { prefs ->
+            val current = prefs[LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY] ?: Int.MIN_VALUE
+            if (versionCode > current) {
+                prefs[LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY] = versionCode
+            }
+        }
+    }
+
     companion object {
         private const val DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 6L
 
@@ -316,5 +330,6 @@ class TweaksRepositoryImpl(
         private val EXTERNAL_MATCH_SEARCH_ENABLED_KEY = booleanPreferencesKey("external_match_search_enabled")
         private val EXTERNAL_IMPORT_BANNER_DISMISSED_AT_KEY = intPreferencesKey("external_import_banner_dismissed_at")
         private val APK_INSPECT_COACHMARK_SHOWN_KEY = booleanPreferencesKey("apk_inspect_coachmark_shown")
+        private val LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY = intPreferencesKey("last_seen_whats_new_version_code")
     }
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/BuildKonfigAppVersionInfo.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/BuildKonfigAppVersionInfo.kt
@@ -1,0 +1,9 @@
+package zed.rainxch.core.data.services
+
+import zed.rainxch.core.data.BuildKonfig
+import zed.rainxch.core.domain.system.AppVersionInfo
+
+class BuildKonfigAppVersionInfo : AppVersionInfo {
+    override val versionCode: Int = BuildKonfig.VERSION_CODE
+    override val versionName: String = BuildKonfig.VERSION_NAME
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
@@ -1,0 +1,41 @@
+package zed.rainxch.core.domain.model
+
+object WhatsNewEntries {
+    val all: List<WhatsNewEntry> = buildList {
+        add(
+            WhatsNewEntry(
+                versionCode = 15,
+                versionName = "1.8.0",
+                releaseDate = "2026-05-03",
+                sections = listOf(
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.NEW,
+                        bullets = listOf(
+                            "What's new sheet — see highlights right after every update.",
+                            "APK Inspect: peek inside any release before installing.",
+                            "Manual rescan surfaces every GitHub-style app on device.",
+                        ),
+                    ),
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.IMPROVED,
+                        bullets = listOf(
+                            "Sui silent install support, alongside Shizuku.",
+                            "Faithful pending row — parked APKs now carry their own icon and version.",
+                            "Auth resilience: token-scoped 401 debounce stops spurious sign-outs.",
+                        ),
+                    ),
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.FIXED,
+                        bullets = listOf(
+                            "Multi-source download race no longer corrupts the final APK.",
+                            "Shizuku-fallback installs no longer mark apps installed before they actually are.",
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }.sortedByDescending { it.versionCode }
+
+    fun forVersionCode(versionCode: Int): WhatsNewEntry? =
+        all.firstOrNull { it.versionCode == versionCode }
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
@@ -4,31 +4,65 @@ object WhatsNewEntries {
     val all: List<WhatsNewEntry> = buildList {
         add(
             WhatsNewEntry(
-                versionCode = 15,
-                versionName = "1.8.0",
+                versionCode = 16,
+                versionName = "1.8.1",
                 releaseDate = "2026-05-03",
                 sections = listOf(
                     WhatsNewSection(
                         type = WhatsNewSectionType.NEW,
                         bullets = listOf(
                             "APK Inspect — peek inside any release before installing.",
-                            "Apps screen now groups updates, pending installs, and installed apps into sections.",
+                            "Apps screen now groups updates, pending installs, and installed apps.",
+                            "What's new sheet — see what changed after every update.",
                         ),
                     ),
                     WhatsNewSection(
                         type = WhatsNewSectionType.IMPROVED,
                         bullets = listOf(
-                            "Manual rescan surfaces every GitHub-style app on device, not just verified ones.",
+                            "Manual rescan surfaces every GitHub-style app on device.",
                             "Tighter auth handling — transient 401s no longer trigger spurious sign-outs.",
-                            "Faithful pending rows — parked APKs carry their own icon and version.",
                         ),
                     ),
                     WhatsNewSection(
                         type = WhatsNewSectionType.FIXED,
                         bullets = listOf(
                             "Multi-source downloads no longer clobber each other's APK file.",
-                            "Shizuku-fallback installs no longer flip rows to \"installed\" before the system confirms.",
+                            "Shizuku-fallback installs no longer flip rows to \"installed\" prematurely.",
                             "Self-update no longer leaves apps stuck on \"Preparing to install\".",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        add(
+            WhatsNewEntry(
+                versionCode = 15,
+                versionName = "1.8.0",
+                releaseDate = "2026-05-01",
+                sections = listOf(
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.NEW,
+                        bullets = listOf(
+                            "GitHub Store backend — auth, search, and discovery work in China.",
+                            "Library Imports — auto-detects GitHub apps you already have on device.",
+                            "Download Mirror System — multi-source race plus SHA-256 verification.",
+                            "Personal Access Token sign-in for networks blocking the OAuth browser flow.",
+                        ),
+                    ),
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.IMPROVED,
+                        bullets = listOf(
+                            "Send feedback in-app — bug reports, feature ideas, change requests.",
+                            "Pre-release channel chip plus \"switch to stable\" rollback in Details.",
+                            "Arch Linux native pkg.tar.zst packages alongside deb, rpm, and AppImage.",
+                        ),
+                    ),
+                    WhatsNewSection(
+                        type = WhatsNewSectionType.FIXED,
+                        bullets = listOf(
+                            "Linux Desktop no longer silently wipes settings and library on reboot.",
+                            "Variant picking now honored — chosen variant installs without override.",
+                            "macOS accessibility crash fixed via Compose Multiplatform 1.10.3.",
                         ),
                     ),
                 ),

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntries.kt
@@ -11,24 +11,24 @@ object WhatsNewEntries {
                     WhatsNewSection(
                         type = WhatsNewSectionType.NEW,
                         bullets = listOf(
-                            "What's new sheet — see highlights right after every update.",
-                            "APK Inspect: peek inside any release before installing.",
-                            "Manual rescan surfaces every GitHub-style app on device.",
+                            "APK Inspect — peek inside any release before installing.",
+                            "Apps screen now groups updates, pending installs, and installed apps into sections.",
                         ),
                     ),
                     WhatsNewSection(
                         type = WhatsNewSectionType.IMPROVED,
                         bullets = listOf(
-                            "Sui silent install support, alongside Shizuku.",
-                            "Faithful pending row — parked APKs now carry their own icon and version.",
-                            "Auth resilience: token-scoped 401 debounce stops spurious sign-outs.",
+                            "Manual rescan surfaces every GitHub-style app on device, not just verified ones.",
+                            "Tighter auth handling — transient 401s no longer trigger spurious sign-outs.",
+                            "Faithful pending rows — parked APKs carry their own icon and version.",
                         ),
                     ),
                     WhatsNewSection(
                         type = WhatsNewSectionType.FIXED,
                         bullets = listOf(
-                            "Multi-source download race no longer corrupts the final APK.",
-                            "Shizuku-fallback installs no longer mark apps installed before they actually are.",
+                            "Multi-source downloads no longer clobber each other's APK file.",
+                            "Shizuku-fallback installs no longer flip rows to \"installed\" before the system confirms.",
+                            "Self-update no longer leaves apps stuck on \"Preparing to install\".",
                         ),
                     ),
                 ),

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntry.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/WhatsNewEntry.kt
@@ -1,0 +1,21 @@
+package zed.rainxch.core.domain.model
+
+data class WhatsNewEntry(
+    val versionCode: Int,
+    val versionName: String,
+    val releaseDate: String,
+    val sections: List<WhatsNewSection>,
+    val showAsSheet: Boolean = true,
+)
+
+data class WhatsNewSection(
+    val type: WhatsNewSectionType,
+    val bullets: List<String>,
+)
+
+enum class WhatsNewSectionType {
+    NEW,
+    IMPROVED,
+    FIXED,
+    HEADS_UP,
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -107,4 +107,8 @@ interface TweaksRepository {
     fun getApkInspectCoachmarkShown(): Flow<Boolean>
 
     suspend fun setApkInspectCoachmarkShown(shown: Boolean)
+
+    fun getLastSeenWhatsNewVersionCode(): Flow<Int?>
+
+    suspend fun setLastSeenWhatsNewVersionCode(versionCode: Int)
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/AppVersionInfo.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/AppVersionInfo.kt
@@ -1,0 +1,6 @@
+package zed.rainxch.core.domain.system
+
+interface AppVersionInfo {
+    val versionCode: Int
+    val versionName: String
+}

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1006,8 +1006,8 @@
     <string name="apk_inspect_protection_privileged">Privileged</string>
     <string name="apk_inspect_protection_normal">Normal</string>
     <string name="apk_inspect_protection_unknown">Unknown</string>
-    <string name="whats_new_title">What\'s new</string>
-    <string name="whats_new_sheet_heading">What\'s new in %1$s</string>
+    <string name="whats_new_title">What's new</string>
+    <string name="whats_new_sheet_heading">What's new in %1$s</string>
     <string name="whats_new_version_label">Version %1$s · %2$s</string>
     <string name="whats_new_section_new">New</string>
     <string name="whats_new_section_improved">Improved</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1006,4 +1006,16 @@
     <string name="apk_inspect_protection_privileged">Privileged</string>
     <string name="apk_inspect_protection_normal">Normal</string>
     <string name="apk_inspect_protection_unknown">Unknown</string>
+    <string name="whats_new_title">What\'s new</string>
+    <string name="whats_new_sheet_heading">What\'s new in %1$s</string>
+    <string name="whats_new_version_label">Version %1$s · %2$s</string>
+    <string name="whats_new_section_new">New</string>
+    <string name="whats_new_section_improved">Improved</string>
+    <string name="whats_new_section_fixed">Fixed</string>
+    <string name="whats_new_section_heads_up">Heads up</string>
+    <string name="whats_new_cta_dismiss">Got it</string>
+    <string name="whats_new_cta_history">View previous versions</string>
+    <string name="whats_new_translations_note">Changelog is in English. Translations welcome via Issues.</string>
+    <string name="whats_new_history_empty">No changelog entries yet.</string>
+    <string name="whats_new_profile_description">Highlights from recent releases.</string>
 </resources>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewHistoryScreen.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewHistoryScreen.kt
@@ -1,0 +1,86 @@
+package zed.rainxch.core.presentation.components.whatsnew
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.model.WhatsNewEntries
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.whats_new_history_empty
+import zed.rainxch.githubstore.core.presentation.res.whats_new_title
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WhatsNewHistoryScreen(
+    onNavigateBack: () -> Unit,
+) {
+    val entries = WhatsNewEntries.all
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(Res.string.whats_new_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (entries.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(Res.string.whats_new_history_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                items(entries) { entry ->
+                    WhatsNewEntryCard(entry)
+                }
+            }
+        }
+    }
+}

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewSheet.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewSheet.kt
@@ -1,0 +1,223 @@
+package zed.rainxch.core.presentation.components.whatsnew
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.model.WhatsNewEntry
+import zed.rainxch.core.domain.model.WhatsNewSection
+import zed.rainxch.core.domain.model.WhatsNewSectionType
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.whats_new_cta_dismiss
+import zed.rainxch.githubstore.core.presentation.res.whats_new_cta_history
+import zed.rainxch.githubstore.core.presentation.res.whats_new_section_fixed
+import zed.rainxch.githubstore.core.presentation.res.whats_new_section_heads_up
+import zed.rainxch.githubstore.core.presentation.res.whats_new_section_improved
+import zed.rainxch.githubstore.core.presentation.res.whats_new_section_new
+import zed.rainxch.githubstore.core.presentation.res.whats_new_sheet_heading
+import zed.rainxch.githubstore.core.presentation.res.whats_new_translations_note
+import zed.rainxch.githubstore.core.presentation.res.whats_new_version_label
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WhatsNewSheet(
+    entry: WhatsNewEntry,
+    showHistoryAction: Boolean,
+    onDismiss: () -> Unit,
+    onViewHistory: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item { SheetHeader(entry) }
+
+            items(entry.sections) { section ->
+                SectionBlock(section)
+            }
+
+            item {
+                Text(
+                    text = stringResource(Res.string.whats_new_translations_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            item {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                    ) {
+                        Text(text = stringResource(Res.string.whats_new_cta_dismiss))
+                    }
+
+                    if (showHistoryAction) {
+                        TextButton(
+                            onClick = onViewHistory,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(text = stringResource(Res.string.whats_new_cta_history))
+                        }
+                    }
+                }
+            }
+
+            item { Spacer(Modifier.height(24.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun SheetHeader(entry: WhatsNewEntry) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = stringResource(Res.string.whats_new_sheet_heading, entry.versionName),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(
+                Res.string.whats_new_version_label,
+                entry.versionName,
+                entry.releaseDate,
+            ),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+fun WhatsNewEntryCard(entry: WhatsNewEntry) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = entry.versionName,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = entry.releaseDate,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            entry.sections.forEach { section ->
+                SectionBlock(section)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionBlock(section: WhatsNewSection) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SectionLabel(type = section.type)
+
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                section.bullets.forEach { bullet ->
+                    BulletRow(text = bullet)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(type: WhatsNewSectionType) {
+    val (label, color) = when (type) {
+        WhatsNewSectionType.NEW -> stringResource(Res.string.whats_new_section_new) to
+            MaterialTheme.colorScheme.primary
+        WhatsNewSectionType.IMPROVED -> stringResource(Res.string.whats_new_section_improved) to
+            MaterialTheme.colorScheme.tertiary
+        WhatsNewSectionType.FIXED -> stringResource(Res.string.whats_new_section_fixed) to
+            MaterialTheme.colorScheme.secondary
+        WhatsNewSectionType.HEADS_UP -> stringResource(Res.string.whats_new_section_heads_up) to
+            MaterialTheme.colorScheme.error
+    }
+
+    Text(
+        text = label.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = color,
+    )
+}
+
+@Composable
+private fun BulletRow(text: String) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = "•",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileAction.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileAction.kt
@@ -17,4 +17,6 @@ sealed interface ProfileAction {
     data object OnRecentlyViewedClick : ProfileAction
 
     data object OnSponsorClick : ProfileAction
+
+    data object OnWhatsNewClick : ProfileAction
 }

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileAction.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileAction.kt
@@ -19,4 +19,6 @@ sealed interface ProfileAction {
     data object OnSponsorClick : ProfileAction
 
     data object OnWhatsNewClick : ProfileAction
+
+    data object OnWhatsNewLongClick : ProfileAction
 }

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
@@ -51,6 +51,7 @@ fun ProfileRoot(
     onNavigateToRecentlyViewed: () -> Unit,
     onNavigateToSponsor: () -> Unit,
     onNavigateToWhatsNew: () -> Unit,
+    onPreviewWhatsNewSheet: () -> Unit,
     viewModel: ProfileViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -135,6 +136,10 @@ fun ProfileRoot(
 
                 ProfileAction.OnWhatsNewClick -> {
                     onNavigateToWhatsNew()
+                }
+
+                ProfileAction.OnWhatsNewLongClick -> {
+                    onPreviewWhatsNewSheet()
                 }
 
                 else -> {

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileRoot.kt
@@ -50,6 +50,7 @@ fun ProfileRoot(
     onNavigateToFavouriteRepos: () -> Unit,
     onNavigateToRecentlyViewed: () -> Unit,
     onNavigateToSponsor: () -> Unit,
+    onNavigateToWhatsNew: () -> Unit,
     viewModel: ProfileViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -130,6 +131,10 @@ fun ProfileRoot(
 
                 ProfileAction.OnSponsorClick -> {
                     onNavigateToSponsor()
+                }
+
+                ProfileAction.OnWhatsNewClick -> {
+                    onNavigateToWhatsNew()
                 }
 
                 else -> {

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
@@ -149,6 +149,10 @@ class ProfileViewModel(
             ProfileAction.OnRecentlyViewedClick -> {
                 // Handed in composable
             }
+
+            ProfileAction.OnWhatsNewClick -> {
+                // Handed in composable
+            }
         }
     }
 }

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
@@ -153,6 +153,10 @@ class ProfileViewModel(
             ProfileAction.OnWhatsNewClick -> {
                 // Handed in composable
             }
+
+            ProfileAction.OnWhatsNewLongClick -> {
+                // Handed in composable
+            }
         }
     }
 }

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Star
@@ -70,6 +71,17 @@ fun LazyListScope.options(
             description = stringResource(Res.string.profile_recently_viewed_description),
             onClick = {
                 onAction(ProfileAction.OnRecentlyViewedClick)
+            },
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        OptionCard(
+            icon = Icons.Default.Campaign,
+            label = stringResource(Res.string.whats_new_title),
+            description = stringResource(Res.string.whats_new_profile_description),
+            onClick = {
+                onAction(ProfileAction.OnWhatsNewClick)
             },
         )
 

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
@@ -1,7 +1,9 @@
 package zed.rainxch.profile.presentation.components.sections
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -83,6 +85,9 @@ fun LazyListScope.options(
             onClick = {
                 onAction(ProfileAction.OnWhatsNewClick)
             },
+            onLongClick = {
+                onAction(ProfileAction.OnWhatsNewLongClick)
+            },
         )
 
         Spacer(Modifier.height(4.dp))
@@ -95,7 +100,7 @@ fun LazyListScope.options(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun OptionCard(
     icon: ImageVector,
@@ -104,72 +109,101 @@ private fun OptionCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
 ) {
+    val cardColors = CardDefaults.elevatedCardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .7f),
+        disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .7f),
+    )
+    val cardShape = RoundedCornerShape(32.dp)
+    val cardBorder = BorderStroke(
+        width = .5.dp,
+        color = MaterialTheme.colorScheme.surface,
+    )
+
+    if (onLongClick != null) {
+        Card(
+            modifier = modifier.combinedClickable(
+                enabled = enabled,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            ),
+            colors = cardColors,
+            shape = cardShape,
+            border = cardBorder,
+        ) {
+            OptionCardContent(icon = icon, label = label, description = description)
+        }
+        return
+    }
+
     Card(
         modifier = modifier,
-        colors =
-            CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-                disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = .7f),
-                disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .7f),
-            ),
+        colors = cardColors,
         onClick = onClick,
-        shape = RoundedCornerShape(32.dp),
-        border =
-            BorderStroke(
-                width = .5.dp,
-                color = MaterialTheme.colorScheme.surface,
-            ),
+        shape = cardShape,
+        border = cardBorder,
         enabled = enabled,
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier =
-                    Modifier
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .background(
-                            Brush.linearGradient(
-                                listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.secondary,
-                                ),
+        OptionCardContent(icon = icon, label = label, description = description)
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun OptionCardContent(
+    icon: ImageVector,
+    label: String,
+    description: String,
+) {
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primary,
+                                MaterialTheme.colorScheme.secondary,
                             ),
-                        ).padding(6.dp),
-                tint = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                    ).padding(6.dp),
+            tint = MaterialTheme.colorScheme.onPrimary,
+        )
+
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(12.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.Start,
+        ) {
+            Text(
+                text = label,
+                maxLines = 1,
+                style = MaterialTheme.typography.titleMedium,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurface,
             )
 
-            Column(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(12.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.Start,
-            ) {
-                Text(
-                    text = label,
-                    maxLines = 1,
-                    style = MaterialTheme.typography.titleMedium,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-
-                Text(
-                    text = description,
-                    maxLines = 2,
-                    style = MaterialTheme.typography.bodyLargeEmphasized,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            Text(
+                text = description,
+                maxLines = 2,
+                style = MaterialTheme.typography.bodyLargeEmphasized,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,11 +51,11 @@ ktlint-gradle = "12.1.1"
 flatpak-gradle-generator = "1.7.0"
 
 projectApplicationId = "zed.rainxch.githubstore"
-projectVersionName = "1.8.0"
+projectVersionName = "1.8.1"
 projectMinSdkVersion = "26"
 projectTargetSdkVersion = "36"
 projectCompileSdkVersion = "36"
-projectVersionCode = "15"
+projectVersionCode = "16"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
Closes #459.

## Summary
- Adds a `ModalBottomSheet` that appears once per `versionCode` bump on first launch after an update.
- Skips the sheet entirely on fresh installs (silently marks the current version as seen so the user lands straight on Home).
- Skips the sheet for releases marked `showAsSheet = false` so bug-fix-only patches stay silent and credible.
- Defers display until the user is on `HomeScreen`, OAuth/rate-limit/session dialogs are not active, and a 600ms debounce has elapsed after Home becomes the destination.
- Adds a permanent **What's new** entry on the Profile screen pointing to a full history (`WhatsNewHistoryScreen`).
- Single editorial source of truth: `WhatsNewEntries` in `core/domain` — one entry per release, hand-written in concise voice.

## Why this shape
UX research (paraphrased): on update users have a low-grade "did anything change?" question. Without a surface, new features stay invisible and "you didn't tell me X existed" turns into support load. But over-using the surface (Slack/Notion-style) trains dismissal. The two big calibrations are:
- **Only show on real updates** — `lastSeenWhatsNewVersionCode < currentVersionCode`, with `showAsSheet=false` per-version flag for silent patches.
- **Get out of the way of competing first-run flows** — gated on Home + auth-settled + no other dialog visible + debounce.

## Files of note
- `core/domain/.../model/WhatsNewEntry.kt`, `WhatsNewEntries.kt` — model + the entry list (edit this every release).
- `core/domain/.../system/AppVersionInfo.kt` — small interface; `BuildKonfigAppVersionInfo` reads from `BuildKonfig.VERSION_CODE` (newly exposed).
- `core/presentation/.../components/whatsnew/WhatsNewSheet.kt`, `WhatsNewHistoryScreen.kt` — the sheet and the history screen.
- `composeApp/.../whatsnew/WhatsNewViewModel.kt` — controller; computes `pendingEntry`, persists via `TweaksRepository.setLastSeenWhatsNewVersionCode`.
- `composeApp/.../Main.kt` — host + display gating.

## Edge cases covered
- **Fresh install** (`lastSeen == null`) → mark current as seen, no sheet.
- **Downgrade** (`lastSeen > current`) → no-op; `setLastSeenWhatsNewVersionCode` only writes when the new value is greater, so downgrade can't poison the bookmark.
- **Skipped versions** (e.g. 1.5 → 1.8) → show only the current version's entry; older entries reachable via "View previous versions" CTA → Profile → What's new.
- **No entry shipped for the current versionCode** → mark seen, no sheet (silent patch).
- **Auth screen / rate-limit / session-expired dialog active** → suppressed.
- **OAuth flow on cold start** → suppressed by the same gate; user sees Home first.

## What's NOT in this PR (resisted scope creep)
- No images, GIFs, or screenshots in the sheet.
- No remote content fetching.
- No analytics or telemetry.
- No per-locale bullet content (English only — scaffolding strings only). UX research recommended this for v1; community translation issue can come later.
- No fresh-install welcome sheet (separate concern).
- No re-show-if-skipped logic.

## Test plan
- [ ] Cold start with no DataStore record → no sheet appears, `lastSeenWhatsNewVersionCode` is set to current.
- [ ] Bump `projectVersionCode` to 16 in `gradle/libs.versions.toml`, add a 1.9.0 entry to `WhatsNewEntries.all` with `showAsSheet=true`, rebuild → sheet appears on launch after Home settles.
- [ ] Same scenario with `showAsSheet=false` → no sheet, `lastSeen` silently advances to 16.
- [ ] Tap **Got it** → sheet dismisses, does not reappear on subsequent launches.
- [ ] Tap **View previous versions** → navigates to history screen.
- [ ] Profile → **What's new** row → opens history screen with 1.8.0 entry visible.
- [ ] Force-quit during OAuth flow → on next launch, no sheet shows on top of `AuthenticationScreen`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "What's New" modal sheet with sections (New/Improved/Fixed/Heads up), dismiss and "View previous versions" actions.
  * Added a changelog history screen accessible from Profile to review past releases.
  * Profile option: tap opens history; long-press previews the latest sheet.
  * App now tracks seen versions so each update sheet shows only once.
  * Changelog updated with v1.8.1 and adjusted v1.8.0 release date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->