### PR TITLE
Install button labels picked release for not-yet-installed apps

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -250,6 +250,20 @@ fun SmartInstallButton(
                 stringResource(Res.string.install_version, normSelected)
             }
 
+            // Not installed yet, but the user reached for the release picker
+            // and chose something other than the newest available release —
+            // the CTA should reflect *which* version will install instead of
+            // misleading them with "Install latest". The latest tag comes
+            // from the head of `allReleases` (GitHub returns newest-first
+            // by `published_at`); fall through to "Install latest" only when
+            // we genuinely can't tell, or the user is already on the head.
+            normSelected != null &&
+                state.allReleases.firstOrNull()?.tagName?.let { latestTag ->
+                    !VersionMath.isExactSameVersion(latestTag, normSelected)
+                } == true -> {
+                stringResource(Res.string.install_version, normSelected)
+            }
+
             else -> {
                 stringResource(Res.string.install_latest)
             }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/SmartInstallButton.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
@@ -97,6 +98,18 @@ fun SmartInstallButton(
         installedApp?.installedVersion?.trim()?.takeIf { it.isNotBlank() }
     val normSelected =
         state.selectedRelease?.tagName?.trim()?.takeIf { it.isNotBlank() }
+
+    // Some maintainers tag releases with path-style strings such as
+    // `com.akylas.documentscanner/android/github/1.21.0/152`. Using the raw
+    // tag in "Install version X" wraps the CTA across two lines and looks
+    // broken. `VersionMath.normalizeVersion` already extracts the
+    // dotted-digit core for these cases (`1.21.0`), so reuse it for the
+    // *display* tag while leaving the actual install pipeline on the raw
+    // tag (which has to match GitHub exactly).
+    val displaySelected =
+        normSelected?.let { tag ->
+            VersionMath.normalizeVersion(tag).takeIf { it.isNotBlank() } ?: tag
+        }
 
     val isSameVersionInstalled =
         isInstalled &&
@@ -247,7 +260,7 @@ fun SmartInstallButton(
                 normInstalled != null &&
                 normSelected != null &&
                 !VersionMath.isExactSameVersion(normInstalled, normSelected) -> {
-                stringResource(Res.string.install_version, normSelected)
+                stringResource(Res.string.install_version, displaySelected ?: normSelected)
             }
 
             // Not installed yet, but the user reached for the release picker
@@ -261,7 +274,7 @@ fun SmartInstallButton(
                 state.allReleases.firstOrNull()?.tagName?.let { latestTag ->
                     !VersionMath.isExactSameVersion(latestTag, normSelected)
                 } == true -> {
-                stringResource(Res.string.install_version, normSelected)
+                stringResource(Res.string.install_version, displaySelected ?: normSelected)
             }
 
             else -> {
@@ -419,6 +432,8 @@ fun SmartInstallButton(
                                     },
                                 fontWeight = FontWeight.Bold,
                                 style = MaterialTheme.typography.titleMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         }
 


### PR DESCRIPTION
## Repro
1. Open details for an app you don't have installed.
2. Open the release picker, pick something other than the newest release.
3. The CTA still says "Install latest" — but tapping it installs the older release the picker is on. Misleading.

## Cause
`SmartInstallButton` only switched to the "Install version X" label inside the **isInstalled && installed != selected** branch. When the app wasn't installed at all, that branch was skipped and the cascade fell straight to the `else -> "Install latest"` regardless of what the picker had selected.

## Fix
Insert an intermediate branch that fires when the app isn't installed yet but `state.selectedRelease.tagName` differs from `state.allReleases.first().tagName` (GitHub returns the feed newest-first by `published_at`, so the head is the latest). When that's the case, render `Install version <selectedTag>`.

`Install latest` stays as the genuine fall-through:
- the picker is on the head of `allReleases`, or
- `allReleases` is empty / we can't compare.

## Behaviour matrix
| State | Picker selection | Before | After |
| --- | --- | --- | --- |
| Not installed | Latest release | Install latest | Install latest (unchanged) |
| Not installed | **Older release** | Install latest | **Install version X** ✓ |
| Installed v1.0, no update | Same v1.0 | Open / Uninstall (handled higher up) | unchanged |
| Installed v1.0, update available | (any) | Update to vY | unchanged |
| Installed v1.0 | Different v0.9 | Install version 0.9 | unchanged |

## Verify
`./gradlew :feature:details:presentation:compileDebugKotlinAndroid` passes clean (only pre-existing warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer install button messaging: selecting a specific release now shows "Install [version]" instead of defaulting to "Install Latest".
  * Display-friendly version labels: version strings are normalized for display so long/path-like tags don’t wrap.
  * Preserves install behavior: the actual selected tag remains unchanged for installation.
  * Button text now enforces a single-line display with ellipsis for overflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/566)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->