### PR TITLE
chore(gitignore): exclude .brain working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ composeApp/release/baselineProfiles/
 composeApp/kotzilla.json
 
 roadmap/
+.brain/


### PR DESCRIPTION
Adds `.brain/` to `.gitignore` so the local strategy/research scratch directory cannot be accidentally staged via `git add -A`. Mirrors the existing `roadmap/` exclusion. Zero code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to ignore additional development and planning directories in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->