### PR TITLE
fix(tweaks): proxy host validation + save-needs-two-taps

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -154,6 +154,7 @@
     <string name="proxy_none_description">اتصال مباشر، بدون وكيل</string>
     <string name="failed_to_save_proxy_settings">فشل حفظ إعدادات الوكيل</string>
     <string name="proxy_host_required">المضيف مطلوب</string>
+    <string name="proxy_host_invalid">أدخل اسم مضيف أو عنوان IP صالحًا</string>
     <string name="invalid_proxy_port">منفذ الوكيل غير صالح</string>
     <string name="proxy_show_password">إظهار كلمة المرور</string>
     <string name="proxy_hide_password">إخفاء كلمة المرور</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -422,6 +422,7 @@
     <string name="proxy_none_description">সরাসরি সংযোগ, কোনো প্রক্সি নেই</string>
     <string name="failed_to_save_proxy_settings">প্রক্সি সেটিংস সংরক্ষণ করতে ব্যর্থ হয়েছে</string>
     <string name="proxy_host_required">প্রক্সি হোস্ট প্রয়োজন</string>
+    <string name="proxy_host_invalid">একটি বৈধ হোস্টনাম বা IP ঠিকানা লিখুন</string>
     <string name="invalid_proxy_port">অবৈধ প্রক্সি পোর্ট</string>
     <string name="proxy_show_password">পাসওয়ার্ড দেখান</string>
     <string name="proxy_hide_password">পাসওয়ার্ড লুকান</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -387,6 +387,7 @@
     <string name="proxy_none_description">Conexión directa, sin proxy</string>
     <string name="failed_to_save_proxy_settings">No se pudieron guardar los ajustes del proxy</string>
     <string name="proxy_host_required">Se requiere el host del proxy</string>
+    <string name="proxy_host_invalid">Introduce un nombre de host o dirección IP válida</string>
     <string name="invalid_proxy_port">Puerto de proxy no válido</string>
     <string name="proxy_show_password">Mostrar contraseña</string>
     <string name="proxy_hide_password">Ocultar contraseña</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -387,6 +387,7 @@
     <string name="proxy_none_description">Connexion directe, pas de proxy</string>
     <string name="failed_to_save_proxy_settings">Échec de l'enregistrement des paramètres du proxy</string>
     <string name="proxy_host_required">L’hôte du proxy est requis</string>
+    <string name="proxy_host_invalid">Saisissez un nom d’hôte ou une adresse IP valide</string>
     <string name="invalid_proxy_port">Port proxy invalide</string>
     <string name="proxy_show_password">Afficher le mot de passe</string>
     <string name="proxy_hide_password">Masquer le mot de passe</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -421,6 +421,7 @@
     <string name="proxy_none_description">सीधा कनेक्शन, कोई प्रॉक्सी नहीं</string>
     <string name="failed_to_save_proxy_settings">प्रॉक्सी सेटिंग्स सहेजने में विफल</string>
     <string name="proxy_host_required">प्रॉक्सी होस्ट आवश्यक है</string>
+    <string name="proxy_host_invalid">मान्य होस्टनाम या IP पता दर्ज करें</string>
     <string name="invalid_proxy_port">अमान्य प्रॉक्सी पोर्ट</string>
     <string name="proxy_show_password">पासवर्ड दिखाएँ</string>
     <string name="proxy_hide_password">पासवर्ड छुपाएँ</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -422,7 +422,8 @@
     <string name="proxy_port_error">La porta deve essere 1–65535</string>
     <string name="proxy_none_description">Connessione diretta, nessun proxy</string>
     <string name="failed_to_save_proxy_settings">Impossibile salvare le impostazioni del proxy</string>
-    <string name="proxy_host_required">L'host del proxy è obbligatorio</string>
+    <string name="proxy_host_required">L\'host del proxy è obbligatorio</string>
+    <string name="proxy_host_invalid">Inserisci un nome host o indirizzo IP valido</string>
     <string name="invalid_proxy_port">Porta proxy non valida</string>
     <string name="proxy_show_password">Mostra password</string>
     <string name="proxy_hide_password">Nascondi password</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -387,6 +387,7 @@
     <string name="proxy_none_description">直接接続、プロキシなし</string>
     <string name="failed_to_save_proxy_settings">プロキシ設定の保存に失敗しました</string>
     <string name="proxy_host_required">プロキシホストは必須です</string>
