### PR TITLE
perf(cache): mutex-guard memory map + periodic cleanup + 24h home TTL (E4.1)

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/cache/CacheManager.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/cache/CacheManager.kt
@@ -59,24 +59,39 @@ class CacheManager(
                 return try {
                     json.decodeFromString(serializer<T>(), jsonData)
                 } catch (_: Exception) {
-                    memoryCacheMutex.withLock { memoryCache.remove(key) }
+                    // Guarded eviction: only remove if no concurrent
+                    // `put` has replaced our snapshot. Without the
+                    // equality check, a fresh value written between
+                    // the snapshot read and this decode failure would
+                    // be wrongly evicted.
+                    memoryCacheMutex.withLock {
+                        if (memoryCache[key] == cached) memoryCache.remove(key)
+                    }
                     null
                 }
             } else {
-                memoryCacheMutex.withLock { memoryCache.remove(key) }
+                memoryCacheMutex.withLock {
+                    if (memoryCache[key] == cached) memoryCache.remove(key)
+                }
             }
         }
 
         val entry = cacheDao.getValid(key, currentTime) ?: return null
+        val snapshot = entry.expiresAt to entry.jsonData
         memoryCacheMutex.withLock {
-            memoryCache[key] = entry.expiresAt to entry.jsonData
+            memoryCache[key] = snapshot
         }
 
         return try {
             json.decodeFromString(serializer<T>(), entry.jsonData)
         } catch (_: Exception) {
-            cacheDao.delete(key)
-            memoryCacheMutex.withLock { memoryCache.remove(key) }
+            // Same race rationale as the in-memory branch — use the
+            // row's cachedAt as a version stamp so a fresh `put` that
+            // raced in between getValid and now is preserved.
+            cacheDao.deleteIfMatches(key, entry.cachedAt)
+            memoryCacheMutex.withLock {
+                if (memoryCache[key] == snapshot) memoryCache.remove(key)
+            }
             null
         }
     }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/cache/CacheManager.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/cache/CacheManager.kt
