### PR TITLE
Redesign Details ErrorState as expressive card

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -206,7 +206,7 @@
     <string name="error_state_subtitle_offline">Check your connection and try again.</string>
     <string name="error_state_subtitle_rate_limit">GitHub or our backend hit a quota. Try again in a moment.</string>
     <string name="error_state_subtitle_not_found">The repository may be private, renamed, or deleted.</string>
-    <string name="error_state_subtitle_generic">We couldn\'t load this repo. Pull to retry below.</string>
+    <string name="error_state_subtitle_generic">We couldn\'t load this repo. Use the Retry button below.</string>
     <string name="retry">Retry</string>
     <string name="error_state_go_back">Go back</string>
     <string name="no_description">No description provided.</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -199,7 +199,16 @@
 
     <!-- Errors & states -->
     <string name="error_loading_details">Error loading details</string>
+    <string name="error_state_title_generic">Something went wrong</string>
+    <string name="error_state_title_offline">You\'re offline</string>
+    <string name="error_state_title_rate_limit">Rate limit hit</string>
+    <string name="error_state_title_not_found">Repository not found</string>
+    <string name="error_state_subtitle_offline">Check your connection and try again.</string>
+    <string name="error_state_subtitle_rate_limit">GitHub or our backend hit a quota. Try again in a moment.</string>
+    <string name="error_state_subtitle_not_found">The repository may be private, renamed, or deleted.</string>
+    <string name="error_state_subtitle_generic">We couldn\'t load this repo. Pull to retry below.</string>
     <string name="retry">Retry</string>
+    <string name="error_state_go_back">Go back</string>
     <string name="no_description">No description provided.</string>
     <string name="no_release_notes">No release notes.</string>
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/states/ErrorState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/states/ErrorState.kt
@@ -1,47 +1,211 @@
 package zed.rainxch.details.presentation.components.states
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.SearchOff
+import androidx.compose.material.icons.outlined.SentimentDissatisfied
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-import zed.rainxch.core.presentation.components.GithubStoreButton
+import zed.rainxch.core.presentation.components.ExpressiveCard
 import zed.rainxch.details.presentation.DetailsAction