+    <string name="proxy_host_invalid">有効なホスト名または IP アドレスを入力してください</string>
     <string name="invalid_proxy_port">無効なプロキシポート</string>
     <string name="proxy_show_password">パスワードを表示</string>
     <string name="proxy_hide_password">パスワードを非表示</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -420,6 +420,7 @@
     <string name="proxy_none_description">직접 연결, 프록시 없음</string>
     <string name="failed_to_save_proxy_settings">프록시 설정을 저장하지 못했습니다</string>
     <string name="proxy_host_required">프록시 호스트가 필요합니다</string>
+    <string name="proxy_host_invalid">유효한 호스트 이름 또는 IP 주소를 입력하세요</string>
     <string name="invalid_proxy_port">잘못된 프록시 포트</string>
     <string name="proxy_show_password">비밀번호 표시</string>
     <string name="proxy_hide_password">비밀번호 숨기기</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -385,6 +385,7 @@
     <string name="proxy_none_description">Połączenie bezpośrednie, bez proxy</string>
     <string name="failed_to_save_proxy_settings">Nie udało się zapisać ustawień proxy</string>
     <string name="proxy_host_required">Host proxy jest wymagany</string>
+    <string name="proxy_host_invalid">Wprowadź prawidłową nazwę hosta lub adres IP</string>
     <string name="invalid_proxy_port">Nieprawidłowy port proxy</string>
     <string name="proxy_show_password">Pokaż hasło</string>
     <string name="proxy_hide_password">Ukryj hasło</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -387,6 +387,7 @@
     <string name="proxy_none_description">Прямое подключение, без прокси</string>
     <string name="failed_to_save_proxy_settings">Не удалось сохранить настройки прокси</string>
     <string name="proxy_host_required">Требуется хост прокси</string>
+    <string name="proxy_host_invalid">Введите корректное имя хоста или IP-адрес</string>
     <string name="invalid_proxy_port">Недопустимый порт прокси</string>
     <string name="proxy_show_password">Показать пароль</string>
     <string name="proxy_hide_password">Скрыть пароль</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -419,6 +419,7 @@
     <string name="proxy_none_description">Doğrudan bağlantı, proxy yok</string>
     <string name="failed_to_save_proxy_settings">Proxy ayarları kaydedilemedi</string>
     <string name="proxy_host_required">Proxy ana bilgisayarı gerekli</string>
+    <string name="proxy_host_invalid">Geçerli bir ana bilgisayar adı veya IP adresi girin</string>
     <string name="invalid_proxy_port">Geçersiz proxy portu</string>
     <string name="proxy_show_password">Şifreyi göster</string>
     <string name="proxy_hide_password">Şifreyi gizle</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -388,6 +388,7 @@
     <string name="proxy_none_description">直连，不使用代理</string>
     <string name="failed_to_save_proxy_settings">无法保存代理设置</string>
     <string name="proxy_host_required">必须填写代理主机</string>
+    <string name="proxy_host_invalid">请输入有效的主机名或 IP 地址</string>
     <string name="invalid_proxy_port">无效的代理端口</string>
     <string name="proxy_show_password">显示密码</string>
     <string name="proxy_hide_password">隐藏密码</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="proxy_none_description">Direct connection, no proxy</string>
     <string name="failed_to_save_proxy_settings">Failed to save proxy settings</string>
     <string name="proxy_host_required">Proxy host is required</string>
