### PR TITLE
Fix cold-start rate-limit dialog and suppress sign-in hint when signed in

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -58,6 +58,7 @@ val viewModelsModule =
                 telemetryRepository = get(),
                 externalImportRepository = get(),
                 apkInspector = get(),
+                authenticationState = get(),
             )
         }
         viewModelOf(::DeveloperProfileViewModel)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -123,6 +123,7 @@ val coreModule =
                 historyDao = get(),
                 installer = get(),
                 clientProvider = get(),
+                backendApiClient = get(),
             )
         }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -39,6 +39,7 @@ class InstalledAppsRepositoryImpl(
     private val historyDao: UpdateHistoryDao,
     private val installer: Installer,
     private val clientProvider: GitHubClientProvider,
+    private val backendApiClient: zed.rainxch.core.data.network.BackendApiClient,
 ) : InstalledAppsRepository {
     // Reads the current Ktor client at every call site so any proxy
     // change (ProxyManager rebuilds the client via [clientProvider])
@@ -126,6 +127,26 @@ class InstalledAppsRepositoryImpl(
         repo: String,
         includePreReleases: Boolean,
     ): List<GithubRelease> {
+        val backendResult = backendApiClient.getReleases(owner, repo, perPage = RELEASE_WINDOW)
+        val backendReleases = backendResult.fold(
+            onSuccess = { it },
+            onFailure = { error ->
+                if (!zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow(error)) {
+                    return emptyList()
+                }
+                null
+            },
+        )
+        if (backendReleases != null) {
+            return backendReleases
+                .asSequence()
+                .filter { it.draft != true }
+                .sortedByDescending { it.publishedAt ?: it.createdAt ?: "" }
+                .map { it.toDomain() }
+                .filter { includePreReleases || !it.isEffectivelyPreRelease() }
+                .toList()
+        }
+
         return try {
             val releases =
                 httpClient

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -124,6 +124,7 @@ class DetailsViewModel(
     private val telemetryRepository: TelemetryRepository,
     private val externalImportRepository: ExternalImportRepository,
     private val apkInspector: ApkInspector,
+    private val authenticationState: zed.rainxch.core.domain.repository.AuthenticationState,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentDownloadJob: Job? = null
@@ -2572,12 +2573,16 @@ class DetailsViewModel(
             } catch (e: RateLimitException) {
                 logger.error("Rate limited: ${e.message}")
                 val seconds = e.rateLimitInfo.timeUntilReset().inWholeSeconds
-                val message = if (seconds > 0L) {
-                    getString(Res.string.rate_limit_exceeded_retry_in, seconds.toInt()) + " " +
-                        getString(Res.string.rate_limit_exceeded_signin_hint)
+                val signedIn = authenticationState.isCurrentlyUserLoggedIn()
+                val base = if (seconds > 0L) {
+                    getString(Res.string.rate_limit_exceeded_retry_in, seconds.toInt())
                 } else {
-                    getString(Res.string.rate_limit_exceeded) + " " +
-                        getString(Res.string.rate_limit_exceeded_signin_hint)
+                    getString(Res.string.rate_limit_exceeded)
+                }
+                val message = if (!signedIn) {
+                    base + " " + getString(Res.string.rate_limit_exceeded_signin_hint)
+                } else {
+                    base
                 }
                 _state.value =
                     _state.value.copy(


### PR DESCRIPTION
Two fixes that didn't make it into #506 before merge.

## 1. Cold-start rate-limit dialog (the actual bug user reported)

\`MainViewModel.init\` runs \`installedAppsRepository.checkAllForUpdates()\` on every cold start. That fans out **N direct GitHub calls** (one per tracked app) via \`fetchReleaseWindow\`. With anon's 60/hr GitHub limit, users with 30+ tracked apps hit the ceiling on first launch — \`RateLimitInterceptor\` parses the \`X-RateLimit-Remaining: 0\` header and fires the global \`RateLimitDialog\` ("Resets in 31 minutes").

PR #505 didn't catch this because it touched feature-level repos (apps, dev-profile, starred), not the \`InstalledAppsRepository\` cold-start fan-out.

**Fix:** \`fetchReleaseWindow\` now goes backend-first via \`backendApiClient.getReleases\`, falls back to direct GitHub on backend 5xx/infra. Backend pool absorbs the cold-start burst (20k/hr aggregate via 4 PATs) instead of anon hitting 60/hr.

## 2. Sign-in hint shown to already-signed-in users

The retry-after toast in DetailsViewModel always appended "Sign in to GitHub for a higher quota." Pointless when user is already signed in. Now gated on \`authenticationState.isCurrentlyUserLoggedIn()\`.

\`AuthenticationState\` injected into \`DetailsViewModel\`; DI updated in \`ViewModelsModule\`.

## Test plan

- [ ] Cold-start with 50+ tracked apps, anonymous: no rate-limit dialog appears.
- [ ] Cold-start same scenario, signed in: same — no dialog (silently uses backend pool, falls through to direct only on backend 5xx).
- [ ] Backend rate limit hit while signed in → toast: "Rate limit hit — retry in Ns." (no sign-in hint).
- [ ] Backend rate limit hit while signed out → toast: "Rate limit hit — retry in Ns. Sign in to GitHub for a higher quota."
- [ ] Backend offline (5xx) → falls back to direct GitHub, behaves as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced rate-limit error messages with context-aware sign-in suggestions—hint appears only when you're not logged in.
  * Release data fetching now routes through the backend API with automatic fallback for better reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->