### PR TITLE
perf(details): parallelise favorite + starred reads on cold path (E4.4)

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -2402,6 +2402,10 @@ class DetailsViewModel(
                     }
                 launch { seenReposRepository.markAsSeen(repo) }
 
+                // Launch both checks in parallel before awaiting either —
+                // previously `isFavoriteDeferred.await()` ran before
+                // `isStarredDeferred` was even started, serialising two
+                // independent reads on the Details screen cold path.
                 val isFavoriteDeferred =
                     async {
                         try {
@@ -2414,7 +2418,6 @@ class DetailsViewModel(
                             false
                         }
                     }
-                val isFavorite = isFavoriteDeferred.await()
                 val isStarredDeferred =
                     async {
                         try {
@@ -2427,6 +2430,7 @@ class DetailsViewModel(
                             false
                         }
                     }
+                val isFavorite = isFavoriteDeferred.await()
                 val isStarred = isStarredDeferred.await()
 
                 val owner = repo.owner.login


### PR DESCRIPTION
Slice E4.4 of the E4 Performance Pass. Audited `DetailsViewModel.loadInitial` for sequential `await()` calls on independent reads.

## Found

`loadInitial` had a buried serialisation:

```kotlin
val isFavoriteDeferred = async { favouritesRepository.isFavoriteSync(repo.id) }
val isFavorite = isFavoriteDeferred.await()           // ← awaited BEFORE next async
val isStarredDeferred = async { starredRepository.isStarred(repo.id) }
val isStarred = isStarredDeferred.await()
```

Two independent DB reads were running back-to-back instead of in parallel. The `state.copy` at the bottom uses both values, so order doesn't matter — they should have been launched together.

## Fix

```kotlin
val isFavoriteDeferred = async { … }
val isStarredDeferred = async { … }   // ← now starts immediately
val isFavorite = isFavoriteDeferred.await()
val isStarred = isStarredDeferred.await()
```

## Audit notes
The rest of `loadInitial` is already correctly parallelised — `allReleasesDeferred`, `statsDeferred`, `readmeDeferred`, `userProfileDeferred`, `installedAppsDeferred` are all launched together before any `await`. The refresh path (`refreshRepository` → `releasesDeferred` + `statsDeferred`) is also correct.

## Win size
Both reads are local DB lookups, ~5–20ms each on a warm cache. Real-world saving is ~10ms on the cold path. Small but free — and the original code was clearly wrong, not a deliberate ordering choice.

## Test plan
- `:feature:details:presentation:compileDebugKotlinAndroid` ✅
- `:feature:details:presentation:compileKotlinJvm` ✅
- Local CodeRabbit was still rate-limited from the earlier slice; SaaS bot reviews on this PR.

## Out of scope
- E4.5 — Macrobenchmark + scroll profile (needs Pixel 6).
- Stale-while-revalidate on Home / Search repositories — Details already does it; Home / Search don't. Separate task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized item details loading to execute repository status checks concurrently instead of sequentially, improving overall load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->