### PR TITLE
fix(search): lower MIN_QUERY_LENGTH to 2 (#372)

### DIFF
--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -73,7 +73,12 @@ class SearchViewModel(
     private val exploreLog = logger.withTag("SearchExplore")
 
     companion object {
-        private const val MIN_QUERY_LENGTH = 3
+        // 2 covers common CJK app names that are exactly two characters
+        // (`B站`, `微博`, `抖音`, `美团`, …) which the previous 3-char floor
+        // silently rejected even when the user explicitly tapped the IME
+        // search action (#372). Single-character queries are still gated
+        // because they'd return millions of GitHub results.
+        private const val MIN_QUERY_LENGTH = 2
     }
 
     private val _state = MutableStateFlow(SearchState())


### PR DESCRIPTION
Search silently no-op'd on 2-char queries because the gate was 3. Hits CJK app names hardest — `B站`, `微博`, `抖音`, `美团` all rejected. Tapping the IME Search action did nothing. Lower the floor to 2; single-char queries stay blocked (would return millions of results). Closes #372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries can now be as short as 2 characters, down from 3, enabling faster discovery of apps with shorter names.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/571)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->