### PR TITLE
Route anon GitHub reads through backend pool

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -132,6 +132,7 @@ val coreModule =
                 starredRepoDao = get(),
                 platform = get(),
                 clientProvider = get(),
+                backendApiClient = get(),
             )
         }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubRepoNetworkModel.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubRepoNetworkModel.kt
@@ -19,4 +19,8 @@ data class GithubRepoNetworkModel(
     @SerialName("releases_url") val releasesUrl: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("fork") val fork: Boolean = false,
+    @SerialName("archived") val archived: Boolean = false,
+    @SerialName("open_issues_count") val openIssuesCount: Int = 0,
+    @SerialName("pushed_at") val pushedAt: String? = null,
+    @SerialName("has_downloads") val hasDownloads: Boolean = false,
 )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/UserProfileNetwork.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/UserProfileNetwork.kt
@@ -18,4 +18,8 @@ data class UserProfileNetwork(
     @SerialName("company") val company: String? = null,
     @SerialName("blog") val blog: String? = null,
     @SerialName("twitter_username") val twitterUsername: String? = null,
+    @SerialName("email") val email: String? = null,
+    @SerialName("public_gists") val publicGists: Int? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
 )

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -37,6 +37,7 @@ import zed.rainxch.core.data.dto.EventRequest
 import zed.rainxch.core.data.dto.ExternalMatchRequest
 import zed.rainxch.core.data.dto.ExternalMatchResponse
 import zed.rainxch.core.data.dto.GithubReadmeResponseDto
+import zed.rainxch.core.data.dto.GithubRepoNetworkModel
 import zed.rainxch.core.data.dto.MirrorListResponse
 import zed.rainxch.core.data.dto.ReleaseNetwork
 import zed.rainxch.core.data.dto.SigningFingerprintSeedResponse
