### PR TITLE
Rate-limit UX polish (#506, stacks on #505)

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendApiClient.kt
@@ -8,9 +8,12 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.contentLength
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -82,6 +85,11 @@ class BackendApiClient(
                 requestTimeoutMillis = 5_000
                 connectTimeoutMillis = 3_000
                 socketTimeoutMillis = 5_000
+            }
+            install(io.ktor.client.plugins.observer.ResponseObserver) {
+                onResponse { response ->
+                    BackendRateLimitTracker.record(response)
+                }
             }
             defaultRequest {
                 url(BASE_URL)
@@ -370,10 +378,36 @@ class BackendApiClient(
             }
         }
 
-    private fun buildRateLimited(response: io.ktor.client.statement.HttpResponse): RateLimitedException {
-        val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
+    private suspend fun buildRateLimited(response: io.ktor.client.statement.HttpResponse): RateLimitedException {
+        BackendRateLimitTracker.record(response)
+        val headerRetryAfter = response.headers["Retry-After"]?.toLongOrNull()
         val resetEpoch = response.headers["X-RateLimit-Reset"]?.toLongOrNull()
-        return RateLimitedException(retryAfterSeconds = retryAfter, resetEpochSeconds = resetEpoch)
+        val limit = response.headers["X-RateLimit-Limit"]?.toIntOrNull()
+        val bodyRetryAfter = parseRateLimitBody(response)
+        val effectiveRetryAfter = bodyRetryAfter ?: headerRetryAfter
+        return RateLimitedException(
+            retryAfterSeconds = effectiveRetryAfter,
+            resetEpochSeconds = resetEpoch,
+            limit = limit,
+        )
+    }
+
+    private suspend fun parseRateLimitBody(response: io.ktor.client.statement.HttpResponse): Long? {
+        val contentLength = response.contentLength() ?: 0L
+        if (contentLength == 0L) return null
+        return try {
+            val text = response.bodyAsText()
+            if (text.isBlank()) return null
+            val element = Json.parseToJsonElement(text)
+            val obj = element as? kotlinx.serialization.json.JsonObject ?: return null
+            obj["retry_after"]?.let { node ->
+                node as? kotlinx.serialization.json.JsonPrimitive
+            }?.contentOrNull?.toLongOrNull()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
     }
 
     private inline fun <T> safeCall(block: () -> Result<T>): Result<T> =
@@ -399,4 +433,5 @@ class BackendException(
 class RateLimitedException(
     val retryAfterSeconds: Long? = null,
     val resetEpochSeconds: Long? = null,
+    val limit: Int? = null,
 ) : Exception("Rate limited by backend (429)")

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendRateLimitTracker.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendRateLimitTracker.kt
@@ -1,0 +1,43 @@
+package zed.rainxch.core.data.network
+
+import io.ktor.client.statement.HttpResponse
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.time.Clock
+
+object BackendRateLimitTracker {
+    private const val PREEMPT_THRESHOLD = 10
+
+    data class Snapshot(
+        val remaining: Int? = null,
+        val resetEpochSec: Long? = null,
+        val limit: Int? = null,
+    )
+
+    private val state = MutableStateFlow(Snapshot())
+
+    fun record(response: HttpResponse) {
+        val remaining = response.headers["X-RateLimit-Remaining"]?.toIntOrNull()
+        val resetEpoch = response.headers["X-RateLimit-Reset"]?.toLongOrNull()
+        val limit = response.headers["X-RateLimit-Limit"]?.toIntOrNull()
+        if (remaining == null && resetEpoch == null && limit == null) return
+        state.update { current ->
+            current.copy(
+                remaining = remaining ?: current.remaining,
+                resetEpochSec = resetEpoch ?: current.resetEpochSec,
+                limit = limit ?: current.limit,
+            )
+        }
+    }
+
+    fun shouldPreempt(): Boolean {
+        val snapshot = state.value
+        val r = snapshot.remaining ?: return false
+        if (r > PREEMPT_THRESHOLD) return false
+        val resetSec = snapshot.resetEpochSec ?: return r <= 0
+        val now = Clock.System.now().epochSeconds
+        return resetSec > now
+    }
+
+    fun snapshot(): Snapshot = state.value
+}

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -346,6 +346,8 @@
     <string name="updated_on_date">updated on %1$s</string>
 
     <string name="rate_limit_exceeded">Rate Limit Exceeded</string>
+    <string name="rate_limit_exceeded_retry_in">Rate limit hit — retry in %1$ds.</string>
+    <string name="rate_limit_exceeded_signin_hint">Sign in to GitHub for a higher quota.</string>
     <string name="rate_limit_used_all">You've used all %1$d API requests.</string>
     <string name="rate_limit_used_all_free">You've used all %1$d free API requests.</string>
     <string name="rate_limit_resets_in_minutes">Resets in %1$d minutes</string>

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -26,6 +26,7 @@ import zed.rainxch.core.data.mappers.toDomain
 import zed.rainxch.core.data.mappers.toSummary
 import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.BackendException
+import zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow as sharedShouldFallback
 import zed.rainxch.core.data.network.GitHubClientProvider
 import zed.rainxch.core.data.network.executeRequest
 import zed.rainxch.core.data.services.LocalizationManager
@@ -78,11 +79,7 @@ class DetailsRepositoryImpl(
      *     doesn't help and only burns more quota.
      */
     private fun shouldFallbackToGithubOrRethrow(cause: Throwable): Boolean =
-        when (cause) {
-            is CancellationException -> throw cause
-            is BackendException -> cause.statusCode in 500..599
-            else -> true
-        }
+        sharedShouldFallback(cause)
 
     private fun BackendRepoResponse.toBackendSummary(): GithubRepoSummary = toSummary()
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -84,6 +84,8 @@ import zed.rainxch.githubstore.core.presentation.res.installer_saved_downloads
 import zed.rainxch.githubstore.core.presentation.res.releases_unavailable_temporarily
 import zed.rainxch.githubstore.core.presentation.res.link_copied_to_clipboard
 import zed.rainxch.githubstore.core.presentation.res.rate_limit_exceeded
+import zed.rainxch.githubstore.core.presentation.res.rate_limit_exceeded_retry_in
+import zed.rainxch.githubstore.core.presentation.res.rate_limit_exceeded_signin_hint
 import zed.rainxch.githubstore.core.presentation.res.removed_from_favourites
 import zed.rainxch.githubstore.core.presentation.res.translation_failed
 import zed.rainxch.githubstore.core.presentation.res.update_package_mismatch
@@ -2569,10 +2571,18 @@ class DetailsViewModel(
                 observeInstalledApp(repo.id)
             } catch (e: RateLimitException) {
                 logger.error("Rate limited: ${e.message}")
+                val seconds = e.rateLimitInfo.timeUntilReset().inWholeSeconds
+                val message = if (seconds > 0L) {
+                    getString(Res.string.rate_limit_exceeded_retry_in, seconds.toInt()) + " " +
+                        getString(Res.string.rate_limit_exceeded_signin_hint)
+                } else {
+                    getString(Res.string.rate_limit_exceeded) + " " +
+                        getString(Res.string.rate_limit_exceeded_signin_hint)
+                }
                 _state.value =
                     _state.value.copy(
                         isLoading = false,
-                        errorMessage = getString(Res.string.rate_limit_exceeded),
+                        errorMessage = message,
                     )
             } catch (t: Throwable) {
                 logger.error("Details load failed: ${t.message}")


### PR DESCRIPTION
Stacks on #505. After backend ships JSON 429 body + global bucket bump 120→360 + mirrored \`X-RateLimit-*\` headers on 429 (PR confirmed by backend agent), this PR wires up the client side so anon users get a friendly retry-after toast instead of raw \"429: ...\" text.

## Why this exists

#505 routes more anon traffic through the backend pool. Without this PR, when the backend's per-IP global bucket trips, callers see whatever \`e.message\` happens to be — which on the empty-body 429 backend currently returns is unhelpful. After backend's next deploy, 429 will carry \`{\"error\": \"rate_limited\", \"retry_after\": <seconds>}\` and \`X-RateLimit-Remaining\` on every response. This PR consumes both.

## What's in here

**BackendApiClient:**
- \`buildRateLimited\` now reads \`Retry-After\` header **and** the JSON body's \`retry_after\` field (body wins if both present).
- New \`BackendRateLimitTracker\` records \`X-RateLimit-Remaining\` / \`X-RateLimit-Reset\` / \`X-RateLimit-Limit\` from every backend response via \`ResponseObserver\`. Exposes \`shouldPreempt()\` for callers that want to back off proactively before tripping 429 (e.g. starred-picker scan).
- \`RateLimitedException\` extended with \`limit\` field.

**DetailsRepositoryImpl:**
- Replaced its private \`shouldFallbackToGithubOrRethrow\` with the shared one from #505 (\`core.data.network\`). Backend 429 now propagates as domain \`RateLimitException\` — same path Direct GitHub 403 takes — so the existing catch sites in DetailsViewModel fire correctly. **This fixes the regression** where backend 429 was leaking as raw text.

**DetailsViewModel:**
- Rate-limit catch site now formats a richer toast: \`\"Rate limit hit — retry in {N}s. Sign in to GitHub for a higher quota.\"\` Reads \`RateLimitInfo.timeUntilReset()\` (already populated from \`Retry-After\` / \`X-RateLimit-Reset\` via the shared fallback policy).
- Falls back to the original \"Rate Limit Exceeded\" string when reset timestamp is unknown.

**Strings:**
- New \`rate_limit_exceeded_retry_in\` (\`%1$ds\` placeholder) and \`rate_limit_exceeded_signin_hint\`. Existing \`rate_limit_exceeded\` retained for the no-countdown fallback.

## What's NOT in here

- \`BackendRateLimitTracker.shouldPreempt()\` is exposed but not yet consumed by any caller. Wiring into the starred-picker scan and bulk paths comes after we see real-world data on how often the bucket is actually near-exhausted. Premature optimization right now.
- Search VM / DevProfile VM rate-limit messaging is unchanged. They already catch \`RateLimitException\` and show the existing string. After this PR they'll automatically pick up the same flow once \`shouldFallbackToGithubOrRethrow\` (shared) sees backend 429. Optional follow-up: extend their catch sites to format the same retry-in countdown.
- Locale strings for the two new keys ship in English only. The existing project pattern is locale-fallback-to-English, and the strings here are mostly numeric/technical. Translate later in a community pass.

## Test plan

- [ ] Force backend 429 (rapid-fire 130 requests/min from one IP). App shows \"Rate limit hit — retry in 47s. Sign in to GitHub for a higher quota.\" Not raw status code.
- [ ] After waiting the retry window, retry succeeds.
- [ ] \`BackendRateLimitTracker.snapshot()\` populated after first successful response (verifiable via debug logging).
- [ ] DetailsRepository no longer surfaces \`BackendException\` for 429 — domain \`RateLimitException\` is what reaches DetailsViewModel.
- [ ] Existing direct-GitHub 403 anon path still produces same friendly toast.
- [ ] Backend 5xx (network unreachable) → still falls back to direct GitHub.