### PR TITLE
Fix compile errors in feature:tweaks:presentation post-merge

### DIFF
--- a/feature/tweaks/presentation/build.gradle.kts
+++ b/feature/tweaks/presentation/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
                 implementation(libs.androidx.compose.ui.tooling.preview)
                 implementation(libs.jetbrains.compose.components.resources)
                 implementation(libs.touchlab.kermit)
+                implementation(libs.kotlinx.collections.immutable)
 
                 api(libs.ktor.client.core)
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -485,6 +485,10 @@ class TweaksViewModel(
                 // Handled in composable
             }
 
+            TweaksAction.OnSkippedUpdatesClick -> {
+                // Handled in composable (navigates to the skipped-updates screen).
+            }
+
             is TweaksAction.OnThemeColorSelected -> {
                 viewModelScope.launch {
                     tweaksRepository.setThemeColor(action.themeColor)

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/skipped/SkippedUpdatesRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/skipped/SkippedUpdatesRoot.kt
@@ -43,6 +43,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.navigate_back
 import zed.rainxch.githubstore.core.presentation.res.skipped_updates_empty_description
 import zed.rainxch.githubstore.core.presentation.res.skipped_updates_empty_title
 import zed.rainxch.githubstore.core.presentation.res.skipped_updates_installed_label


### PR DESCRIPTION
## Why
After #559 (skip-version polish), #561 (downgrade detection), and #564 (text overflow) all landed on main, \`./gradlew compileDebugKotlinAndroid\` from \`main\` failed with three errors in \`:feature:tweaks:presentation\`. CI didn't catch this because each individual PR compiled fine in isolation — the regression only surfaced once all three were merged together.

## Errors fixed

1. **`SkippedUpdatesState.kt` / `SkippedUpdatesViewModel.kt`** — imported `kotlinx.collections.immutable.ImmutableList`, `persistentListOf`, and `toImmutableList`, but the module's `build.gradle.kts` had no dependency on `kotlinx-collections-immutable`. Eight unresolved-reference errors.
   - Fix: add `implementation(libs.kotlinx.collections.immutable)` to `feature/tweaks/presentation/build.gradle.kts` `commonMain` (the alias already exists in `gradle/libs.versions.toml`).

2. **`SkippedUpdatesRoot.kt:96`** — `stringResource(Res.string.navigate_back)` referenced without an explicit per-string import. compose-resources requires every string to be individually imported alongside the `Res` reference.
   - Fix: `import zed.rainxch.githubstore.core.presentation.res.navigate_back`.

3. **`TweaksViewModel.onAction()`** — `when (action)` missing the `OnSkippedUpdatesClick` branch. The composable handles the navigation, so the ViewModel branch is a no-op, but the compiler-promoted exhaustiveness check still requires it.
   - Fix: add a no-op `TweaksAction.OnSkippedUpdatesClick -> { /* handled in composable */ }` branch.

## Verify
```
./gradlew compileDebugKotlinAndroid     # passes
./gradlew compileKotlinJvm              # passes
```

Only pre-existing warnings remain (`Unnecessary safe call` in `DetailsViewModel.kt` lines 510 + 1469) — unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation to a skipped updates screen, now accessible from the settings interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/565)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->