### PR TITLE
perf(startup): defer non-critical work off Application.onCreate (E4.3)

### DIFF
--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
@@ -32,13 +32,26 @@ class GithubStoreApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Synchronous: Koin must be ready before the first composition can
+        // resolve any singleton; everything else can run on the app scope.
         initKoin {
             androidContext(this@GithubStoreApp)
         }
 
-        createNotificationChannels()
-        registerPackageEventReceiver()
-        startDownloadNotificationObserver()
+        // Deferred to the app scope so they don't block the first frame:
+        //  - notification channels are only consumed when a worker posts
+        //    a notification (minutes later at the earliest)
+        //  - dynamic PackageEventReceiver is the in-process fast path; the
+        //    manifest-registered receiver still catches broadcasts during
+        //    the millisecond gap until the dynamic registration lands
+        //  - the download notification observer has nothing to observe
+        //    until the user starts a download
+        appScope.launch {
+            createNotificationChannels()
+            registerPackageEventReceiver()
+            startDownloadNotificationObserver()
+        }
+
         scheduleBackgroundUpdateChecks()
         registerSelfAsInstalledApp()
         scheduleInitialExternalScan()

--- a/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
+++ b/composeApp/src/androidMain/kotlin/zed/rainxch/githubstore/app/GithubStoreApp.kt
@@ -38,7 +38,11 @@ class GithubStoreApp : Application() {
             androidContext(this@GithubStoreApp)
         }
 
-        // Deferred to the app scope so they don't block the first frame:
+        // Deferred to the app scope so they don't block the first frame.
+        // Each step gets its own launch + runCatching so a failure in one
+        // (NotificationManager hiccup, broadcast-registration race, etc.)
+        // doesn't abort the others — matches the pattern used by the
+        // other startup blocks below.
         //  - notification channels are only consumed when a worker posts
         //    a notification (minutes later at the earliest)
         //  - dynamic PackageEventReceiver is the in-process fast path; the
@@ -47,9 +51,16 @@ class GithubStoreApp : Application() {
         //  - the download notification observer has nothing to observe
         //    until the user starts a download
         appScope.launch {
-            createNotificationChannels()
-            registerPackageEventReceiver()
-            startDownloadNotificationObserver()
+            runCatching { createNotificationChannels() }
+                .onFailure { Logger.w(it) { "Notification-channel creation failed" } }
+        }
+        appScope.launch {
+            runCatching { registerPackageEventReceiver() }
+                .onFailure { Logger.w(it) { "Dynamic PackageEventReceiver registration failed" } }
+        }
+        appScope.launch {
+            runCatching { startDownloadNotificationObserver() }
+                .onFailure { Logger.w(it) { "Download notification observer start failed" } }
         }
 
         scheduleBackgroundUpdateChecks()


### PR DESCRIPTION
Slice E4.3 of the E4 Performance Pass. Trims synchronous work off the Android Application.onCreate critical path so the first frame composes faster.

## Audit

`GithubStoreApp.onCreate` was running 7 things synchronously. Five were already `appScope.launch`-ed; three were not:

| Step | Why it was sync | Why it can defer |
|---|---|---|
| `createNotificationChannels()` | platform call, blocks onCreate | channels are only consumed when a worker posts a notification (minutes later at the earliest) |
| `registerPackageEventReceiver()` | dynamic in-process receiver registration | the manifest-registered static receiver still catches every `PACKAGE_*` broadcast during the millisecond gap until the dynamic registration lands |
| `startDownloadNotificationObserver()` | flow collector for active downloads | nothing to observe until the user starts a download |

Moved all three onto `appScope.launch { … }` (preserves order). `initKoin { … }` stays synchronous — Koin must be ready before the first composition can resolve any singleton.

## What stays sync
- `initKoin` — required by every downstream `get<T>()`.
- The four already-async schedulers (`scheduleBackgroundUpdateChecks`, `registerSelfAsInstalledApp`, `scheduleInitialExternalScan`, `scheduleSigningSeedSync`) — unchanged, already off the critical path.

## DesktopApp.main
Audited; already lean. CrashReporter / A11yCrashGuard / JVM DNS TTL / Koin init / language tag — all required before Compose runs. No deferral candidates.

## Test plan
- `:composeApp:compileDebugKotlinAndroid` ✅
- Local CodeRabbit was rate-limited at run time (14m cooldown); the SaaS bot will review on this PR.
- Manual: cold-start the app, post-startup tap an install — broadcast still fires through the manifest receiver, install completes; deferred dynamic receiver finishes registering during the same coroutine dispatch tick.

## Out of scope
- E4.4 — verify `DetailsViewModel.loadDetails` parallel `async {}`.
- E4.5 — Macrobenchmark + scroll profile (needs Pixel 6 device).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved app startup performance by deferring initialization of background notification systems, making launch faster and more responsive.
  * Notification setup is now more resilient: individual setup steps run independently so failures won’t block app startup; notifications may initialize shortly after launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->