### PR TITLE
fix(apps): show actually-installed tag instead of latest after older-version install

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/PackageEventReceiver.kt
@@ -184,10 +184,23 @@ class PackageEventReceiver() :
                             versionCodeMatchesTarget ||
                                 (expectedVersionCode <= 0L && versionNameChanged)
 
+                        // Source-of-truth for the tag the user just
+                        // installed: `pendingInstallVersion` carries the
+                        // exact release tag the orchestrator parked the
+                        // file under (set during download flow). It's
+                        // honest about explicit older-version installs;
+                        // `app.latestVersion` is GHS's cached idea of
+                        // "what GitHub says is latest" and would show
+                        // the wrong tag if the user picked an older
+                        // release from the version picker.
+                        val installedTag =
+                            app.pendingInstallVersion
+                                ?: app.latestVersion
+                                ?: systemInfo.versionName
                         if (wasActuallyUpdated) {
                             repo.updateAppVersion(
                                 packageName = packageName,
-                                newTag = app.latestVersion ?: systemInfo.versionName,
+                                newTag = installedTag,
                                 newAssetName = app.latestAssetName ?: "",
                                 newAssetUrl = app.latestAssetUrl ?: "",
                                 newVersionName = systemInfo.versionName,
@@ -195,18 +208,20 @@ class PackageEventReceiver() :
                                 signingFingerprint = app.signingFingerprint,
                             )
                             repo.updatePendingStatus(packageName, false)
-                            Logger.i { "Update confirmed via broadcast: $packageName (v${systemInfo.versionName})" }
+                            Logger.i { "Update confirmed via broadcast: $packageName (v${systemInfo.versionName}, tag=$installedTag)" }
                         } else {
                             // Even on the "didn't reach target" branch the
                             // installedVersion tag must move forward when the
                             // user accepted some install — leaving it pinned
                             // to the old tag makes the apps row report the
-                            // pre-install version forever.
+                            // pre-install version forever. Use the parked
+                            // tag so an explicit older-version install is
+                            // honoured (issue: details + apps screens were
+                            // showing latest when user picked older).
                             repo.updateApp(
                                 app.copy(
                                     isPendingInstall = false,
-                                    installedVersion =
-                                        app.latestVersion ?: systemInfo.versionName,
+                                    installedVersion = installedTag,
                                     installedVersionName = systemInfo.versionName,
                                     installedVersionCode = systemInfo.versionCode,
                                     isUpdateAvailable =


### PR DESCRIPTION
Field-reported bug: install an older release of an app via the Details screen version picker → the system reports the correct (lower) version, but GHS Apps + Details screens keep showing the latest tag instead of the one the user picked.

## Root cause

\`PackageEventReceiver.onPackageInstalled\` post-install update was pulling the displayed \`installedVersion\` from \`app.latestVersion\` — that field is GHS's cached "what GitHub says is the latest tag", **not** what the user just installed. So an explicit older-version install would land the correct APK in the OS but render the latest tag in our UI.

The \`if (wasActuallyUpdated)\` happy path used \`app.latestVersion ?: systemInfo.versionName\` for \`newTag\` (correct under the assumption the user always installs the latest — broken by the version picker). The else-branch added in PR #541 used the same wrong source.

## Fix

Both branches now read the parked tag from \`app.pendingInstallVersion\` first — that field is set by \`DefaultDownloadOrchestrator.parkForUser\` to the exact \`releaseTag\` the user requested via the Details version picker. Falls back to \`app.latestVersion\` then \`systemInfo.versionName\` if the parked tag was somehow not persisted.

\`\`\`kotlin
val installedTag =
    app.pendingInstallVersion
        ?: app.latestVersion
        ?: systemInfo.versionName
\`\`\`

Used in:
- \`if (wasActuallyUpdated)\` → \`repo.updateAppVersion(newTag = installedTag, ...)\`
- else-branch → \`installedVersion = installedTag\` in the column-only update

Happy-path behaviour is unchanged for normal latest-version updates: \`pendingInstallVersion\` equals \`latestVersion\` in that case.

## Test plan
- \`:core:data:compileDebugKotlinAndroid\` ✅
- Local CodeRabbit: 1 finding in untracked \`RELEASE_NOTES_1.8.1.md\` (out-of-scope) → skipped.
- Manual:
  - [ ] Install a tracked app via Details → Older versions picker → pick v1.0 (with v1.5 latest available). Confirm system shows v1.0, GHS Apps + Details now show v1.0 too.
  - [ ] Normal update flow on another app → still shows latest tag correctly.
  - [ ] Update Available badge: app with installed v1.0 still flags v1.5 as available (\`isUpdateAvailable\` derived from \`latestVersionCode > systemInfo.versionCode\`, which still works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app installation version tracking to correctly display installed versions, particularly for pending installations and explicit older-version installs. The system now derives version information from multiple sources for more reliable version display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->