@@ -1,5 +1,10 @@
 package zed.rainxch.core.data.cache
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import zed.rainxch.core.data.local.db.dao.CacheDao
@@ -8,43 +13,70 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 
 class CacheManager(
-    val cacheDao: CacheDao,
+    @PublishedApi internal val cacheDao: CacheDao,
+    appScope: CoroutineScope? = null,
 ) {
-    val json =
+    @PublishedApi
+    internal val json =
         Json {
             ignoreUnknownKeys = true
             isLenient = true
             encodeDefaults = true
         }
 
-    val memoryCache = HashMap<String, Pair<Long, String>>()
+    // Guarded by [memoryCacheMutex]. Multiple repositories read/write
+    // this map from concurrent ViewModel scopes — without the mutex a
+    // structural HashMap mutation can corrupt internal state on rehash.
+    // `@PublishedApi internal` so the inline reified `get` / `put` can
+    // touch them without leaking the map to outside callers.
+    @PublishedApi
+    internal val memoryCache = HashMap<String, Pair<Long, String>>()
+
+    @PublishedApi
+    internal val memoryCacheMutex = Mutex()
+
+    init {
+        appScope?.launch {
+            // Periodic janitor: in-memory cache grows otherwise unbounded
+            // over a long session. Run once an hour off the critical path;
+            // mutex serialises with foreground reads/writes.
+            while (true) {
+                delay(CLEANUP_INTERVAL_MS)
+                runCatching { cleanupExpired() }
+            }
+        }
+    }
 
     fun now(): Long = Clock.System.now().toEpochMilliseconds()
 
     suspend inline fun <reified T> get(key: String): T? {
         val currentTime = now()
 
-        memoryCache[key]?.let { (expiresAt, jsonData) ->
+        val cached = memoryCacheMutex.withLock { memoryCache[key] }
+        if (cached != null) {
+            val (expiresAt, jsonData) = cached
             if (expiresAt > currentTime) {
                 return try {
                     json.decodeFromString(serializer<T>(), jsonData)
                 } catch (_: Exception) {
-                    memoryCache.remove(key)
+                    memoryCacheMutex.withLock { memoryCache.remove(key) }
                     null
                 }
             } else {
-                memoryCache.remove(key)
+                memoryCacheMutex.withLock { memoryCache.remove(key) }
             }
         }
 
         val entry = cacheDao.getValid(key, currentTime) ?: return null
-        memoryCache[key] = entry.expiresAt to entry.jsonData
+        memoryCacheMutex.withLock {
+            memoryCache[key] = entry.expiresAt to entry.jsonData
+        }
 
         return try {
             json.decodeFromString(serializer<T>(), entry.jsonData)
         } catch (_: Exception) {
             cacheDao.delete(key)
-            memoryCache.remove(key)
+            memoryCacheMutex.withLock { memoryCache.remove(key) }
             null
         }
     }
@@ -67,7 +99,9 @@ class CacheManager(
         val jsonData = json.encodeToString(serializer<T>(), value)
         val expiresAt = currentTime + ttlMillis
 
-        memoryCache[key] = expiresAt to jsonData
+        memoryCacheMutex.withLock {
+            memoryCache[key] = expiresAt to jsonData
+        }
 
         cacheDao.put(
             CacheEntryEntity(
@@ -80,38 +114,45 @@ class CacheManager(
     }
 
     suspend fun invalidate(key: String) {
-        memoryCache.remove(key)
+        memoryCacheMutex.withLock { memoryCache.remove(key) }
         cacheDao.delete(key)
     }
 
     suspend fun invalidateByPrefix(prefix: String) {
-        val keysToRemove = memoryCache.keys.filter { it.startsWith(prefix) }
-        keysToRemove.forEach { memoryCache.remove(it) }
+        memoryCacheMutex.withLock {
+            val keysToRemove = memoryCache.keys.filter { it.startsWith(prefix) }
+            keysToRemove.forEach { memoryCache.remove(it) }
+        }
         cacheDao.deleteByPrefix(prefix)
     }
 
     suspend fun clearAll() {
-        memoryCache.clear()
+        memoryCacheMutex.withLock { memoryCache.clear() }
         cacheDao.deleteAll()
     }
 
     suspend fun cleanupExpired() {
         val currentTime = now()
-        val expiredKeys =
-            memoryCache.entries
-                .filter { it.value.first <= currentTime }
-                .map { it.key }
-        expiredKeys.forEach { memoryCache.remove(it) }
+        memoryCacheMutex.withLock {
+            val expiredKeys =
+                memoryCache.entries
+                    .filter { it.value.first <= currentTime }
+                    .map { it.key }
+            expiredKeys.forEach { memoryCache.remove(it) }
+        }
         cacheDao.deleteExpired(currentTime)
     }
 
     companion object CacheTtl {
-        val HOME_REPOS = 12.hours.inWholeMilliseconds
+        // Tuned per E4 perf-pass spec: home grid is browsed often + tolerates
+        // stale data well; longer TTL cuts cold-start network round-trips.
+        val HOME_REPOS = 24.hours.inWholeMilliseconds
         val REPO_DETAILS = 6.hours.inWholeMilliseconds
         val RELEASES = 6.hours.inWholeMilliseconds
         val README = 12.hours.inWholeMilliseconds
         val USER_PROFILE = 6.hours.inWholeMilliseconds
         val SEARCH_RESULTS = 1.hours.inWholeMilliseconds
         val REPO_STATS = 6.hours.inWholeMilliseconds
+        const val CLEANUP_INTERVAL_MS: Long = 60L * 60L * 1000L
     }
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -217,7 +217,7 @@ val coreModule =
         }
 
         single<CacheManager> {
-            CacheManager(cacheDao = get())
+            CacheManager(cacheDao = get(), appScope = get())
         }
 
         single<BackendApiClient> {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/CacheDao.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/CacheDao.kt
@@ -29,6 +29,16 @@ interface CacheDao {
     @Query("DELETE FROM cache_entries WHERE `key` = :key")
     suspend fun delete(key: String)
 
+    /**
+     * Conditional delete used by CacheManager when a row decoded as a
+     * malformed payload — guards against evicting a freshly-put row that
+     * raced in between the read and the decode-failure delete. Compares
+     * `cachedAt` because (key, cachedAt) is effectively the row's version
+     * stamp on this schema.
+     */
+    @Query("DELETE FROM cache_entries WHERE `key` = :key AND cachedAt = :cachedAt")
+    suspend fun deleteIfMatches(key: String, cachedAt: Long)
+
     @Query("DELETE FROM cache_entries WHERE `key` LIKE :prefix || '%'")
     suspend fun deleteByPrefix(prefix: String)
 


### PR DESCRIPTION
First slice of E4 Performance Pass. Pure static-friendly changes; no profiler required.

## What & why

### 1. Thread-safe memory cache
`CacheManager.memoryCache` is a plain `HashMap` mutated from any caller's coroutine — Home, Details, Search, Profile repositories all hit it concurrently from their respective ViewModel scopes. Concurrent structural mutations (`put` during another caller's rehash) can corrupt internal state. Added `kotlinx.coroutines.sync.Mutex` and wrapped every read/write touching the map.

`memoryCache`, `memoryCacheMutex`, `cacheDao`, and `json` are now `@PublishedApi internal` so the inline reified `get<T>()` / `put<T>()` keep working from feature-module call sites without the map being effectively public-API.

### 2. Periodic janitor for the in-memory cache
`cleanupExpired()` was defined but had no callers. Memory map grew unbounded over a long session. `CacheManager` constructor now takes an optional `appScope: CoroutineScope?` and launches a 1h janitor loop that runs `cleanupExpired()` off the critical path. Mutex serialises it with foreground reads/writes. Wired in `coreModule` Koin via `appScope = get()`.

### 3. `HOME_REPOS` TTL 12h → 24h
Per E4 spec recommendation. Home grid is browsed often, tolerates stale data well, longer TTL cuts cold-start network round-trips on the highest-traffic surface.

## Test plan
- `:core:data:compileDebugKotlinAndroid` ✅
- `:core:data:compileKotlinJvm` ✅
- Local CodeRabbit: 0 findings (after applying the `@PublishedApi internal` visibility fix from the first pass).
- Manual smoke deferred until full E4 lands — the change is ABI-compatible for callers and the mutex semantics preserve the original happy-path behaviour.

## Out of scope (later E4 slices)
- E4.2 — bouncy `Spring` sweep (survey #16).
- E4.3 — defer non-critical `Application.onCreate` / `MainActivity.onCreate` work.
- E4.4 — verify `DetailsViewModel.loadDetails` parallel `async {}`.
- E4.5 — Macrobenchmark + scroll profile (needs Pixel 6 device).
- LRU eviction on `memoryCache` — bounded growth is good-enough with periodic cleanup; LRU adds complexity, defer until profile shows it matters.
- Stale-while-revalidate fallback in Home / Search repositories — Details already uses `getStale` correctly; Home / Search don't. Separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic periodic background cache cleanup to remove expired entries.

* **Bug Fixes**
  * Safer in-memory cache concurrency handling to prevent race conditions and accidental evictions.
  * Conditional eviction behavior to avoid removing freshly written entries after decode failures.

* **Performance**
  * Increased home repository cache retention from 12 to 24 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->