### PR TITLE
Fix rate-limit dialog firing on 200 responses + skip Details enrichment when anon

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/RateLimitInterceptor.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/RateLimitInterceptor.kt
@@ -42,9 +42,13 @@ class RateLimitInterceptor(
                 val response = subject
 
                 parseRateLimitFromHeaders(response.headers)?.let { rateLimitInfo ->
-                    plugin.rateLimitRepository.updateRateLimit(rateLimitInfo)
+                    val isErrorResponse = response.status.value == 403 || response.status.value == 429
+                    plugin.rateLimitRepository.updateRateLimit(
+                        rateLimitInfo = rateLimitInfo,
+                        notifyExhausted = isErrorResponse && rateLimitInfo.isExhausted,
+                    )
 
-                    if (response.status.value == 403 && rateLimitInfo.isExhausted) {
+                    if (isErrorResponse && rateLimitInfo.isExhausted) {
                         throw RateLimitException(rateLimitInfo)
                     }
                 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/RateLimitRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/RateLimitRepositoryImpl.kt
@@ -16,9 +16,9 @@ class RateLimitRepositoryImpl : RateLimitRepository {
     private val _rateLimitExhaustedEvent = MutableSharedFlow<RateLimitInfo>(extraBufferCapacity = 1)
     override val rateLimitExhaustedEvent: SharedFlow<RateLimitInfo> = _rateLimitExhaustedEvent
 
-    override fun updateRateLimit(rateLimitInfo: RateLimitInfo?) {
+    override fun updateRateLimit(rateLimitInfo: RateLimitInfo?, notifyExhausted: Boolean) {
         _rateLimitState.value = rateLimitInfo
-        if (rateLimitInfo?.isExhausted == true) {
+        if (notifyExhausted && rateLimitInfo != null) {
             _rateLimitExhaustedEvent.tryEmit(rateLimitInfo)
         }
     }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/RateLimitRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/RateLimitRepository.kt
@@ -8,7 +8,10 @@ interface RateLimitRepository {
     val rateLimitState: StateFlow<RateLimitInfo?>
     val rateLimitExhaustedEvent: SharedFlow<RateLimitInfo>
 
-    fun updateRateLimit(rateLimitInfo: RateLimitInfo?)
+    fun updateRateLimit(
+        rateLimitInfo: RateLimitInfo?,
+        notifyExhausted: Boolean = rateLimitInfo?.isExhausted == true,
+    )
 
     fun getCurrentRateLimit(): RateLimitInfo?
 

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/di/SharedModule.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/di/SharedModule.kt
@@ -19,6 +19,7 @@ val detailsModule =
                 backendApiClient = get(),
                 localizationManager = get(),
                 cacheManager = get(),
+                tokenStore = get(),
             )
         }
 

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -47,6 +47,7 @@ class DetailsRepositoryImpl(
     private val localizationManager: LocalizationManager,
     private val logger: GitHubStoreLogger,
     private val cacheManager: CacheManager,
+    private val tokenStore: zed.rainxch.core.data.data_source.TokenStore,
 ) : DetailsRepository {
     private val httpClient: HttpClient get() = clientProvider.client
 
@@ -489,10 +490,10 @@ class DetailsRepositoryImpl(
             onSuccess = { backendRepo ->
                 logger.debug("Backend hit for repo stats $owner/$repo")
 
-                // Explicit try/catch (not runCatching) so cancellation
-                // propagates — runCatching would swallow it and break
-                // structured concurrency.
-                val githubInfo =
+                val hasToken = runCatching {
+                    tokenStore.currentToken()?.accessToken?.isNotBlank() == true
+                }.getOrDefault(false)
+                val githubInfo = if (hasToken) {
                     try {
                         httpClient.executeRequest<RepoInfoNetwork> {
                             get("/repos/$owner/$repo") {
@@ -505,6 +506,9 @@ class DetailsRepositoryImpl(
                         logger.debug("GitHub enrichment failed for $owner/$repo: ${e.message}")
                         null
                     }
+                } else {
+                    null
+                }
 
                 // If the GitHub enrichment didn't land, reuse the stale
                 // cached openIssues/license from a previous successful


### PR DESCRIPTION
Two related fixes for the residual rate-limit dialog on Details screen.

## 1. \`RateLimitInterceptor\` was firing global dialog on successful responses

The interceptor parses \`X-RateLimit-Remaining\` from every direct GitHub response. When the value reaches 0 (anon tipped over the 60/hr boundary), \`rateLimitRepository.updateRateLimit\` was emitting \`rateLimitExhaustedEvent\` **even on 200 responses**. \`MainViewModel\` collects that event and pops the global \`RateLimitDialog\` ("Resets in 31 minutes").

Result: user sees the dialog after a successful Details load, because the secondary GitHub enrichment call tipped \`remaining\` to 0 on its way back with valid data.

**Fix:** \`updateRateLimit\` now takes an explicit \`notifyExhausted\` flag. Interceptor only sets it true on actual error responses (403/429). State tracking (the \`StateFlow\` that powers the rate-limit indicator chip) still updates on every response. Domain interface signature backward-compatible — default value preserves existing behavior at the type level for any other callers.

## 2. Details \`getRepoStats\` enrichment burns anon's 60/hr for openIssues/license

\`DetailsRepositoryImpl.getRepoStats\` calls backend first (provides stars/forks/downloads), then makes a **direct GitHub call** to enrich with \`openIssues\` and \`license\` fields that backend doesn't expose. For anon users, this single enrichment call is 1/60 of their hourly budget — for a non-critical UI field. Cached stale value falls through gracefully on absence.

**Fix:** gate the enrichment on \`tokenStore.currentToken()\`. Signed-in users (5000/hr quota) keep getting enriched stats. Anon users skip it entirely — backend stats only. \`openIssues\` falls back to stale cache or 0; \`license\` falls back to stale cache or null. Same UX as if the GitHub call had failed silently.

Better long-term: ask backend to add \`openIssues\` and \`license\` to \`/v1/repo\` so signed-in users don't need this either. Tracked separately.

## Test plan

- [ ] Anon, open Details on a fresh repo: backend-only stats render. No global rate-limit dialog. No 60/hr drain on this open.
- [ ] Signed-in, open Details: enrichment fires, openIssues + license populate.
- [ ] Anon, hit GitHub direct rate limit elsewhere (e.g. via existing direct path that's still anon): 403 + exhausted → dialog fires correctly. Bug fix doesn't suppress legit dialog.
- [ ] State chip / \`rateLimitState\` flow still updates on every response (verify via existing UI affordance if any reads it).

Independent of #505/#506/#507 in scope. Branches off main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository details now display correctly when unauthenticated, using cached information where available
  * Improved rate limit detection and error notification handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->