### PR TITLE
fix(whatsnew): defeat locale race by threading tag explicitly to loader

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewLoaderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewLoaderImpl.kt
@@ -18,15 +18,16 @@ class WhatsNewLoaderImpl(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun loadAll(): List<WhatsNewEntry> =
+    override suspend fun loadAll(languageTag: String?): List<WhatsNewEntry> =
         knownVersionCodes
-            .mapNotNull { vc -> loadOrNull(vc) }
+            .mapNotNull { vc -> loadOrNull(vc, languageTag) }
             .sortedByDescending { it.versionCode }
 
-    override suspend fun forVersionCode(versionCode: Int): WhatsNewEntry? = loadOrNull(versionCode)
+    override suspend fun forVersionCode(versionCode: Int, languageTag: String?): WhatsNewEntry? =
+        loadOrNull(versionCode, languageTag)
 
-    private suspend fun loadOrNull(versionCode: Int): WhatsNewEntry? {
-        val candidates = candidatePaths(versionCode)
+    private suspend fun loadOrNull(versionCode: Int, languageTag: String?): WhatsNewEntry? {
+        val candidates = candidatePaths(versionCode, languageTag)
         for (path in candidates) {
             val parsed = readEntry(path)
             if (parsed != null) return parsed
@@ -34,9 +35,17 @@ class WhatsNewLoaderImpl(
         return null
     }
 
-    private fun candidatePaths(versionCode: Int): List<String> {
-        val full = localizationManager.getCurrentLanguageCode()
-        val primary = localizationManager.getPrimaryLanguageCode()
+    private fun candidatePaths(versionCode: Int, languageTag: String?): List<String> {
+        // Explicit tag passed in wins over global Locale lookup —
+        // prevents the race with MainActivity's `setActiveLanguageTag`
+        // when both this VM and MainActivity subscribe to the same
+        // `getAppLanguage()` flow (#526 follow-up).
+        val (full, primary) = if (!languageTag.isNullOrBlank()) {
+            languageTag to languageTag.substringBefore('-')
+        } else {
+            localizationManager.getCurrentLanguageCode() to
+                localizationManager.getPrimaryLanguageCode()
+        }
         val paths = LinkedHashSet<String>()
         if (full.isNotBlank()) paths += "files/whatsnew/$full/$versionCode.json"
         if (primary.isNotBlank() && primary != full) paths += "files/whatsnew/$primary/$versionCode.json"

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewViewModel.kt
@@ -31,20 +31,27 @@ class WhatsNewViewModel(
     private val _hasHistory = MutableStateFlow(false)
     val hasHistory: StateFlow<Boolean> = _hasHistory.asStateFlow()
 
+    @Volatile
+    private var lastLanguageTag: String? = null
+
     init {
         // Re-load whenever the user's selected app language changes.
-        // The loader resolves locale per call, but cached state on this
-        // VM would otherwise serve the previous language's text after
-        // the user switches in Tweaks. distinctUntilChanged guards
-        // against the initial replay-emit firing the load twice.
+        // The tag is threaded explicitly into the loader so we beat
+        // the race against MainActivity's setActiveLanguageTag — both
+        // collectors fan out from the same flow with no ordering
+        // guarantee, so reading Locale.getDefault() inside the loader
+        // can return the previous language. distinctUntilChanged
+        // guards against the initial replay-emit firing the load
+        // twice.
         viewModelScope.launch {
             try {
                 tweaksRepository
                     .getAppLanguage()
                     .distinctUntilChanged()
-                    .collect {
-                        reloadHistory()
-                        reloadPending()
+                    .collect { tag ->
+                        lastLanguageTag = tag
+                        reloadHistory(tag)
+                        reloadPending(tag)
                     }
             } catch (t: Throwable) {
                 logger.e(t) { "Failed to observe app-language for what's-new reloads" }
@@ -52,9 +59,9 @@ class WhatsNewViewModel(
         }
     }
 
-    private suspend fun reloadHistory() {
+    private suspend fun reloadHistory(languageTag: String?) {
         try {
-            val entries = whatsNewLoader.loadAll()
+            val entries = whatsNewLoader.loadAll(languageTag)
             _historyEntries.value = entries
             _hasHistory.value = entries.size > 1
         } catch (t: Throwable) {
@@ -62,21 +69,21 @@ class WhatsNewViewModel(
         }
     }
 
-    private suspend fun reloadPending() {
+    private suspend fun reloadPending(languageTag: String?) {
         try {
-            evaluate()
+            evaluate(languageTag)
         } catch (t: Throwable) {
             logger.e(t) { "Failed to evaluate what's-new state" }
         }
     }
 
-    private suspend fun evaluate() {
+    private suspend fun evaluate(languageTag: String? = lastLanguageTag) {
         val current = appVersionInfo.versionCode
         val lastSeen = tweaksRepository.getLastSeenWhatsNewVersionCode().first() ?: Int.MIN_VALUE
 
         if (lastSeen >= current) return
 
-        val entry = whatsNewLoader.forVersionCode(current)
+        val entry = whatsNewLoader.forVersionCode(current, languageTag)
         if (entry == null || !entry.showAsSheet) {
             tweaksRepository.setLastSeenWhatsNewVersionCode(current)
             return
@@ -100,10 +107,11 @@ class WhatsNewViewModel(
     fun forceShowLatest() {
         viewModelScope.launch {
             try {
+                val tag = lastLanguageTag
                 val current = appVersionInfo.versionCode
                 val entry =
-                    whatsNewLoader.forVersionCode(current)
-                        ?: whatsNewLoader.loadAll().firstOrNull()
+                    whatsNewLoader.forVersionCode(current, tag)
+                        ?: whatsNewLoader.loadAll(tag).firstOrNull()
                         ?: return@launch
                 _pendingEntry.value = entry
             } catch (t: Throwable) {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/WhatsNewLoader.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/WhatsNewLoader.kt
@@ -3,7 +3,18 @@ package zed.rainxch.core.domain.repository
 import zed.rainxch.core.domain.model.WhatsNewEntry
 
 interface WhatsNewLoader {
-    suspend fun loadAll(): List<WhatsNewEntry>
+    /**
+     * Optional explicit BCP-47 [languageTag] (e.g. `"zh-CN"`, `"fr"`,
+     * `null`). When non-null, this takes precedence over the global
+     * `LocalizationManager` lookup — used to defeat the race where the
+     * `getAppLanguage()` flow fans out to multiple subscribers and the
+     * loader runs before the global `Locale.getDefault()` has caught up
+     * with the user's just-picked language. Null falls back to
+     * whatever `LocalizationManager.getCurrentLanguageCode()` returns
+     * at call time (suitable for paths where the tag isn't known
+     * upfront, e.g. a deep-linked one-shot load).
+     */
+    suspend fun loadAll(languageTag: String? = null): List<WhatsNewEntry>
 
-    suspend fun forVersionCode(versionCode: Int): WhatsNewEntry?
+    suspend fun forVersionCode(versionCode: Int, languageTag: String? = null): WhatsNewEntry?
 }


### PR DESCRIPTION
## Bug
After #526 the what's-new sheet/history still showed stale-language content when switching app language. Reporter confirmed it's reproducible on the merged build.

## Root cause
\`WhatsNewLoaderImpl\` resolved the locale via \`localizationManager.getCurrentLanguageCode()\` → \`Locale.getDefault()\`. That's a *mutable global* updated by \`MainActivity.setActiveLanguageTag()\`.

Both the WhatsNewVM and MainActivity subscribe to the same \`tweaksRepository.getAppLanguage()\` flow. No ordering guarantee between subscribers. When the VM's collector fired first, the loader read \`Locale.getDefault()\` *before* MainActivity had a chance to call \`setActiveLanguageTag()\` → loader resolved the *previous* locale → stale content cached. \`recreate()\` afterwards preserved the ViewModelStore + the stale cache.

## Fix
Thread the BCP-47 tag explicitly from the flow value into \`WhatsNewLoader\`:
- \`WhatsNewLoader.loadAll(languageTag: String?)\` and \`forVersionCode(versionCode, languageTag)\` now take an optional explicit tag.
- \`WhatsNewLoaderImpl.candidatePaths\` honors the explicit tag when non-null; falls back to \`LocalizationManager\` only when the caller didn't supply one (preserves the deep-link / one-shot path).
- \`WhatsNewViewModel\` stashes the latest emitted tag in \`lastLanguageTag\` and threads it through every loader call (\`reloadHistory\`, \`reloadPending\`, \`evaluate\`, \`forceShowLatest\`).

Net result: the loader's resolved locale comes from the same flow value that's about to update the global \`Locale.getDefault()\`, so the order between subscribers no longer matters.

## Test plan
- [ ] Switch language in Tweaks while what's-new sheet is up → content swaps to new language live (no race).
- [ ] Cold-start with previously-picked language → sheet/history render in that language.
- [ ] Profile → "Show latest what's-new" after language switch → renders in current language.
- [ ] Regression: user who never picked a language sees device-default locale (loader falls back to \`LocalizationManager.getCurrentLanguageCode()\` when tag is null, same as before #526).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "What's New" content now displays in your app's selected language. The system automatically loads language-specific release notes to ensure you receive updates in your preferred language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->