-import zed.rainxch.githubstore.core.presentation.res.*
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.error_state_go_back
+import zed.rainxch.githubstore.core.presentation.res.error_state_subtitle_generic
+import zed.rainxch.githubstore.core.presentation.res.error_state_subtitle_not_found
+import zed.rainxch.githubstore.core.presentation.res.error_state_subtitle_offline
+import zed.rainxch.githubstore.core.presentation.res.error_state_subtitle_rate_limit
+import zed.rainxch.githubstore.core.presentation.res.error_state_title_generic
+import zed.rainxch.githubstore.core.presentation.res.error_state_title_not_found
+import zed.rainxch.githubstore.core.presentation.res.error_state_title_offline
+import zed.rainxch.githubstore.core.presentation.res.error_state_title_rate_limit
+import zed.rainxch.githubstore.core.presentation.res.retry
 
 @Composable
 fun ErrorState(
     errorMessage: String,
     onAction: (DetailsAction) -> Unit,
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+    val kind = classify(errorMessage)
+    Box(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = stringResource(Res.string.error_loading_details),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Center,
-        )
+        ExpressiveCard(
+            modifier = Modifier.widthIn(max = 480.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                IconBadge(icon = kind.icon, tint = kind.tint())
 
-        Text(
-            text = errorMessage,
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.error,
-        )
+                Text(
+                    text = stringResource(kind.titleRes),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
 
-        GithubStoreButton(
-            text = stringResource(Res.string.retry),
-            onClick = {
-                onAction(DetailsAction.Retry)
-            },
+                Text(
+                    text = stringResource(kind.subtitleRes),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+
+                if (errorMessage.isNotBlank() && !kind.hideRawMessage) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = errorMessage,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                    )
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    TextButton(
+                        onClick = { onAction(DetailsAction.OnNavigateBackClick) },
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.error_state_go_back),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    Button(
+                        onClick = { onAction(DetailsAction.Retry) },
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(16.dp),
+                        contentPadding = PaddingValues(vertical = 12.dp),
+                        colors = ButtonDefaults.buttonColors(),
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.retry),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconBadge(icon: ImageVector, tint: Color) {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .clip(CircleShape)
+            .background(tint.copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(36.dp),
         )
+    }
+}
+
+private enum class ErrorKind(
+    val icon: ImageVector,
+    val titleRes: StringResource,
+    val subtitleRes: StringResource,
+    val hideRawMessage: Boolean = false,
+) {
+    OFFLINE(
+        icon = Icons.Outlined.CloudOff,
+        titleRes = Res.string.error_state_title_offline,
+        subtitleRes = Res.string.error_state_subtitle_offline,
+        hideRawMessage = true,
+    ),
+    RATE_LIMIT(
+        icon = Icons.Outlined.HourglassEmpty,
+        titleRes = Res.string.error_state_title_rate_limit,
+        subtitleRes = Res.string.error_state_subtitle_rate_limit,
+        hideRawMessage = false,
+    ),
+    NOT_FOUND(
+        icon = Icons.Outlined.SearchOff,
+        titleRes = Res.string.error_state_title_not_found,
+        subtitleRes = Res.string.error_state_subtitle_not_found,
+        hideRawMessage = true,
+    ),
+    GENERIC(
+        icon = Icons.Outlined.SentimentDissatisfied,
+        titleRes = Res.string.error_state_title_generic,
+        subtitleRes = Res.string.error_state_subtitle_generic,
+    ),
+}
+
+@Composable
+private fun ErrorKind.tint(): Color = when (this) {
+    ErrorKind.OFFLINE -> MaterialTheme.colorScheme.tertiary
+    ErrorKind.RATE_LIMIT -> MaterialTheme.colorScheme.tertiary
+    ErrorKind.NOT_FOUND -> MaterialTheme.colorScheme.secondary
+    ErrorKind.GENERIC -> MaterialTheme.colorScheme.error
+}
+
+private fun classify(message: String): ErrorKind {
+    val lower = message.lowercase()
+    return when {
+        lower.contains("rate limit") || lower.contains("retry in") || lower.contains("429") ->
+            ErrorKind.RATE_LIMIT
+        lower.contains("404") || lower.contains("not found") -> ErrorKind.NOT_FOUND
+        lower.contains("unable to resolve host") ||
+            lower.contains("unknownhost") ||
+            lower.contains("connection refused") ||
+            lower.contains("network is unreachable") ||
+            lower.contains("timeout") ||
+            lower.contains("offline") -> ErrorKind.OFFLINE
+        else -> ErrorKind.GENERIC
     }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/states/ErrorState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/states/ErrorState.kt
@@ -88,7 +88,7 @@ fun ErrorState(
                     textAlign = TextAlign.Center,
                 )
 
-                if (errorMessage.isNotBlank() && !kind.hideRawMessage) {
+                if (kind == ErrorKind.RATE_LIMIT && errorMessage.isNotBlank()) {
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = errorMessage,


### PR DESCRIPTION
The Details error UI was three left-aligned text labels stacked at top — ugly and uninformative. This PR replaces it with a centered expressive card that classifies the error and shows a contextual icon, title, subtitle, and dual-action footer.

## Classifier

The error message string is sniffed for keywords to pick one of four kinds:

| Kind | Trigger keywords | Icon | Title | Subtitle |
|---|---|---|---|---|
| Rate limit | "rate limit", "retry in", "429" | HourglassEmpty (tertiary) | Rate limit hit | GitHub or our backend hit a quota. Try again in a moment. |
| Offline | "unable to resolve host", "unknownhost", "connection refused", "network is unreachable", "timeout", "offline" | CloudOff (tertiary) | You're offline | Check your connection and try again. |
| Not found | "404", "not found" | SearchOff (secondary) | Repository not found | The repository may be private, renamed, or deleted. |
| Generic | (anything else) | SentimentDissatisfied (error) | Something went wrong | We couldn't load this repo. Pull to retry below. |

For rate limit, the original message (e.g. "Rate limit hit — retry in 47s.") shows under the subtitle in a chip-styled box so the countdown stays visible. Other kinds hide the raw error to avoid leaking internals; the friendly subtitle covers it.

## Layout

- Centered \`ExpressiveCard\` wrapper, max width 480dp (looks right on phone + tablet).
- 72dp circular icon badge with tinted-15%-alpha background.
- Headline-small title, body-medium subtitle, both centered.
- Footer row: "Go back" (TextButton, weight 1) + "Retry" (filled Button, weight 1) — equal-width, dual-action.
- 32.dp rounded corners (matches \`ExpressiveCard\`'s house style).

## Strings

8 new keys (English only — locale fallback per project pattern). Existing \`error_loading_details\` and \`retry\` retained for backward compat.

## Test plan

- [ ] Trigger rate-limit on Details (e.g., burst /v1/repo until 429): card shows hourglass icon, "Rate limit hit", retry countdown chip, both buttons work.
- [ ] Airplane mode → open Details: cloud-off icon, "You're offline", retry succeeds when connection returns.
- [ ] Open Details on a deleted repo URL: search-off icon, "Repository not found".
- [ ] Force a 5xx (mock backend): generic kind with sad-face icon and full error text.
- [ ] Tap "Go back": navigates up. Tap "Retry": refetches.
- [ ] Long-pressing an error message doesn't break a11y — full message is in the chip when shown, otherwise hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error screens with a card-based layout, localized titles and subtitles for generic, offline, rate-limit, and not-found errors.
  * Added a "Go back" action alongside existing retry; raw error details are shown only when appropriate (rate-limit).
  * Introduced icon badges and contextual visuals to better indicate error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->