@@ -96,20 +97,20 @@ class BackendApiClient(
     suspend fun getCategory(category: String, platform: String): Result<List<BackendRepoResponse>> =
         safeCall {
             val response = httpClient.get("categories/$category/$platform")
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
     suspend fun getTopic(bucket: String, platform: String): Result<List<BackendRepoResponse>> =
         safeCall {
             val response = httpClient.get("topics/$bucket/$platform")
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -130,10 +131,10 @@ class BackendApiClient(
                 parameter("offset", offset)
                 if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -156,10 +157,10 @@ class BackendApiClient(
 
                 if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -177,10 +178,10 @@ class BackendApiClient(
             val response = httpClient.get("repo/$owner/$name") {
                 if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -202,10 +203,10 @@ class BackendApiClient(
                     socketTimeoutMillis = 15_000
                 }
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -222,10 +223,60 @@ class BackendApiClient(
                     socketTimeoutMillis = 15_000
                 }
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
+            }
+        }
+
+    suspend fun getUserRepos(
+        username: String,
+        page: Int = 1,
+        perPage: Int = 30,
+        sort: String? = "updated",
+        type: String? = null,
+    ): Result<List<GithubRepoNetworkModel>> =
+        safeCall {
+            val token = currentUserGithubToken()
+            val response = httpClient.get("users/$username/repos") {
+                parameter("page", page)
+                parameter("per_page", perPage)
+                if (sort != null) parameter("sort", sort)
+                if (type != null) parameter("type", type)
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    socketTimeoutMillis = 15_000
+                }
+            }
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
+            }
+        }
+
+    suspend fun getUserStarred(
+        username: String,
+        page: Int = 1,
+        perPage: Int = 30,
+    ): Result<List<GithubRepoNetworkModel>> =
+        safeCall {
+            val token = currentUserGithubToken()
+            val response = httpClient.get("users/$username/starred") {
+                parameter("page", page)
+                parameter("per_page", perPage)
+                if (token != null) header(X_GITHUB_TOKEN_HEADER, token)
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    socketTimeoutMillis = 15_000
+                }
+            }
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -239,10 +290,10 @@ class BackendApiClient(
                     socketTimeoutMillis = 15_000
                 }
             }
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -286,20 +337,20 @@ class BackendApiClient(
     suspend fun getMirrorList(): Result<MirrorListResponse> =
         safeCall {
             val response = httpClient.get("mirrors/list")
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
     suspend fun getAnnouncements(): Result<AnnouncementsResponseDto> =
         safeCall {
             val response = httpClient.get("announcements")
-            if (response.status.isSuccess()) {
-                Result.success(response.body())
-            } else {
-                Result.failure(BackendException(response.status.value))
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.TooManyRequests -> Result.failure(buildRateLimited(response))
+                else -> Result.failure(BackendException(response.status.value))
             }
         }
 
@@ -318,6 +369,12 @@ class BackendApiClient(
                     Result.failure(BackendException(response.status.value))
             }
         }
+
+    private fun buildRateLimited(response: io.ktor.client.statement.HttpResponse): RateLimitedException {
+        val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
+        val resetEpoch = response.headers["X-RateLimit-Reset"]?.toLongOrNull()
+        return RateLimitedException(retryAfterSeconds = retryAfter, resetEpochSeconds = resetEpoch)
+    }
 
     private inline fun <T> safeCall(block: () -> Result<T>): Result<T> =
         try {
@@ -339,4 +396,7 @@ class BackendException(
     message: String = "HTTP $statusCode",
 ) : Exception(message)
 
-class RateLimitedException : Exception("Rate limited by backend (429)")
+class RateLimitedException(
+    val retryAfterSeconds: Long? = null,
+    val resetEpochSeconds: Long? = null,
+) : Exception("Rate limited by backend (429)")

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendFallbackPolicy.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendFallbackPolicy.kt
@@ -1,0 +1,35 @@
+package zed.rainxch.core.data.network
+
+import zed.rainxch.core.domain.model.RateLimitException
+import zed.rainxch.core.domain.model.RateLimitInfo
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
+
+/**
+ * Centralized policy for backend → direct-GitHub fallback. **Side
+ * effect:** rethrows `CancellationException` so structured concurrency
+ * is preserved, and converts a backend rate-limit into a domain
+ * [RateLimitException] so callers can surface retry-after to the user.
+ */
+fun shouldFallbackToGithubOrRethrow(cause: Throwable): Boolean =
+    when (cause) {
+        is CancellationException -> throw cause
+        is RateLimitedException -> throw cause.toDomainRateLimitException()
+        is BackendException -> cause.statusCode in 500..599
+        else -> true
+    }
+
+private fun RateLimitedException.toDomainRateLimitException(): RateLimitException {
+    val nowSec = Clock.System.now().epochSeconds
+    val reset = resetEpochSeconds
+        ?: retryAfterSeconds?.let { nowSec + it }
+        ?: nowSec
+    return RateLimitException(
+        rateLimitInfo = RateLimitInfo(
+            limit = 0,
+            remaining = 0,
+            resetTimestamp = reset,
+            resource = "backend",
+        ),
+    )
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/StarredRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/StarredRepositoryImpl.kt
@@ -39,6 +39,7 @@ class StarredRepositoryImpl(
     private val installedAppsDao: InstalledAppDao,
     private val platform: Platform,
     private val clientProvider: GitHubClientProvider,
+    private val backendApiClient: zed.rainxch.core.data.network.BackendApiClient,
 ) : StarredRepository {
     private val httpClient: HttpClient get() = clientProvider.client
 
@@ -161,10 +162,34 @@ class StarredRepositoryImpl(
             }
         }
 
+    private fun matchesPlatform(assetName: String): Boolean {
+        val name = assetName.lowercase()
+        return when (platform) {
+            Platform.ANDROID -> name.endsWith(".apk")
+            Platform.WINDOWS -> name.endsWith(".msi") || name.endsWith(".exe")
+            Platform.MACOS -> name.endsWith(".dmg") || name.endsWith(".pkg")
+            Platform.LINUX -> name.endsWith(".appimage") || name.endsWith(".deb") ||
+                name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
+        }
+    }
+
     private suspend fun checkForValidAssets(
         owner: String,
         repo: String,
     ): Boolean {
+        val backendResult = backendApiClient.getReleases(owner, repo, perPage = 10)
+        backendResult.fold(
+            onSuccess = { releases ->
+                val stable = releases.firstOrNull { it.draft != true && it.prerelease != true }
+                    ?: return false
+                if (stable.assets.isEmpty()) return false
+                return stable.assets.any { asset -> matchesPlatform(asset.name) }
+            },
+            onFailure = { error ->
+                if (!zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow(error)) return false
+            },
+        )
+
         return try {
             val releasesResponse =
                 httpClient.get("/repos/$owner/$repo/releases") {

--- a/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/di/SharedModule.kt
+++ b/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/di/SharedModule.kt
@@ -12,6 +12,7 @@ val appsModule =
                 appsRepository = get(),
                 logger = get(),
                 clientProvider = get(),
+                backendApiClient = get(),
                 packageMonitor = get(),
                 tweaksRepository = get(),
             )

--- a/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
+++ b/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
@@ -24,8 +24,10 @@ import zed.rainxch.core.domain.model.ObtainiumExport
 import zed.rainxch.core.data.dto.GithubRepoNetworkModel
 import zed.rainxch.core.data.dto.ReleaseNetwork
 import zed.rainxch.core.data.mappers.toDomain
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.GitHubClientProvider
 import zed.rainxch.core.data.network.executeRequest
+import zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.DeviceApp
 import zed.rainxch.core.domain.model.ExportedApp
@@ -46,6 +48,7 @@ class AppsRepositoryImpl(
     private val appsRepository: InstalledAppsRepository,
     private val logger: GitHubStoreLogger,
     private val clientProvider: GitHubClientProvider,
+    private val backendApiClient: BackendApiClient,
     private val packageMonitor: PackageMonitor,
     private val tweaksRepository: TweaksRepository,
 ) : AppsRepository {
@@ -76,8 +79,23 @@ class AppsRepositoryImpl(
         owner: String,
         repo: String,
         includePreReleases: Boolean,
-    ): GithubRelease? =
-        try {
+    ): GithubRelease? {
+        val backendResult = backendApiClient.getReleases(owner, repo, perPage = 10)
+        backendResult.fold(
+            onSuccess = { releases ->
+                return releases
+                    .asSequence()
+                    .filter { it.draft != true }
+                    .filter { includePreReleases || it.prerelease != true }
+                    .maxByOrNull { it.publishedAt ?: it.createdAt ?: "" }
+                    ?.toDomain()
+            },
+            onFailure = { error ->
+                if (!shouldFallbackToGithubOrRethrow(error)) return null
+            },
+        )
+
+        return try {
             val releases =
                 httpClient
                     .executeRequest<List<ReleaseNetwork>> {
@@ -99,6 +117,7 @@ class AppsRepositoryImpl(
             logger.error("Failed to fetch latest release for $owner/$repo: ${e.message}")
             null
         }
+    }
 
     override suspend fun getDeviceApps(): List<DeviceApp> = packageMonitor.getAllInstalledApps()
 
@@ -112,8 +131,34 @@ class AppsRepositoryImpl(
     override suspend fun fetchRepoInfo(
         owner: String,
         repo: String,
-    ): GithubRepoInfo? =
-        try {
+    ): GithubRepoInfo? {
+        val backendResult = backendApiClient.getRepo(owner, repo)
+        backendResult.fold(
+            onSuccess = { backendRepo ->
+                val includePreReleases = tweaksRepository.getIncludePreReleases().first()
+                val latestTag = if (includePreReleases || backendRepo.latestReleaseTag == null) {
+                    resolveLatestTagViaReleases(owner, repo, includePreReleases)
+                        ?: backendRepo.latestReleaseTag
+                } else {
+                    backendRepo.latestReleaseTag
+                }
+                return GithubRepoInfo(
+                    id = backendRepo.id,
+                    name = backendRepo.name,
+                    owner = backendRepo.owner.login,
+                    ownerAvatarUrl = backendRepo.owner.avatarUrl.orEmpty(),
+                    description = backendRepo.description,
+                    language = backendRepo.language,
+                    htmlUrl = backendRepo.htmlUrl,
+                    latestReleaseTag = latestTag,
+                )
+            },
+            onFailure = { error ->
+                if (!shouldFallbackToGithubOrRethrow(error)) return null
+            },
+        )
+
+        return try {
             val repoModel =
                 httpClient
                     .executeRequest<GithubRepoNetworkModel> {
@@ -123,26 +168,7 @@ class AppsRepositoryImpl(
                     }.getOrThrow()
 
             val includePreReleases = tweaksRepository.getIncludePreReleases().first()
-            val latestTag =
-                try {
-                    val releases =
-                        httpClient
-                            .executeRequest<List<ReleaseNetwork>> {
-                                get("/repos/$owner/$repo/releases") {
-                                    header(HttpHeaders.Accept, "application/vnd.github+json")
-                                    parameter("per_page", 5)
-                                }
-                            }.getOrThrow()
-
-                    releases
-                        .asSequence()
-                        .filter { it.draft != true }
-                        .filter { includePreReleases || it.prerelease != true }
-                        .maxByOrNull { it.publishedAt ?: it.createdAt ?: "" }
-                        ?.tagName
-                } catch (_: Exception) {
-                    null
-                }
+            val latestTag = resolveLatestTagViaReleases(owner, repo, includePreReleases)
 
             GithubRepoInfo(
                 id = repoModel.id,
@@ -160,6 +186,48 @@ class AppsRepositoryImpl(
             logger.error("Failed to fetch repo info for $owner/$repo: ${e.message}")
             null
         }
+    }
+
+    private suspend fun resolveLatestTagViaReleases(
+        owner: String,
+        repo: String,
+        includePreReleases: Boolean,
+    ): String? {
+        val backendReleases = backendApiClient.getReleases(owner, repo, perPage = 5)
+        backendReleases.fold(
+            onSuccess = { releases ->
+                return releases
+                    .asSequence()
+                    .filter { it.draft != true }
+                    .filter { includePreReleases || it.prerelease != true }
+                    .maxByOrNull { it.publishedAt ?: it.createdAt ?: "" }
+                    ?.tagName
+            },
+            onFailure = { error ->
+                if (!shouldFallbackToGithubOrRethrow(error)) return null
+            },
+        )
+
+        return try {
+            val releases =
+                httpClient
+                    .executeRequest<List<ReleaseNetwork>> {
+                        get("/repos/$owner/$repo/releases") {
+                            header(HttpHeaders.Accept, "application/vnd.github+json")
+                            parameter("per_page", 5)
+                        }
+                    }.getOrThrow()
+
+            releases
+                .asSequence()
+                .filter { it.draft != true }
+                .filter { includePreReleases || it.prerelease != true }
+                .maxByOrNull { it.publishedAt ?: it.createdAt ?: "" }
+                ?.tagName
+        } catch (_: Exception) {
+            null
+        }
+    }
 
     override suspend fun linkAppToRepo(
         deviceApp: DeviceApp,

--- a/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/di/SharedModule.kt
+++ b/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/di/SharedModule.kt
@@ -10,6 +10,7 @@ val devProfileModule =
             DeveloperProfileRepositoryImpl(
                 logger = get(),
                 clientProvider = get(),
+                backendApiClient = get(),
                 platform = get(),
                 installedAppsDao = get(),
                 favouritesRepository = get(),

--- a/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/mappers/GithubRepoNetworkModelToGitHubRepoResponse.kt
+++ b/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/mappers/GithubRepoNetworkModelToGitHubRepoResponse.kt
@@ -1,0 +1,22 @@
+package zed.rainxch.devprofile.data.mappers
+
+import zed.rainxch.core.data.dto.GithubRepoNetworkModel
+import zed.rainxch.devprofile.data.dto.GitHubRepoResponse
+
+fun GithubRepoNetworkModel.toGitHubRepoResponse(): GitHubRepoResponse =
+    GitHubRepoResponse(
+        id = id,
+        name = name,
+        fullName = fullName,
+        description = description,
+        htmlUrl = htmlUrl,
+        stargazersCount = stargazersCount,
+        forksCount = forksCount,
+        openIssuesCount = openIssuesCount,
+        language = language,
+        updatedAt = updatedAt,
+        pushedAt = pushedAt,
+        hasDownloads = hasDownloads,
+        archived = archived,
+        fork = fork,
+    )

--- a/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/mappers/UserProfileNetworkToDomain.kt
+++ b/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/mappers/UserProfileNetworkToDomain.kt
@@ -1,0 +1,24 @@
+package zed.rainxch.devprofile.data.mappers
+
+import zed.rainxch.core.data.dto.UserProfileNetwork
+import zed.rainxch.devprofile.domain.model.DeveloperProfile
+
+fun UserProfileNetwork.toDeveloperProfile(): DeveloperProfile =
+    DeveloperProfile(
+        login = login,
+        name = name,
+        avatarUrl = avatarUrl,
+        bio = bio,
+        company = company,
+        location = location,
+        email = email,
+        blog = blog,
+        twitterUsername = twitterUsername,
+        publicRepos = publicRepos,
+        publicGists = publicGists ?: 0,
+        followers = followers,
+        following = following,
+        createdAt = createdAt.orEmpty(),
+        updatedAt = updatedAt.orEmpty(),
+        htmlUrl = htmlUrl,
+    )

--- a/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/repository/DeveloperProfileRepositoryImpl.kt
+++ b/feature/dev-profile/data/src/commonMain/kotlin/zed/rainxch/devprofile/data/repository/DeveloperProfileRepositoryImpl.kt
@@ -17,20 +17,25 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import zed.rainxch.core.data.local.db.dao.InstalledAppDao
+import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.GitHubClientProvider
+import zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.Platform
 import zed.rainxch.core.domain.model.RateLimitException
 import zed.rainxch.core.domain.repository.FavouritesRepository
 import zed.rainxch.devprofile.data.dto.GitHubRepoResponse
 import zed.rainxch.devprofile.data.dto.GitHubUserResponse
+import zed.rainxch.devprofile.data.mappers.toDeveloperProfile
 import zed.rainxch.devprofile.data.mappers.toDomain
+import zed.rainxch.devprofile.data.mappers.toGitHubRepoResponse
 import zed.rainxch.devprofile.domain.model.DeveloperProfile
 import zed.rainxch.devprofile.domain.model.DeveloperRepository
 import zed.rainxch.devprofile.domain.repository.DeveloperProfileRepository
 
 class DeveloperProfileRepositoryImpl(
     private val clientProvider: GitHubClientProvider,
+    private val backendApiClient: BackendApiClient,
     private val platform: Platform,
     private val installedAppsDao: InstalledAppDao,
     private val favouritesRepository: FavouritesRepository,
@@ -40,6 +45,14 @@ class DeveloperProfileRepositoryImpl(
 
     override suspend fun getDeveloperProfile(username: String): Result<DeveloperProfile> {
         return withContext(Dispatchers.IO) {
+            val backendResult = backendApiClient.getUser(username)
+            backendResult.fold(
+                onSuccess = { return@withContext Result.success(it.toDeveloperProfile()) },
+                onFailure = { error ->
+                    if (!shouldFallbackToGithubOrRethrow(error)) return@withContext Result.failure(error)
+                },
+            )
+
             try {
                 val response = httpClient.get("/users/$username")
 
@@ -68,30 +81,56 @@ class DeveloperProfileRepositoryImpl(
                 val allRepos = mutableListOf<GitHubRepoResponse>()
                 var page = 1
                 val perPage = 100
+                var useBackend = true
 
                 while (true) {
-                    val response =
-                        httpClient.get("/users/$username/repos") {
-                            parameter("per_page", perPage)
-                            parameter("page", page)
-                            parameter("type", "owner")
-                            parameter("sort", "updated")
-                            parameter("direction", "desc")
+                    val pageRepos: List<GitHubRepoResponse> = if (useBackend) {
+                        val backendResult = backendApiClient.getUserRepos(
+                            username = username,
+                            page = page,
+                            perPage = perPage,
+                            sort = "updated",
+                            type = "owner",
+                        )
+                        val mapped = backendResult.fold(
+                            onSuccess = { it.map { repo -> repo.toGitHubRepoResponse() } },
+                            onFailure = { error ->
+                                if (!shouldFallbackToGithubOrRethrow(error)) {
+                                    return@withContext Result.failure(error)
+                                }
+                                useBackend = false
+                                null
+                            },
+                        )
+                        if (mapped != null) {
+                            mapped
+                        } else {
+                            continue
+                        }
+                    } else {
+                        val response =
+                            httpClient.get("/users/$username/repos") {
+                                parameter("per_page", perPage)
+                                parameter("page", page)
+                                parameter("type", "owner")
+                                parameter("sort", "updated")
+                                parameter("direction", "desc")
+                            }
+
+                        if (!response.status.isSuccess()) {
+                            return@withContext Result.failure(
+                                Exception("Failed to fetch repositories: ${response.status.description}"),
+                            )
                         }
 
-                    if (!response.status.isSuccess()) {
-                        return@withContext Result.failure(
-                            Exception("Failed to fetch repositories: ${response.status.description}"),
-                        )
+                        response.body()
                     }
 
-                    val repos: List<GitHubRepoResponse> = response.body()
+                    if (pageRepos.isEmpty()) break
 
-                    if (repos.isEmpty()) break
+                    allRepos.addAll(pageRepos.filter { !it.archived && !it.fork })
 
-                    allRepos.addAll(repos.filter { !it.archived && !it.fork })
-
-                    if (repos.size < perPage) break
+                    if (pageRepos.size < perPage) break
                     page++
                 }
 
@@ -154,6 +193,28 @@ class DeveloperProfileRepositoryImpl(
         owner: String,
         repoName: String,
     ): Triple<Boolean, Boolean, String?> {
+        val backendResult = backendApiClient.getReleases(owner, repoName, perPage = 10)
+        backendResult.fold(
+            onSuccess = { releases ->
+                val stableRelease = releases.firstOrNull { it.draft != true && it.prerelease != true }
+                if (stableRelease == null) return Triple(releases.isNotEmpty(), false, null)
+                val hasInstallable = stableRelease.assets.any { asset ->
+                    val name = asset.name.lowercase()
+                    when (platform) {
+                        Platform.ANDROID -> name.endsWith(".apk")
+                        Platform.WINDOWS -> name.endsWith(".msi") || name.endsWith(".exe")
+                        Platform.MACOS -> name.endsWith(".dmg") || name.endsWith(".pkg")
+                        Platform.LINUX -> name.endsWith(".appimage") || name.endsWith(".deb") ||
+                            name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
+                    }
+                }
+                return Triple(true, hasInstallable, stableRelease.tagName)
+            },
+            onFailure = { error ->
+                if (!shouldFallbackToGithubOrRethrow(error)) return Triple(false, false, null)
+            },
+        )
+
         return try {
             val response =
                 httpClient.get("/repos/$owner/$repoName/releases") {


### PR DESCRIPTION
Anon users were hitting GitHub's 60/hr direct limit because several feature repos called \`api.github.com\` directly instead of going through the backend's 4-token pool (20k/hr aggregate). This PR rewires those paths through \`BackendApiClient\` so anon traffic is amplified by the pool.

Builds on backend PR #4 which raised the per-IP search bucket 60→240/min and added \`/v1/users/{u}/repos\` + \`/v1/users/{u}/starred\` passthrough.

## Changes

**Backend client (\`BackendApiClient\`):**
- New methods: \`getUserRepos(username, page, perPage, sort, type)\`, \`getUserStarred(username, page, perPage)\`.
- All read methods now parse \`Retry-After\` + \`X-RateLimit-Reset\` headers on 429 → \`RateLimitedException(retryAfterSeconds, resetEpochSeconds)\`.

**Shared fallback policy (\`BackendFallbackPolicy.kt\`):**
- Extracted \`shouldFallbackToGithubOrRethrow\` from \`DetailsRepositoryImpl\` into a top-level helper. Same semantics: rethrows \`CancellationException\`, falls back on infra/5xx, doesn't fall back on 4xx.
- Backend \`RateLimitedException\` is converted to the domain \`RateLimitException\` and rethrown so callers (Tweaks, Details, Apps) can show the existing rate-limit toast with the backend's \`Retry-After\` baked into \`RateLimitInfo.resetTimestamp\`.

**\`AppsRepositoryImpl\`:**
- \`fetchRepoInfo\` and \`getLatestRelease\` now try \`backendApiClient.getRepo\` / \`getReleases\` first, fall back to direct GitHub on 5xx/infra errors. Kills the rate-limit prompt when adding apps by link or scanning starred repos for APK releases.

**\`StarredRepositoryImpl.checkForValidAssets\`:**
- Per-repo APK probe routes through \`backendApiClient.getReleases\`. Add-from-starred picker scans no longer drain anon's 60/hr budget.

**\`DeveloperProfileRepositoryImpl\`:**
- \`getDeveloperProfile\` (\`/users/{u}\`) → \`backendApiClient.getUser\` (existing endpoint).
- \`getDeveloperRepositories\` (\`/users/{u}/repos\`) → \`backendApiClient.getUserRepos\` (new endpoint from backend PR #4).
- \`checkReleaseInfo\` (\`/repos/{o}/{r}/releases\`) → \`backendApiClient.getReleases\`.
- All three keep the direct path as fallback for backend infra failures.

**DTO compatibility:**
- \`UserProfileNetwork\` extended with \`email\`, \`publicGists\`, \`createdAt\`, \`updatedAt\` (all optional) so backend's \`/v1/user\` passthrough deserializes the same surface dev-profile screen needs.
- \`GithubRepoNetworkModel\` extended with \`archived\`, \`openIssuesCount\`, \`pushedAt\`, \`hasDownloads\` (all optional) for the same reason on \`/v1/users/{u}/repos\`.

## Tradeoffs

- Backend \`RateLimitedException\` is reflected up as the domain \`RateLimitException\` rather than introducing a third class. Existing UI catch sites (8+ in DetailsViewModel, 1 in StarredPickerViewModel) keep working unchanged. The trade is that \`RateLimitInfo.limit\` is set to 0 for backend-origin errors since we don't know the backend's per-IP bucket from a 429 alone — only \`resetTimestamp\` is meaningful. Future improvement: surface \`X-RateLimit-Limit\` / \`X-RateLimit-Remaining\` from backend.
- \`/user/starred\` (signed-in user's own starred list) still goes direct because it's OAuth-bound — backend has no equivalent for this auth flow. Signed-in users hit 5000/hr GitHub anyway, so the only impact is on signed-in-anon edge cases that don't really exist.
- DetailsRepository's secondary GitHub enrichment call (\`openIssues\`/\`license\`) still goes direct. Cached value falls through gracefully on rate-limit. Future: ask backend to include those fields in \`/v1/repo\` so this last call can drop.
- Did not bump UI strings to surface \`Retry-After\` countdown. The plumbing (\`RateLimitInfo.resetTimestamp\`) is in place; UX polish can land separately.

## Test plan

- [ ] Sign out. Open Apps → Add by link → paste \`https://github.com/foo/bar\`. Verify no rate-limit prompt after 5+ adds in a minute.
- [ ] Sign in, open Add from starred picker on an account with 100+ stars. Verify scan completes without 429 (backend pool absorbs).
- [ ] Open Developer Profile screen for a user with 50+ public repos. Verify all repos load + per-repo release-probe completes.
- [ ] Backend deliberately rate-limited (force 429 via curl loop, hit anon bucket): rate-limit toast appears in app with \`RateLimitInfo.resetTimestamp\` populated.
- [ ] Backend offline (5xx) → direct-GitHub fallback fires; same UX as before this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced repository metadata now includes archived status, open issues count, and last push timestamp
  * Expanded user profile information with email, public gists count, and account creation/update timestamps
  * Integrated backend API with automatic GitHub fallback for improved service reliability

* **Bug Fixes**
  * Improved rate limit handling with server-provided reset timing for better retry accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->