+    <string name="proxy_host_invalid">Enter a valid hostname or IP address</string>
     <string name="invalid_proxy_port">Invalid proxy port</string>
     <string name="proxy_show_password">Show password</string>
     <string name="proxy_hide_password">Hide password</string>

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/components/sections/Options.kt
@@ -47,15 +47,16 @@ fun LazyListScope.options(
     onAction: (ProfileAction) -> Unit,
 ) {
     item {
-        OptionCard(
-            icon = Icons.Default.Star,
-            label = stringResource(Res.string.stars),
-            description = stringResource(Res.string.profile_stars_description),
-            onClick = {
-                onAction(ProfileAction.OnStarredReposClick)
-            },
-            enabled = isUserLoggedIn,
-        )
+        if (isUserLoggedIn) {
+            OptionCard(
+                icon = Icons.Default.Star,
+                label = stringResource(Res.string.stars),
+                description = stringResource(Res.string.profile_stars_description),
+                onClick = {
+                    onAction(ProfileAction.OnStarredReposClick)
+                },
+            )
+        }
 
         Spacer(Modifier.height(4.dp))
 
@@ -126,7 +127,6 @@ private fun OptionCard(
     description: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
     onLongClick: (() -> Unit)? = null,
     hasBadge: Boolean = false,
 ) {
@@ -145,7 +145,6 @@ private fun OptionCard(
     if (onLongClick != null) {
         Card(
             modifier = modifier.combinedClickable(
-                enabled = enabled,
                 onClick = onClick,
                 onLongClick = onLongClick,
             ),
@@ -153,7 +152,12 @@ private fun OptionCard(
             shape = cardShape,
             border = cardBorder,
         ) {
-            OptionCardContent(icon = icon, label = label, description = description, hasBadge = hasBadge)
+            OptionCardContent(
+                icon = icon,
+                label = label,
+                description = description,
+                hasBadge = hasBadge
+            )
         }
         return
     }
@@ -164,9 +168,12 @@ private fun OptionCard(
         onClick = onClick,
         shape = cardShape,
         border = cardBorder,
-        enabled = enabled,
     ) {
-        OptionCardContent(icon = icon, label = label, description = description)
+        OptionCardContent(
+            icon = icon,
+            label = label,
+            description = description
+        )
     }
 }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -142,13 +142,6 @@ fun TweaksRoot(
                             withDismissAction = true,
                         )
                     if (result == SnackbarResult.ActionPerformed) {
-                        // Best-effort relaunch on Desktop; see
-                        // `RestartApp.jvm.kt`. Falls back to plain
-                        // exit if a clean relaunch isn't possible
-                        // (IDE runs, sandbox restrictions) — the
-                        // preference is already persisted so the new
-                        // locale takes effect on the next manual
-                        // launch either way.
                         restartAppAfterLanguageChange()
                     }
                 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -62,6 +62,28 @@ class TweaksViewModel(
 ) : ViewModel() {
     private companion object {
         private const val BATTERY_OPT_PREF_READ_TIMEOUT_MS: Long = 1_000
+
+        // IPv4 dotted-quad, each octet 0..255.
+        private val IPV4_PATTERN =
+            Regex(
+                "^(25[0-5]|2[0-4]\\d|[01]?\\d?\\d)" +
+                    "(\\.(25[0-5]|2[0-4]\\d|[01]?\\d?\\d)){3}$",
+            )
+
+        // IPv6 literal — character-level only (hex groups + colons,
+        // optional `::` shortcut). Permissive on canonical form because
+        // proxy clients normalize it; we only need to reject "looks
+        // wrong" inputs like `not a url`.
+        private val IPV6_PATTERN = Regex("^[0-9A-Fa-f:]+$")
+
+        // RFC 1123 hostname: labels of 1..63 alphanumeric / hyphen,
+        // must start and end with alphanumeric, separated by dots.
+        // Total length capped at 253 by the caller.
+        private val HOSTNAME_PATTERN =
+            Regex(
+                "^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)" +
+                    "(?:\\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$",
+            )
     }
 
     private var hasLoadedInitialData = false
@@ -611,14 +633,16 @@ class TweaksViewModel(
                                         return
                                     }
                             val host =
-                                form.host.trim().takeIf { it.isNotBlank() }
+                                form.host.trim().takeIf { isValidProxyHost(it) }
                                     ?: run {
+                                        val msg =
+                                            if (form.host.isBlank()) {
+                                                getString(Res.string.proxy_host_required)
+                                            } else {
+                                                getString(Res.string.proxy_host_invalid)
+                                            }
                                         viewModelScope.launch {
-                                            _events.send(
-                                                TweaksEvent.OnProxySaveError(
-                                                    getString(Res.string.proxy_host_required),
-                                                ),
-                                            )
+                                            _events.send(TweaksEvent.OnProxySaveError(msg))
                                         }
                                         return
                                     }
@@ -995,14 +1019,16 @@ class TweaksViewModel(
                             return null
                         }
                 val host =
-                    form.host.trim().takeIf { it.isNotBlank() }
+                    form.host.trim().takeIf { isValidProxyHost(it) }
                         ?: run {
+                            val msg =
+                                if (form.host.isBlank()) {
+                                    getString(Res.string.proxy_host_required)
+                                } else {
+                                    getString(Res.string.proxy_host_invalid)
+                                }
                             viewModelScope.launch {
-                                _events.send(
-                                    TweaksEvent.OnProxyTestError(
-                                        getString(Res.string.proxy_host_required),
-                                    ),
-                                )
+                                _events.send(TweaksEvent.OnProxyTestError(msg))
                             }
                             return null
                         }
@@ -1015,6 +1041,35 @@ class TweaksViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Light-but-real proxy host validator. Accepts:
+     *  - IPv4 dotted-quad (`192.168.1.1`) with octet range 0..255
+     *  - IPv6 literal, with or without surrounding brackets (`::1`,
+     *    `[2001:db8::1]`) — character-level only, doesn't validate
+     *    canonical form
+     *  - RFC 1123 hostname — labels of 1..63 alphanumeric / hyphen
+     *    characters separated by dots, must start/end with alphanumeric
+     *
+     * Rejects: garbage strings (`not a url`), schemes (`http://...`),
+     * paths (`example.com/api`), spaces, control characters. Mirrors the
+     * port validator's "reject and show clear error" contract.
+     */
+    private fun isValidProxyHost(raw: String): Boolean {
+        val host = raw.trim()
+        if (host.isBlank()) return false
+        if (host.length > 253) return false
+        if (host.any { it.isWhitespace() }) return false
+        if (host.contains("://") || host.contains("/") ||
+            host.contains("?") || host.contains("#")
+        ) {
+            return false
+        }
+        if (IPV4_PATTERN.matches(host)) return true
+        val ipv6Candidate = host.trim('[', ']')
+        if (ipv6Candidate.contains(":") && IPV6_PATTERN.matches(ipv6Candidate)) return true
+        return HOSTNAME_PATTERN.matches(host)
     }
 
     private suspend fun ProxyTestOutcome.toEvent(): TweaksEvent =

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Appearance.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Appearance.kt
@@ -46,8 +46,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.getPlatform
 import zed.rainxch.core.domain.model.AppTheme
 import zed.rainxch.core.domain.model.FontTheme
+import zed.rainxch.core.domain.model.Platform
 import zed.rainxch.core.presentation.components.ExpressiveCard
 import zed.rainxch.core.presentation.theme.isDynamicColorAvailable
 import zed.rainxch.core.presentation.utils.displayName
@@ -120,14 +122,16 @@ fun LazyListScope.appearanceSection(
 
         Spacer(Modifier.height(8.dp))
 
-        ToggleSettingCard(
-            title = stringResource(Res.string.scrollbar_option_title),
-            description = stringResource(Res.string.scrollbar_option_description),
-            checked = state.isScrollbarEnabled,
-            onCheckedChange = { enabled ->
-                onAction(TweaksAction.OnScrollbarToggled(enabled))
-            },
-        )
+        if (getPlatform() != Platform.ANDROID) {
+            ToggleSettingCard(
+                title = stringResource(Res.string.scrollbar_option_title),
+                description = stringResource(Res.string.scrollbar_option_description),
+                checked = state.isScrollbarEnabled,
+                onCheckedChange = { enabled ->
+                    onAction(TweaksAction.OnScrollbarToggled(enabled))
+                },
+            )
+        }
     }
 }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Network.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Network.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -242,12 +243,19 @@ private fun ProxyDetailsFields(
     form: ProxyScopeFormState,
     onAction: (TweaksAction) -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
     val portValue = form.port
     val isPortInvalid =
         portValue.isNotEmpty() &&
             (portValue.toIntOrNull()?.let { it !in 1..65535 } ?: true)
+    val hostValue = form.host
+    // Real-time host validation mirrors the port pattern: only flag as
+    // invalid once the user has typed something, so the empty initial
+    // state doesn't shout an error at them.
+    val isHostInvalid = hostValue.isNotEmpty() && !isLikelyValidProxyHost(hostValue)
     val isFormValid =
-        form.host.isNotBlank() &&
+        hostValue.isNotEmpty() &&
+            !isHostInvalid &&
             portValue.isNotEmpty() &&
             portValue.toIntOrNull()?.let { it in 1..65535 } == true
 
@@ -265,6 +273,13 @@ private fun ProxyDetailsFields(
                 label = { Text(stringResource(Res.string.proxy_host)) },
                 placeholder = { Text("127.0.0.1") },
                 singleLine = true,
+                isError = isHostInvalid,
+                supportingText =
+                    if (isHostInvalid) {
+                        { Text(stringResource(Res.string.proxy_host_invalid)) }
+                    } else {
+                        null
+                    },
                 modifier = Modifier.weight(2f),
                 shape = RoundedCornerShape(12.dp),
             )
@@ -342,11 +357,22 @@ private fun ProxyDetailsFields(
             ProxyTestButton(
                 isInProgress = form.isTestInProgress,
                 enabled = isFormValid && !form.isTestInProgress,
-                onClick = { onAction(TweaksAction.OnProxyTest(scope)) },
+                onClick = {
+                    focusManager.clearFocus()
+                    onAction(TweaksAction.OnProxyTest(scope))
+                },
             )
 
             FilledTonalButton(
-                onClick = { onAction(TweaksAction.OnProxySave(scope)) },
+                // `clearFocus()` first so the IME commits any pending
+                // keystroke before the save runs — without this the
+                // user sometimes has to tap Save twice on Android,
+                // because the first tap goes to focus dismissal and the
+                // second one actually fires the click.
+                onClick = {
+                    focusManager.clearFocus()
+                    onAction(TweaksAction.OnProxySave(scope))
+                },
                 enabled = isFormValid && !form.isTestInProgress,
             ) {
                 Icon(
@@ -392,3 +418,40 @@ private fun ProxyTestButton(
         }
     }
 }
+
+/**
+ * UI-side mirror of `TweaksViewModel.isValidProxyHost`. Drives the
+ * real-time `isError` highlight on the host TextField so the user
+ * sees a problem before they tap Save — same UX as the port field.
+ * Authoritative validation still happens server-side in the VM; this
+ * is the optimistic, free-of-cost preview.
+ */
+private fun isLikelyValidProxyHost(raw: String): Boolean {
+    val host = raw.trim()
+    if (host.isBlank()) return false
+    if (host.length > 253) return false
+    if (host.any { it.isWhitespace() }) return false
+    if (host.contains("://") || host.contains("/") ||
+        host.contains("?") || host.contains("#")
+    ) {
+        return false
+    }
+    if (IPV4_PATTERN.matches(host)) return true
+    val ipv6Candidate = host.trim('[', ']')
+    if (ipv6Candidate.contains(":") && IPV6_PATTERN.matches(ipv6Candidate)) return true
+    return HOSTNAME_PATTERN.matches(host)
+}
+
+private val IPV4_PATTERN =
+    Regex(
+        "^(25[0-5]|2[0-4]\\d|[01]?\\d?\\d)" +
+            "(\\.(25[0-5]|2[0-4]\\d|[01]?\\d?\\d)){3}$",
+    )
+
+private val IPV6_PATTERN = Regex("^[0-9A-Fa-f:]+$")
+
+private val HOSTNAME_PATTERN =
+    Regex(
+        "^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)" +
+            "(?:\\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$",
+    )


### PR DESCRIPTION
Two bugs in the Tweaks → Network → Proxy form found in device-side bug-bash (#534 follow-up):

1. **Host accepted any non-blank text** (`not a url`, garbage with spaces, etc.). Only port had real-time validation. Added a hostname / IPv4 / IPv6 validator (`isValidProxyHost` in VM, mirrored as `isLikelyValidProxyHost` in Network.kt for the real-time `isError` highlight). Save + Test paths now reject malformed hosts with a clear error (`proxy_host_invalid` string across 13 locales).

2. **Save required two taps** — first tap lost IME focus from the host/port field, second tap actually fired the click. Wrapped both Save and Test `onClick` to call `LocalFocusManager.clearFocus()` first so the IME commits pending input synchronously.

Bonus: `isFormValid` now incorporates the host validity gate so the Save button stays disabled until the host parses cleanly — matches the port-side UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proxy host validation with real-time feedback and specific error messages distinguishing between missing and invalid inputs.

* **Improvements**
  * Refined proxy settings user experience with clearer validation error feedback.
  * Improved platform compatibility (Android UI adjustments).

* **Localization**
  * Added translated proxy validation error messages across 14 languages (Arabic, Bengali, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Russian, Turkish, and Chinese).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/576)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->