### PR TITLE
fix(install): unstick install gate + clean download log noise

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
@@ -172,6 +172,15 @@ class AndroidDownloader(
                         if (total != null) ((finalDownloaded * 100L) / total).toInt() else 100
                     emit(DownloadProgress(finalDownloaded, total, finalPercent))
                 }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                // Cancellation is the normal MultiSourceDownloader race
+                // outcome (loser racer cancelled when winner emits first
+                // progress). Don't log it as an error — that floods
+                // Logcat with confusing red lines that look like real
+                // download failures. Clean up the temp file and rethrow
+                // so structured concurrency stays correct.
+                tempFile.delete()
+                throw e
             } catch (e: Exception) {
                 tempFile.delete()
                 Logger.e(e) { "Download failed" }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultSystemInstallSerializer.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultSystemInstallSerializer.kt
@@ -13,6 +13,13 @@ class DefaultSystemInstallSerializer : SystemInstallSerializer {
         packageName: String,
         timeoutMs: Long,
     ) {
+        val initiallyHeldBy = pending.value
+        if (initiallyHeldBy != null) {
+            Logger.i {
+                "SystemInstallSerializer: $packageName waiting for $initiallyHeldBy to clear " +
+                    "(timeout ${timeoutMs}ms)"
+            }
+        }
         val acquired =
             withTimeoutOrNull(timeoutMs) {
                 while (!pending.compareAndSet(null, packageName)) {
@@ -25,6 +32,10 @@ class DefaultSystemInstallSerializer : SystemInstallSerializer {
                 "SystemInstallSerializer: timed out waiting for ${pending.value} to clear; force-claiming for $packageName"
             }
             pending.value = packageName
+        } else if (initiallyHeldBy != null) {
+            Logger.i {
+                "SystemInstallSerializer: $packageName acquired gate after waiting for $initiallyHeldBy"
+            }
         }
     }
 

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/SystemInstallSerializer.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/system/SystemInstallSerializer.kt
@@ -9,6 +9,14 @@ interface SystemInstallSerializer {
     fun markCompleted(packageName: String)
 
     companion object {
-        const val DEFAULT_TIMEOUT_MS: Long = 60_000L
+        // Tuned down from 60s after field reports of "stuck at 100%"
+        // when a prior install returned DELEGATED_TO_SYSTEM and the
+        // broadcast that releases the gate never arrived (user
+        // dismissed the system dialog, OEM throttling, Shizuku
+        // fallback to default installer with no follow-through).
+        // 15s is long enough to cover a normal Shizuku/Dhizuku silent
+        // install round-trip and short enough that the queue recovers
+        // before the user gives up.
+        const val DEFAULT_TIMEOUT_MS: Long = 15_000L
     }
 }


### PR DESCRIPTION
Surfaced from a field report of "downloads complete at 100% but never start installing" when mirror download is on and 2-3 apps are queued.

## Root cause (Candidate A — confirmed by code read)

`DefaultDownloadOrchestrator.runInstall` (the AlwaysInstall path used by Shizuku/Dhizuku) handles the two `InstallOutcome` values asymmetrically:

- `COMPLETED` (silent install succeeded) → `markCompleted` releases the gate immediately. ✅
- `DELEGATED_TO_SYSTEM` (silent install fell back to the AndroidInstaller default-dialog path — `SilentInstallerDispatcher.kt:110-112` does this when the Shizuku binder is null, returns non-zero, or throws) → **gate is intentionally not released**, by design, because the system installer dialog is still up.

The intentional non-release is correct for the dialog stacking case it was designed for. But when the user dismisses the dialog (or the dialog never opens because the fallback failed too), no `PACKAGE_REPLACED` broadcast arrives, no `markCompleted` fires, and the gate stays held until the timeout. The other 2-3 apps in the queue are downloaded fully (UI shows 100%), then sit at `awaitFreeAndMarkPending` waiting on a gate that nothing will release.

Default timeout was 60s. With 3 apps queued behind a stuck gate, that's up to 3×60s of "stuck at 100%" before the queue recovers. Matches the field-report symptom exactly.

## Fix

Three small changes; no behaviour change for the happy path:

1. **`SystemInstallSerializer.DEFAULT_TIMEOUT_MS` 60_000L → 15_000L.** Long enough for a normal Shizuku/Dhizuku silent install round-trip, short enough that a stuck gate recovers before the user gives up. Force-claim semantics on timeout are unchanged.

2. **`DefaultSystemInstallSerializer.awaitFreeAndMarkPending` now logs when it has to wait.** `Logger.i { "$packageName waiting for $heldBy to clear (timeout 15000ms)" }` on entry-while-blocked, and a matching "acquired gate after waiting for $heldBy" on success. Future stuck reproductions show the queue clearly in Logcat.

3. **`AndroidDownloader` no longer logs `CancellationException` as an error.** The `MultiSourceDownloader` race cancels the loser racer on every download when a mirror is configured — that's the normal happy path. The previous catch-all `catch (e: Exception)` was logging every losing racer as `Logger.e { "Download failed" }`, flooding Logcat with red lines that look like real failures and obscured the actual stuck-install signal in the field report. Cancellation now gets a dedicated catch that cleans up the temp file and rethrows without logging; non-cancellation `Exception` still logs as before.

## Test plan
- `:core:data:compileDebugKotlinAndroid` ✅
- `:core:data:compileKotlinJvm` ✅
- Local CodeRabbit review: 0 findings.
- Field smoke: queue 3 apps with mirror download on. Confirm:
  - Logcat no longer flooded with `Download failed` for losing racers.
  - If gate ever sticks, Logcat shows the `awaiting / acquired` pair so the next bug report is actionable.
  - Worst-case stuck recovery is now ~15s per queued app instead of ~60s.

## Notes
- This does NOT change the gate-locked-during-DELEGATED_TO_SYSTEM behaviour — that's still correct for the dialog-stacking case the gate was originally designed for. The timeout shrink is the safety net.
- Shizuku-fallback-to-default path that originally exposed this is left as-is. A follow-up could add a `markCompleted` after the fallback intent fires (since the fallback intent IS the system dialog and the gate is held by definition there too — same logic as the inherent `DELEGATED_TO_SYSTEM` path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Download cancellations are now properly handled without generating error logs.
  * System installation timeout reduced from 60 to 15 seconds, addressing instances where installations appeared stuck at 100%.

* **Improvements**
  * Enhanced logging for better installation diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->