### PR TITLE
chore(tweaks): settings bug-bash pass — 4 small fixes (E3 R5)

### DIFF
--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
@@ -121,8 +121,6 @@ sealed interface TweaksAction {
 
     data object OnClearDownloadsDismiss : TweaksAction
 
-    data object OnHelpClick : TweaksAction
-
     data object OnFeedbackClick : TweaksAction
 
     data object OnFeedbackDismiss : TweaksAction

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -20,6 +20,7 @@ import zed.rainxch.core.domain.model.ProxyConfig
 import zed.rainxch.core.domain.model.ProxyScope
 import zed.rainxch.core.domain.model.TranslationProvider
 import zed.rainxch.core.domain.network.ProxyTestOutcome
+import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.network.ProxyTester
 import zed.rainxch.core.domain.repository.DeviceIdentityRepository
 import zed.rainxch.core.domain.repository.ProxyRepository
@@ -28,7 +29,6 @@ import zed.rainxch.core.domain.repository.TelemetryRepository
 import zed.rainxch.core.domain.repository.TweaksRepository
 import zed.rainxch.core.domain.system.InstallerStatusProvider
 import zed.rainxch.core.domain.system.UpdateScheduleManager
-import zed.rainxch.core.domain.utils.BrowserHelper
 import zed.rainxch.tweaks.presentation.model.ProxyScopeFormState
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_save_proxy_settings
@@ -44,7 +44,6 @@ import zed.rainxch.profile.domain.repository.ProfileRepository
 import zed.rainxch.tweaks.presentation.model.ProxyType
 
 class TweaksViewModel(
-    private val browserHelper: BrowserHelper,
     private val tweaksRepository: TweaksRepository,
     private val profileRepository: ProfileRepository,
     private val installerStatusProvider: InstallerStatusProvider,
@@ -54,6 +53,7 @@ class TweaksViewModel(
     private val seenReposRepository: SeenReposRepository,
     private val deviceIdentityRepository: DeviceIdentityRepository,
     private val telemetryRepository: TelemetryRepository,
+    private val logger: GitHubStoreLogger,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var cacheSizeJob: Job? = null
@@ -315,7 +315,7 @@ class TweaksViewModel(
                     )
                 }
             }.onFailure { error ->
-                println("TweaksViewModel: failed to persist installer attribution: ${error.message}")
+                logger.error("TweaksViewModel: failed to persist installer attribution", error)
                 _state.update {
                     it.copy(installerAttributionCustomError = "write_failed")
                 }
@@ -327,7 +327,7 @@ class TweaksViewModel(
         viewModelScope.launch {
             tweaksRepository.getInstallerAttribution()
                 .catch { e ->
-                    println("TweaksViewModel: installer attribution flow error: ${e.message}")
+                    logger.error("TweaksViewModel: installer attribution flow error", e)
                 }
                 .collect { attribution ->
                     _state.update { current ->
@@ -678,7 +678,7 @@ class TweaksViewModel(
                         }.onSuccess {
                             _state.update { it.copy(installerAttributionCustomError = null) }
                         }.onFailure { error ->
-                            println("TweaksViewModel: failed to persist installer attribution: ${error.message}")
+                            logger.error("TweaksViewModel: failed to persist installer attribution", error)
                             _state.update { it.copy(installerAttributionCustomError = "write_failed") }
                         }
                     }
@@ -766,12 +766,6 @@ class TweaksViewModel(
 
             TweaksAction.OnClearDownloadsDismiss -> {
                 _state.update { it.copy(isClearDownloadsDialogVisible = false) }
-            }
-
-            TweaksAction.OnHelpClick -> {
-                browserHelper.openUrl(
-                    url = "https://github.com/OpenHub-Store/GitHub-Store/issues",
-                )
             }
 
             TweaksAction.OnMirrorPickerClick -> {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/About.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/About.kt
@@ -1,6 +1,8 @@
 package zed.rainxch.tweaks.presentation.components.sections
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -25,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -113,18 +117,18 @@ private fun AboutItem(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(
-            shapes = IconButtonDefaults.shapes(),
-            onClick = { },
-            colors =
-                IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                ),
+        Box(
+            modifier =
+                Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
                 modifier = Modifier.size(24.dp),
             )
         }

--- a/feature/tweaks/presentation/src/jvmMain/kotlin/zed/rainxch/tweaks/presentation/RestartApp.jvm.kt
+++ b/feature/tweaks/presentation/src/jvmMain/kotlin/zed/rainxch/tweaks/presentation/RestartApp.jvm.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.tweaks.presentation
 
+import co.touchlab.kermit.Logger
 import kotlin.system.exitProcess
 
 /**
@@ -29,18 +30,17 @@ actual fun restartAppAfterLanguageChange() {
                 .inheritIO()
                 .start()
         } else {
-            System.err.println(
-                "restartAppAfterLanguageChange: ProcessHandle has no command; exiting without relaunch",
-            )
+            Logger.w {
+                "restartAppAfterLanguageChange: ProcessHandle has no command; exiting without relaunch"
+            }
         }
     } catch (t: Throwable) {
         // Swallow: we'd rather exit cleanly than leave the user in a
         // limbo where the app is stuck with the old locale because
-        // the relaunch errored out. stderr so packaging regressions
-        // are still noticeable in logs without adding a logging dep.
-        System.err.println(
-            "restartAppAfterLanguageChange: relaunch failed (${t.javaClass.simpleName}: ${t.message}), falling back to plain exit",
-        )
+        // the relaunch errored out.
+        Logger.w(t) {
+            "restartAppAfterLanguageChange: relaunch failed, falling back to plain exit"
+        }
     }
     exitProcess(0)
 }


### PR DESCRIPTION
Static-audit pass over the Tweaks surface (8 sections, ~2.5K LOC) per Foundation Sprint Task 3 / E3 R5 brief. Surfaced 4 concrete code-level findings; manual interactive bug-bash on real devices is queued separately.

## Bugs fixed

| # | Severity | Location | Fix |
|---|---|---|---|
| 1 | low | `TweaksViewModel.kt` (3 sites) | Replaced `println(...)` with the injected `GitHubStoreLogger`. Failures in the installer-attribution flow now reach Desktop crash-log + Android Logcat through the same pipeline as the rest of the repo. |
| 2 | low (a11y) | `About.kt` `AboutItem` | Leading decorative icon was wrapped in an `IconButton` with `onClick = { }`, exposing an interactive Button role + ripple to TalkBack. Replaced with a non-clickable `Box` carrying the same shape + container colour. |
| 3 | low (dead code) | `TweaksAction.kt`, `TweaksViewModel.kt` | `OnHelpClick` action was defined + handled (opened the GitHub issues page) but never emitted from any composable. Action removed; dead `BrowserHelper` constructor dependency dropped. |
| 4 | low | `RestartApp.jvm.kt` (2 sites) | Two `System.err.println` log lines bypassed the Desktop crash-reporter pipeline. The "without adding a logging dep" rationale was stale — Kermit is already transitively available. Routed through `co.touchlab.kermit.Logger`. |

## Issues noted but skipped (with reasoning)

- **Telemetry UI is dead** per CLAUDE.md "no production telemetry of any kind ships" — but the toggle does still flip a real DataStore flag that `TelemetryRepositoryImpl.flushPending` consults. Removing the UI is a strategic decision, not a bug. File a separate task if the call is to fully strip.
- **`refreshCacheSize` re-launch**: verified safe — `observeCacheSize()` is a single-emit cold flow; the collect job completes after one emission, so the manual-refresh tap correctly relaunches.
- **`OnProxyTypeSelected` re-fires save when re-tapping the current type**: idempotent DataStore write, no observable harm.

## Tests deferred to interactive bug-bash

The static audit cannot prove these — the operator should run a device-side pass to verify:

- Theme color change applies live (no app restart)
- Proxy URL with invalid host surfaces clear error
- Mirror picker auto-suggest connection-test refreshes after re-open
- Update interval persists across app upgrade
- Auto-update toggle actually disables the Worker
- Cache-clear actually clears all caches
- Translation provider switch from Google → Youdao with creds present commits + activates immediately
- Send-feedback flow end-to-end on email + GitHub paths

Findings doc at `roadmap/E3_R5_SETTINGS_BUGBASH.md` (gitignored) tracks the full audit + checklist for the device pass.

## Test plan

- Compile clean: `:feature:tweaks:presentation:compileDebugKotlinAndroid` ✅, `:feature:tweaks:presentation:compileKotlinJvm` ✅, `:composeApp:compileDebugKotlinAndroid` ✅.
- Manual smoke (Tweaks surface):
  - [ ] Open Tweaks → About → tap leading info icon → no ripple, no a11y "Button" announcement.
  - [ ] Switch installer attribution to Custom with invalid package name → error supportingText shows + Logcat now carries the failure tag (was a `println` before).
  - [ ] Desktop: trigger language change → Logcat shows the restart attempt through Kermit.

## What's-new

Skipped — these are silent internal cleanups (no user-visible behaviour change). Per the headline-only what's-new philosophy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Help button functionality has been removed from the Tweaks settings.

* **Style Changes**
  * Help icon in the About section is now visually redesigned as a non-interactive element.

* **Improvements**
  * Enhanced error logging mechanism for installer-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->