### PR TITLE
chore(apps): rename FAB Add by link to Track an app (#535)

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -577,7 +577,7 @@
     <string name="battery_optimization_card_open">فتح الإعدادات</string>
     <string name="battery_optimization_card_dismiss">ربما لاحقاً</string>
 
-    <string name="add_by_link">إضافة عبر رابط</string>
+    <string name="add_by_link">تتبّع تطبيقًا</string>
     <string name="link_app_title">ربط التطبيق بالمستودع</string>
     <string name="pick_installed_app">اختر تطبيقاً مثبتاً لربطه بمستودع GitHub</string>
     <string name="search_apps_hint">البحث عن التطبيقات…</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -576,7 +576,7 @@
     <string name="battery_optimization_card_open">সেটিংস খুলুন</string>
     <string name="battery_optimization_card_dismiss">পরে</string>
 
-    <string name="add_by_link">লিঙ্ক দিয়ে যোগ করুন</string>
+    <string name="add_by_link">অ্যাপ ট্র্যাক করুন</string>
     <string name="link_app_title">অ্যাপ রিপোজিটরিতে লিঙ্ক করুন</string>
     <string name="pick_installed_app">GitHub রিপোজিটরিতে লিঙ্ক করতে একটি ইনস্টল করা অ্যাপ বেছে নিন</string>
     <string name="search_apps_hint">অ্যাপ খুঁজুন…</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -537,7 +537,7 @@
     <string name="battery_optimization_card_open">Abrir ajustes</string>
     <string name="battery_optimization_card_dismiss">Más tarde</string>
 
-    <string name="add_by_link">Añadir por enlace</string>
+    <string name="add_by_link">Seguir una app</string>
     <string name="link_app_title">Vincular app al repositorio</string>
     <string name="pick_installed_app">Elige una app instalada para vincularla a un repositorio de GitHub</string>
     <string name="search_apps_hint">Buscar apps…</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -538,7 +538,7 @@
     <string name="battery_optimization_card_open">Ouvrir les paramètres</string>
     <string name="battery_optimization_card_dismiss">Plus tard</string>
 
-    <string name="add_by_link">Ajouter par lien</string>
+    <string name="add_by_link">Suivre une appli</string>
     <string name="link_app_title">Lier l'app au dépôt</string>
     <string name="pick_installed_app">Choisissez une app installée à lier à un dépôt GitHub</string>
     <string name="search_apps_hint">Rechercher des apps…</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -575,7 +575,7 @@
     <string name="battery_optimization_card_open">सेटिंग्स खोलें</string>
     <string name="battery_optimization_card_dismiss">बाद में</string>
 
-    <string name="add_by_link">लिंक से जोड़ें</string>
+    <string name="add_by_link">ऐप ट्रैक करें</string>
     <string name="link_app_title">ऐप को रिपॉजिटरी से लिंक करें</string>
     <string name="pick_installed_app">GitHub रिपॉजिटरी से लिंक करने के लिए एक इंस्टॉल किया हुआ ऐप चुनें</string>
     <string name="search_apps_hint">ऐप्स खोजें…</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -576,7 +576,7 @@
     <string name="battery_optimization_card_open">Apri impostazioni</string>
     <string name="battery_optimization_card_dismiss">Più tardi</string>
 
-    <string name="add_by_link">Aggiungi tramite link</string>
+    <string name="add_by_link">Traccia un\'app</string>
     <string name="link_app_title">Collega app al repository</string>
     <string name="pick_installed_app">Scegli un'app installata da collegare a un repository GitHub</string>
     <string name="search_apps_hint">Cerca app…</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -539,7 +539,7 @@
     <string name="battery_optimization_card_open">設定を開く</string>
     <string name="battery_optimization_card_dismiss">後で</string>
 
-    <string name="add_by_link">リンクで追加</string>
+    <string name="add_by_link">アプリを追跡</string>
     <string name="link_app_title">アプリをリポジトリにリンク</string>
     <string name="pick_installed_app">GitHubリポジトリにリンクするインストール済みアプリを選択</string>
     <string name="search_apps_hint">アプリを検索…</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -574,7 +574,7 @@
     <string name="battery_optimization_card_open">설정 열기</string>
     <string name="battery_optimization_card_dismiss">나중에</string>
 
-    <string name="add_by_link">링크로 추가</string>
+    <string name="add_by_link">앱 추적</string>
     <string name="link_app_title">앱을 저장소에 연결</string>
     <string name="pick_installed_app">GitHub 저장소에 연결할 설치된 앱을 선택하세요</string>
     <string name="search_apps_hint">앱 검색…</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -540,7 +540,7 @@
     <string name="battery_optimization_card_open">Otwórz ustawienia</string>
     <string name="battery_optimization_card_dismiss">Później</string>
 
-    <string name="add_by_link">Dodaj przez link</string>
+    <string name="add_by_link">Śledź aplikację</string>
     <string name="link_app_title">Połącz aplikację z repozytorium</string>
     <string name="pick_installed_app">Wybierz zainstalowaną aplikację, aby połączyć ją z repozytorium GitHub</string>
     <string name="search_apps_hint">Szukaj aplikacji…</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -540,7 +540,7 @@
     <string name="battery_optimization_card_open">Открыть настройки</string>
     <string name="battery_optimization_card_dismiss">Позже</string>
 
-    <string name="add_by_link">Добавить по ссылке</string>
+    <string name="add_by_link">Отслеживать приложение</string>
     <string name="link_app_title">Привязать приложение к репозиторию</string>
     <string name="pick_installed_app">Выберите установленное приложение для привязки к репозиторию GitHub</string>
     <string name="search_apps_hint">Поиск приложений…</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -574,7 +574,7 @@
     <string name="battery_optimization_card_open">Ayarları aç</string>
     <string name="battery_optimization_card_dismiss">Sonra</string>
 
-    <string name="add_by_link">Bağlantıyla ekle</string>
+    <string name="add_by_link">Uygulama izle</string>
     <string name="link_app_title">Uygulamayı depoya bağla</string>
     <string name="pick_installed_app">GitHub deposuna bağlamak için yüklü bir uygulama seçin</string>
     <string name="search_apps_hint">Uygulama ara…</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -540,7 +540,7 @@
     <string name="battery_optimization_card_open">打开设置</string>
     <string name="battery_optimization_card_dismiss">稍后</string>
 
-    <string name="add_by_link">通过链接添加</string>
+    <string name="add_by_link">追踪应用</string>
     <string name="link_app_title">将应用链接到仓库</string>
     <string name="pick_installed_app">选择一个已安装的应用以链接到GitHub仓库</string>
     <string name="search_apps_hint">搜索应用…</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -677,7 +677,7 @@
     <string name="battery_optimization_card_open">Open settings</string>
     <string name="battery_optimization_card_dismiss">Maybe later</string>
 
-    <string name="add_by_link">Add by link</string>
+    <string name="add_by_link">Track an app</string>
     <string name="link_app_title">Link app to repository</string>
     <string name="pick_installed_app">Pick an installed app to link with a GitHub repository</string>
     <string name="search_apps_hint">Search apps…</string>


### PR DESCRIPTION
FAB on Apps screen now reads "Track an app" instead of "Add by link". Users complained (issue #535) they couldn't find the "pick from installed apps" entry — turns out it's already step 1 of the Add-by-link flow, but the FAB label hid it. New label communicates the broader intent. String value swap only, key unchanged. 13 locales.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated UI text from "Add by link" to "Track an app" across all supported languages (English, Arabic, Bengali, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Russian, Turkish, and Chinese).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/572)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->