### PR TITLE
fix(apps): re-check on Apps screen resume (#514)

### DIFF
--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -37,6 +37,15 @@ sealed interface AppsAction {
 
     data object OnRefresh : AppsAction
 
+    // Fired by AppsRoot on ON_RESUME. Routes through the existing
+    // cooldown-gated refresh path (`autoCheckForUpdatesIfNeeded`) so
+    // re-entering the Apps screen catches external installs that
+    // `PackageEventReceiver` may have missed — e.g. when GHS was
+    // background-killed by an aggressive OEM ROM and never received
+    // the PACKAGE_REPLACED broadcast. The 30-minute cooldown keeps
+    // rapid resumes from burning GitHub rate limits.
+    data object OnLifecycleResume : AppsAction
+
     data object OnToggleUpToDateSection : AppsAction
 
     data class OnNavigateToRepo(

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -65,11 +65,15 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -175,11 +179,11 @@ fun AppsRoot(
     // `PackageEventReceiver` missed when GHS was background-killed by
     // an aggressive OEM ROM. The VM debounces network calls via
     // `UPDATE_CHECK_COOLDOWN_MS` (30 min) so rapid resumes are cheap.
-    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
-    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
         val observer =
-            androidx.lifecycle.LifecycleEventObserver { _, event ->
-                if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
                     viewModel.onAction(AppsAction.OnLifecycleResume)
                 }
             }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -170,6 +170,23 @@ fun AppsRoot(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
+    // Re-entry sync: fires the cooldown-gated update check whenever the
+    // user returns to the Apps screen. Catches external installs that
+    // `PackageEventReceiver` missed when GHS was background-killed by
+    // an aggressive OEM ROM. The VM debounces network calls via
+    // `UPDATE_CHECK_COOLDOWN_MS` (30 min) so rapid resumes are cheap.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer =
+            androidx.lifecycle.LifecycleEventObserver { _, event ->
+                if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                    viewModel.onAction(AppsAction.OnLifecycleResume)
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
             is AppsEvent.NavigateToRepo -> {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -189,20 +189,20 @@ class AppsViewModel(
 
     private fun checkAllForUpdates() {
         viewModelScope.launch {
-            // Stamp the timestamp at launch start so a second resume that
-            // races the network call finds the cooldown gate already
-            // tripped and exits — otherwise both runs proceed concurrently
-            // because the previous version updated the timestamp only on
-            // success completion. The cooldown thus doubles as a
-            // single-inflight guard for autoCheckForUpdatesIfNeeded.
-            val now = System.currentTimeMillis()
-            lastAutoCheckTimestamp = now
-            _state.update {
-                it.copy(isCheckingForUpdates = true, lastCheckedTimestamp = now)
-            }
+            // Stamp the inflight guard at launch start — a second resume
+            // that races the network call finds the cooldown gate already
+            // tripped and exits early. `lastCheckedTimestamp` (the UI
+            // "last checked" indicator) still only advances on success so
+            // a failed check doesn't lie to the user — matches the
+            // `refresh()` semantics.
+            lastAutoCheckTimestamp = System.currentTimeMillis()
+            _state.update { it.copy(isCheckingForUpdates = true) }
             try {
                 syncInstalledAppsUseCase()
                 installedAppsRepository.checkAllForUpdates()
+                _state.update {
+                    it.copy(lastCheckedTimestamp = System.currentTimeMillis())
+                }
             } catch (e: Exception) {
                 logger.error("Check all for updates failed: ${e.message}")
             } finally {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -189,13 +189,20 @@ class AppsViewModel(
 
     private fun checkAllForUpdates() {
         viewModelScope.launch {
-            _state.update { it.copy(isCheckingForUpdates = true) }
+            // Stamp the timestamp at launch start so a second resume that
+            // races the network call finds the cooldown gate already
+            // tripped and exits — otherwise both runs proceed concurrently
+            // because the previous version updated the timestamp only on
+            // success completion. The cooldown thus doubles as a
+            // single-inflight guard for autoCheckForUpdatesIfNeeded.
+            val now = System.currentTimeMillis()
+            lastAutoCheckTimestamp = now
+            _state.update {
+                it.copy(isCheckingForUpdates = true, lastCheckedTimestamp = now)
+            }
             try {
                 syncInstalledAppsUseCase()
                 installedAppsRepository.checkAllForUpdates()
-                val now = System.currentTimeMillis()
-                lastAutoCheckTimestamp = now
-                _state.update { it.copy(lastCheckedTimestamp = now) }
             } catch (e: Exception) {
                 logger.error("Check all for updates failed: ${e.message}")
             } finally {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -298,6 +298,10 @@ class AppsViewModel(
                 refresh()
             }
 
+            AppsAction.OnLifecycleResume -> {
+                autoCheckForUpdatesIfNeeded()
+            }
+
             AppsAction.OnToggleUpToDateSection -> {
                 _state.update { it.copy(isUpToDateSectionExpanded = !it.isUpToDateSectionExpanded) }
             }


### PR DESCRIPTION
Apps row could stay stuck at the old version when an external install (file-manager sideload, update via another app) landed while GHS was background-killed by an aggressive OEM ROM — `PackageEventReceiver` never received `PACKAGE_REPLACED`, and `SyncInstalledAppsUseCase` only ran on cold start (`hasLoadedInitialData` flag, once per VM lifetime). Result: GHS kept prompting for a version the user already installed (NextPlayer case in #514).

Wire `AppsRoot` to fire `AppsAction.OnLifecycleResume` on `ON_RESUME`. VM routes through `autoCheckForUpdatesIfNeeded` which honors the existing 30-min cooldown — so rapid resumes don't burn GitHub rate limits, but the first resume after a missed external install catches the drift. Closes #514.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps screen now triggers a lifecycle-driven refresh when you return to it so newly installed apps are detected promptly, while respecting a 30-minute cooldown to avoid excessive checks.

* **Bug Fixes**
  * Update-check indicators and "last checked" timestamps now update immediately when a check starts, providing clearer feedback during refresh.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/573)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->