### PR TITLE
fix(desktop): SKIKO_RENDER_API env escape hatch for Linux hybrid-GPU SEGV (#546)

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -41,6 +41,17 @@ fun main(args: Array<String>) {
     // raised by the macOS accessibility bridge (see `A11yCrashGuard`).
     A11yCrashGuard.install()
 
+    // Skiko default backend on Linux is OpenGL, but on hybrid-GPU
+    // setups (e.g. AMD iGPU + Nvidia dGPU on Bazzite) the proprietary
+    // Nvidia driver path can SEGV the JVM before any Java exception
+    // handler runs (see issue #546). Honour an explicit
+    // `SKIKO_RENDER_API` env var if the user set one (escape hatch
+    // for reporters who can rescue the install with `SOFTWARE`), and
+    // otherwise leave Skiko to its default — pinning a specific API
+    // unconditionally would regress users who DO have a working
+    // accelerated path.
+    selectLinuxRenderBackendIfRequested()
+
     // Reduce JVM DNS cache TTL so network changes (VPN on/off) are picked up quickly.
     // Default JVM caches positive lookups for 30s and negative lookups forever,
     // which breaks connectivity when a VPN changes DNS/routing mid-session.
@@ -117,4 +128,25 @@ fun main(args: Array<String>) {
             App(deepLinkUri = deepLinkUri)
         }
     }
+}
+
+/**
+ * Honour `SKIKO_RENDER_API` (env) or `-Dskiko.renderApi` (system
+ * property) on Linux so users hitting the Nvidia hybrid-GPU SEGV
+ * (issue #546) can rescue the install via:
+ *
+ *     SKIKO_RENDER_API=SOFTWARE ./GitHub-Store-x86_64.AppImage
+ *
+ * Skiko reads the system property internally; we copy the env var
+ * into the property when present so AppImage launchers don't need
+ * to construct `-D` flags. Other platforms are skipped — Mac/Win
+ * are unaffected by this class of bug.
+ */
+private fun selectLinuxRenderBackendIfRequested() {
+    val osName = System.getProperty("os.name", "").lowercase()
+    if (!osName.contains("linux")) return
+    if (System.getProperty("skiko.renderApi") != null) return
+    val fromEnv = System.getenv("SKIKO_RENDER_API")?.trim().orEmpty()
+    if (fromEnv.isEmpty()) return
+    System.setProperty("skiko.renderApi", fromEnv)
 }


### PR DESCRIPTION
Addresses #546 — Linux AppImage / pkg.tar.zst SEGVs as normal user on Bazzite DX with hybrid GPU (Radeon 780M iGPU + RTX 4060 dGPU). Works under \`sudo\` only.

## Diagnosis
The crash is in native code (Skiko / Skia), before any Java exception handler runs — that's why the reporter sees a bare \`segmentation fault (core dumped)\` with no log output and \`CrashReporter\` (which IS installed first) doesn't capture anything. The pattern is consistent with the Nvidia proprietary driver path on hybrid-GPU setups: when the unprivileged process tries to bring up an OpenGL/Vulkan context against the dGPU, the proprietary stack SEGVs the JVM. Sudo dodges it because root has different DRM render-node access.

We can't catch this in Java. We CAN give the reporter (and any future hybrid-GPU sufferers) a working escape hatch they can set without rebuilding the app.

## Fix
Honour \`SKIKO_RENDER_API\` from the process environment on Linux only. If set, copy into the \`skiko.renderApi\` system property before any Compose / Skiko code runs. If unset, leave Skiko to its default — pinning a specific backend unconditionally would regress the much larger population that does have a working accelerated path.

Mac / Windows skipped — different graphics stacks, different bug class.

This means a stuck reporter can launch via:

\`\`\`bash
SKIKO_RENDER_API=SOFTWARE ./GitHub-Store-x86_64.AppImage   # CPU rendering
# or
SKIKO_RENDER_API=OPENGL ./GitHub-Store-x86_64.AppImage     # force OpenGL
\`\`\`

\`SOFTWARE\` is the safe bet for Bazzite DX hybrid setups — slow but always works. \`OPENGL\` is the fallback if Vulkan was the actual culprit.

## Other workarounds for the user (documented in issue reply)
- \`__NV_PRIME_RENDER_OFFLOAD=0\` to force iGPU (AMD) — reporter says AMD path works.
- Membership in \`render\` and \`video\` groups: \`sudo usermod -aG render,video \$USER\`.
- For Bazzite DX specifically: \`ujust setup-nvidia\` or rebase off the dGPU-image variant.

## Test plan
- \`:composeApp:compileKotlinJvm\` ✅
- Local CodeRabbit: 0 findings.
- Cannot reproduce locally without a Bazzite/Nvidia hybrid setup. Reporter on the issue can verify \`SKIKO_RENDER_API=SOFTWARE\` in the next 1.9.0 release; if successful, we'll surface the escape hatch in the README.

## Out of scope
- Auto-detect hybrid GPU and force \`SOFTWARE\` — too aggressive, would slow down working setups.
- AppImage launcher script that sets the env var by default — defer until we hear back from the reporter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Linux rendering backend initialization to better support systems with hybrid GPU configurations, including support for environment-variable-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->