### PR TITLE
fix(tweaks): unbreak main — suspend getString in coroutine scope

### DIFF
--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -37,6 +37,7 @@ import zed.rainxch.tweaks.presentation.model.ProxyScopeFormState
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_save_proxy_settings
 import zed.rainxch.githubstore.core.presentation.res.invalid_proxy_port
+import zed.rainxch.githubstore.core.presentation.res.proxy_host_invalid
 import zed.rainxch.githubstore.core.presentation.res.proxy_host_required
 import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_auth_required
 import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_dns
@@ -635,13 +636,14 @@ class TweaksViewModel(
                             val host =
                                 form.host.trim().takeIf { isValidProxyHost(it) }
                                     ?: run {
-                                        val msg =
-                                            if (form.host.isBlank()) {
-                                                getString(Res.string.proxy_host_required)
-                                            } else {
-                                                getString(Res.string.proxy_host_invalid)
-                                            }
+                                        val isBlank = form.host.isBlank()
                                         viewModelScope.launch {
+                                            val msg =
+                                                if (isBlank) {
+                                                    getString(Res.string.proxy_host_required)
+                                                } else {
+                                                    getString(Res.string.proxy_host_invalid)
+                                                }
                                             _events.send(TweaksEvent.OnProxySaveError(msg))
                                         }
                                         return
@@ -1021,13 +1023,14 @@ class TweaksViewModel(
                 val host =
                     form.host.trim().takeIf { isValidProxyHost(it) }
                         ?: run {
-                            val msg =
-                                if (form.host.isBlank()) {
-                                    getString(Res.string.proxy_host_required)
-                                } else {
-                                    getString(Res.string.proxy_host_invalid)
-                                }
+                            val isBlank = form.host.isBlank()
                             viewModelScope.launch {
+                                val msg =
+                                    if (isBlank) {
+                                        getString(Res.string.proxy_host_required)
+                                    } else {
+                                        getString(Res.string.proxy_host_invalid)
+                                    }
                                 _events.send(TweaksEvent.OnProxyTestError(msg))
                             }
                             return null


### PR DESCRIPTION
Main is broken after #576 merged. The proxy-host validation path calls `getString(Res.string.proxy_host_*)` outside a coroutine — `getString` is a Compose Resources suspend function. Compiler error:

```
TweaksViewModel.kt:641:49 Suspend function 'suspend fun getString(resource: StringResource): String' can only be called from a coroutine or another suspend function.
```

(Also at lines 643, 1027, 1029.)

Fix: move the `getString` calls inside the existing `viewModelScope.launch { … }` block; pass the `isBlank` boolean across the boundary. Same fix in both `OnProxySave` and `buildProxyConfigForTest`. Verified locally with `./gradlew :feature:tweaks:presentation:compileDebugKotlinAndroid :feature:tweaks:presentation:compileKotlinJvm` — both green. Apologies for shipping the suspend bug into #576 without a compile pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced proxy host validation error messages to better distinguish between empty and invalid host inputs when saving or testing proxy configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/577)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->