### PR TITLE
Robust long-text handling on app rows, repo headers, announcements (refs #538)

### DIFF
--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/announcements/AnnouncementCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/announcements/AnnouncementCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.domain.model.Announcement
@@ -101,6 +102,8 @@ fun AnnouncementCard(
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
                 )
 
                 ExpandableBody(announcement.body)

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -915,16 +915,19 @@ fun AppItemCard(
                     apkFilePath = app.pendingInstallFilePath,
                 )
 
-                Column(modifier = Modifier.weight(1f)) {
+                Column(modifier = Modifier.weight(1f).fillMaxWidth()) {
                     Text(
                         text = app.appName,
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
 
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
                         CoilImage(
                             imageModel = { app.repoOwnerAvatarUrl },
@@ -946,6 +949,9 @@ fun AppItemCard(
                             text = app.repoOwner,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
                         )
                     }
 
@@ -998,6 +1004,8 @@ fun AppItemCard(
                                     ),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.primary,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
                             )
                             // Show the pinned variant tag inline so users can
                             // see at a glance which APK they'll get when they
@@ -1011,6 +1019,8 @@ fun AppItemCard(
                                         ),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                         }
@@ -1026,6 +1036,8 @@ fun AppItemCard(
                                     ),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         }
                     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.coil3.CoilImage
 import org.jetbrains.compose.resources.stringResource
@@ -163,6 +164,8 @@ fun AppHeader(
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onBackground,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f, fill = false),
                     )
 
@@ -175,6 +178,8 @@ fun AppHeader(
                         text = stringResource(Res.string.by_author, author),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
 


### PR DESCRIPTION
## What this PR fixes
Refs #538 (UI portion).

Long app names, repo names, owner handles, and version labels could break the layout — pushing siblings off-screen, wrapping awkwardly under the action button, or stacking 4–5 lines deep on apps with verbose versionName schemes (calver dates, multi-segment build identifiers, locale strings).

## Hardened components

### `AppItemCard` (apps screen)
- `app.appName` → `maxLines = 2, overflow = Ellipsis`
- `app.repoOwner` → `maxLines = 1, overflow = Ellipsis`, given `weight(1f, fill = false)` so it ellipsises before squeezing siblings.
- Version label (both `isUpdateAvailable` and idle branches) → `maxLines = 2, overflow = Ellipsis` — accommodates `1.8.6 → 1.8.7 (released yesterday)` style strings without losing the tail.
- Inline variant tag → `maxLines = 1, overflow = Ellipsis`.
- Column gets `fillMaxWidth()` and the inner Row gets `fillMaxWidth()` so the weight allocation is unambiguous.

### `AppHeader` (details screen)
- `repository.name` → `maxLines = 2, overflow = Ellipsis`. Long repo names like `awesome-cross-platform-multimedia-toolkit-x` no longer push the fork badge off the right edge.
- Author byline → `maxLines = 1, overflow = Ellipsis`.
- Required adding `import androidx.compose.ui.text.style.TextOverflow`.

### `AnnouncementCard`
- Announcement title → `maxLines = 3, overflow = Ellipsis`. Three lines is the comfort ceiling — a single critical advisory shouldn't be able to push the body, action row, or acknowledge button off-screen.
- Required adding `import androidx.compose.ui.text.style.TextOverflow`.

## Already protected (no changes needed)
- `CompactAppRow` — already uses `maxLines = 1, overflow = Ellipsis` on appName / repoOwner / version label.
- `RepositoryCard` — already protects every dynamic field on the discovery card.
- `SkippedUpdatesRoot` — already protects appName / skippedTag / installedVersion.
- `InspectRow` (APK Inspect sheet) — intentionally unprotected because the SHA-256 fingerprint is meant to wrap fully so users can verify it.

## Test plan
- [ ] Install an app with an extremely long versionName (e.g. \`1.0.0+build.20260510.commit.abc123def4567890\`) — the row stays single-card, ellipsises cleanly, and the action button stays accessible.
- [ ] Install an app whose owner login is 30+ chars — owner ellipsises, doesn't push avatar.
- [ ] Open details on a repo with a multi-word name — name fits within 2 lines, fork badge still visible.
- [ ] Trigger a multi-paragraph announcement — title caps at 3 lines, body still readable, acknowledge button still tappable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied text line limits and ellipsis to text elements across announcement cards, app listings, and app detail sections for consistent display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->