### PR TITLE
Strip build-variant suffix during version normalization (closes #557)

### DIFF
--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/VersionMath.kt
@@ -62,11 +62,19 @@ object VersionMath {
         // parsed independently. Only inserts before known markers to
         // avoid mauling architecture suffixes like `1arm64`.
         val separated = insertHyphenBeforeKnownMarker(calverNormalized)
-        if (parseSemanticVersion(separated) != null) {
-            return separated
+        // Build-variant suffix (`-f`, `-m`, `-arm64`, `-stable`, …) —
+        // some maintainers append a flavour marker to the installed
+        // versionName but tag GitHub with the bare semver core, so the
+        // exact same artefact reads as `1.8.6-f` on-device but `1.8.6`
+        // in the release feed. Strip these flavour markers so the
+        // comparator doesn't perpetually report a phantom update.
+        // Pre-release markers (`-beta`, `-rc1`, …) are preserved.
+        val deflavoured = stripBuildVariantSuffix(separated)
+        if (parseSemanticVersion(deflavoured) != null) {
+            return deflavoured
         }
-        val match = DOTTED_DIGIT_PATTERN.find(separated)
-        return match?.value ?: separated
+        val match = DOTTED_DIGIT_PATTERN.find(deflavoured)
+        return match?.value ?: deflavoured
     }
 
     private fun stripFullPrefix(version: String): String {
@@ -93,6 +101,81 @@ object VersionMath {
         val core = "$year.$month.$day"
         return if (tail.isNotEmpty()) "$core-$tail" else core
     }
+
+    /**
+     * Strip a curated set of build-variant / flavour markers that
+     * routinely appear in installed `versionName`s but never in the
+     * GitHub release tag (the maintainer ships a single `1.8.6` tag
+     * but emits `1.8.6-f`, `1.8.6-m` APKs). Without this step the
+     * comparator reads the suffix as a semver pre-release identifier,
+     * ranks the bare tag higher, and surfaces a phantom update.
+     *
+     * Recognised markers (case-insensitive, before any `.` separator
+     * inside the pre-release segment):
+     *  - **Build flavour**: `f` / `full`, `m` / `mini` / `minified`,
+     *    `l` / `lite`, `r` / `release`, `d` / `debug`, `x` / `extended`.
+     *  - **Channel**: `stable`, `final`, `prod`, `production`, `gms`,
+     *    `fdroid`, `github`, `store`.
+     *  - **Architecture**: `armv7`, `armv8`, `arm64`, `armeabi`, `x86`,
+     *    `x64`, `x86_64`, `universal`, `android`, `ios`.
+     *
+     * Intentionally NOT stripped (these are real pre-release markers):
+     *  - `alpha`, `beta`, `rc`, `preview`, `prerelease`, `snapshot`,
+     *    `canary`, `nightly`, `milestone`, `ea`, `dev`, `pre`, `m\d+`.
+     *
+     * The function only acts when [version] parses as semver; if the
+     * input lacks a recognisable numeric core there's nothing to anchor
+     * a "core + flavour" split to and we leave the string alone.
+     *
+     * Examples:
+     *   `1.8.6-f`        → `1.8.6`     (full APK)
+     *   `1.8.6-m`        → `1.8.6`     (minified APK)
+     *   `1.8.6-arm64`    → `1.8.6`     (architecture)
+     *   `1.8.6-stable`   → `1.8.6`     (channel)
+     *   `1.8.6-b`        → `1.8.6-b`   (untouched: `b` could be beta)
+     *   `1.8.6-beta`     → `1.8.6-beta` (real pre-release)
+     *   `1.8.6-rc.1`     → `1.8.6-rc.1` (real pre-release)
+     */
+    private fun stripBuildVariantSuffix(version: String): String {
+        val parsed = parseSemanticVersion(version) ?: return version
+        val pre = parsed.preRelease ?: return version
+        if (!isBuildVariantMarker(pre)) return version
+        return parsed.numbers.joinToString(".")
+    }
+
+    private fun isBuildVariantMarker(preRelease: String): Boolean {
+        if (preRelease.isEmpty()) return false
+        // Compound pre-release identifiers (`armv7-beta`, `rc.1`) are
+        // ambiguous: even if the first token looks like a build flavour,
+        // a downstream segment may signal a real pre-release. Bail and
+        // keep the suffix intact rather than risk silently swallowing
+        // pre-release intent.
+        if (preRelease.contains('.') || preRelease.contains('-')) return false
+        val token = preRelease.lowercase()
+        // Real pre-release markers always win — don't strip something
+        // that semver/users treat as a pre-release identifier.
+        if (KNOWN_PRE_RELEASE_PREFIXES.any { token.startsWith(it) }) {
+            return false
+        }
+        if (M_DIGIT_TAIL_PATTERN.containsMatchIn(token)) return false
+        return BUILD_VARIANT_LITERALS.contains(token)
+    }
+
+    private val BUILD_VARIANT_LITERALS =
+        setOf(
+            // Build flavours (single-letter)
+            "f", "m", "l", "r", "d", "x",
+            // Build flavours (words)
+            "full", "mini", "minified", "lite", "release", "debug",
+            "extended",
+            // Distribution channel
+            "stable", "final", "prod", "production",
+            "gms", "fdroid", "github", "store",
+            // Architecture
+            "armv7", "armv8", "arm64", "armeabi",
+            "x86", "x64", "x86_64", "universal",
+            "android", "ios",
+        )
 
     private fun insertHyphenBeforeKnownMarker(s: String): String {
         val match = ADJACENT_ALPHA_PATTERN.find(s) ?: return s


### PR DESCRIPTION
## What this PR fixes
Closes #557.

Apps that emit multiple APK variants under a single GitHub tag (e.g. tag `1.8.6` published, but the APKs install as `1.8.6-f` for full / `1.8.6-m` for minified / `1.8.6-arm64` for an architecture split) currently always show as having an update available, because the bare GitHub tag ranks higher than the on-device versionName under semver pre-release ordering rules.

`VersionMath.normalizeVersion` now recognises and strips a curated set of build-variant / flavour markers from the semver pre-release identifier before comparison. Pre-release markers (`alpha`, `beta`, `rc`, `preview`, `nightly`, etc.) are preserved.

## Algorithm
- Apply only when the input parses as semver and has a single-segment pre-release identifier.
- Compound pre-release identifiers (`armv7-beta`, `rc.1`, `f-x86_64`) are left intact — too risky to disambiguate flavour-vs-pre-release from the tail alone.
- A guard check rejects anything whose first/only token starts with a known pre-release prefix (`alpha`, `beta`, `rc`, `preview`, `prerelease`, `snapshot`, `canary`, `nightly`, `milestone`, `ea`, `dev`, `pre`, `m\d+`).
- The remaining single-segment identifiers are matched against a literal allowlist:
  - **Build flavours** (single-letter): `f`, `m`, `l`, `r`, `d`, `x`
  - **Build flavours** (words): `full`, `mini`, `minified`, `lite`, `release`, `debug`, `extended`
  - **Distribution channel**: `stable`, `final`, `prod`, `production`, `gms`, `fdroid`, `github`, `store`
  - **Architecture**: `armv7`, `armv8`, `arm64`, `armeabi`, `x86`, `x64`, `x86_64`, `universal`, `android`, `ios`

## Behaviour matrix
| Comparison | Before | After |
| --- | --- | --- |
| `isVersionNewer("1.8.6", "1.8.6-f")` | `true` (phantom) | `false` ✓ |
| `isVersionNewer("1.8.6", "1.8.6-m")` | `true` (phantom) | `false` ✓ |
| `isVersionNewer("1.8.6", "1.8.6-arm64")` | `true` (phantom) | `false` ✓ |
| `isVersionNewer("1.8.6", "1.8.6-stable")` | `true` (phantom) | `false` ✓ |
| `isVersionNewer("1.8.7", "1.8.6-f")` | `true` | `true` (real update) ✓ |
| `isVersionNewer("1.8.6", "1.8.6-b")` | `true` | `true` (`b` could be beta — conservative, untouched) |
| `isVersionNewer("1.8.6", "1.8.6-beta")` | `true` | `true` (real pre-release) |
| `isVersionNewer("1.8.6", "1.8.6-rc.1")` | `true` | `true` (compound, untouched) |
| `isVersionNewer("1.8.6-f", "1.8.6-m")` | n/a | `false` (both strip to `1.8.6`) |

## Scope
- `normalizeVersion` (and therefore `isVersionNewer`, `compareVersions`, `isSameVersion`, `ExternalInstallVerdict`, the periodic `checkForUpdates` path, the `DetailsState.findRelease` lookup) all benefit from the strip.
- `isExactSameVersion` is intentionally **unchanged** — its existing docstring states it distinguishes build-metadata variants for the install-CTA gate (`SmartInstallButton`, `AppHeader`). Preserving that behaviour avoids a surprise change in those callers.

## Test plan
- [ ] Manual: install a known multi-flavour app (e.g. N-Zik full APK on a `1.8.6-f` versionName, GitHub tag `1.8.6`). Trigger update check. Verify update badge disappears.
- [ ] Same setup, publish a real new release (`1.8.7`) → verify update badge re-appears.
- [ ] Verify beta apps tagged `1.8.6-beta` still surface stable `1.8.6` as available (semver: stable > pre-release).
- [ ] Spot-check an app that uses architecture-suffixed versionNames (`-arm64`, `-armv7`) — phantom update should be gone.

## Out of scope
- Per-app override / regex strip rule (the broader proposal in the issue body). The maintainers can add an `assetFilterRegex`-equivalent for versionName patterns if the curated list misses anyone.
- Touching `isExactSameVersion`. Could be a follow-up for the install button on the details screen, but that's a separate UX call about whether `1.8.6-f` and `1.8.6` are "the same release".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version normalization to better handle build-variant and flavor suffixes in version strings, ensuring more consistent comparison and display while preserving meaningful pre-release information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/560)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->