### PR TITLE
fix(updates): expedited request can't carry initial delay (crash hotfix)

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/BootReceiver.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/BootReceiver.kt
@@ -34,6 +34,13 @@ class BootReceiver : BroadcastReceiver() {
                 Logger.i { "BootReceiver: Device booted, update check disabled — skipping" }
                 UpdateScheduler.cancel(context)
             }
+        } catch (t: Throwable) {
+            // Don't let scheduling failures crash the framework's
+            // broadcast pipeline — propagation triggers a second
+            // `sendFinished` from the platform after our own
+            // `pendingResult.finish()` and surfaces as
+            // `IllegalStateException: Broadcast already finished`.
+            Logger.e(t) { "BootReceiver: scheduling failed; dropped" }
         } finally {
             pendingResult.finish()
         }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/UpdateScheduler.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/UpdateScheduler.kt
@@ -46,15 +46,15 @@ object UpdateScheduler {
                 request = request,
             )
 
+        // Note: an expedited request CANNOT carry an initial delay —
+        // WorkManager throws `IllegalArgumentException: Expedited jobs
+        // cannot be delayed` at build time. Drop the cold-start backoff
+        // and let the OS scheduler dispatch as soon as the network
+        // constraint is satisfied; on aggressive-OEM ROMs the expedited
+        // tier is what actually gets the work to run.
         val immediateRequest =
             OneTimeWorkRequestBuilder<UpdateCheckWorker>()
                 .setConstraints(constraints)
-                .setInitialDelay(1, TimeUnit.MINUTES)
-                // Aggressive-OEM ROMs (Oppo / OnePlus / Realme / Xiaomi)
-                // throttle generic background work hard. Expedited tier
-                // gets more headroom; fall back to non-expedited when
-                // the system has no expedited budget left so the work
-                // still runs eventually rather than failing outright.
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
 


### PR DESCRIPTION
Hotfix for the two crashes from PR #545.

## Crash 1 — \`Expedited jobs cannot be delayed\`

\`\`\`
java.lang.IllegalArgumentException: Expedited jobs cannot be delayed
    at androidx.work.WorkRequest\$Builder.build(WorkRequest.kt:305)
    at zed.rainxch.core.data.services.UpdateScheduler.schedule(UpdateScheduler.kt:59)
\`\`\`

\`UpdateScheduler.schedule\` was building a one-time \`UpdateCheckWorker\` with both \`.setInitialDelay(1, TimeUnit.MINUTES)\` (cold-start back-off, predates this PR) and \`.setExpedited(...)\` (added in PR #545 for aggressive-OEM headroom). WorkManager rejects the combination at \`build()\` time.

**Fix:** dropped \`setInitialDelay\`. Expedited dispatch is what we actually wanted on aggressive ROMs anyway — the 1-minute backoff was a minor optimisation, not a hard requirement. Network-constraint dispatch is fast enough on a fresh boot.

## Crash 2 — \`Broadcast already finished\`

\`\`\`
java.lang.IllegalStateException: Broadcast already finished
    at android.content.BroadcastReceiver\$PendingResult.sendFinished(BroadcastReceiver.java:313)
    at android.app.ActivityThread.handleReceiver(ActivityThread.java:5591)
\`\`\`

Caused by Crash 1's \`IllegalArgumentException\` escaping \`BootReceiver.onReceive\` after \`pendingResult.finish()\` had already run in the \`finally\` block. Android's broadcast pipeline saw the unhandled throw, called its own \`sendFinished\`, and tripped the already-finished guard.

**Fix:** added a defensive \`catch (t: Throwable) { Logger.e(...) }\` between \`try\` and \`finally\` in \`BootReceiver\`. Scheduling failures are logged and swallowed — they don't propagate to the framework. Crash 2 won't recur after Crash 1 is fixed, but the catch is the right shape for any future scheduler bug.

## Test plan
- \`:composeApp:compileDebugKotlinAndroid\` ✅
- \`:core:data:compileDebugKotlinAndroid\` ✅
- Manual: cold-start app on Android — no immediate crash, periodic + immediate update-check work both enqueue. Reboot device — BootReceiver schedules cleanly.

## Note
\`scheduleBackgroundUpdateChecks\` in \`GithubStoreApp\` was already wrapped in \`try / Logger.e\` so the same throw on cold start logged but didn't crash the app. The crash report came from BootReceiver's narrower error path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for background task scheduling to prevent crashes during boot and system events.
  * Optimized work request scheduling to reduce delays and dispatch tasks more efficiently when network becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->