### PR TITLE
ci(signpath): fix artifact-configuration slug to 'initial'

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -63,14 +63,27 @@ jobs:
           retry ./gradlew :composeApp:packageExe :composeApp:packageMsi
         shell: bash
 
+      # Flatten .exe + .msi into a single directory so the uploaded artifact
+      # zip contains them at the root (no `exe/` and `msi/` subdirectories).
+      # SignPath's artifact-configuration XML uses simple `*.exe` / `*.msi`
+      # globs at zip root; nested paths cause "Expected path to match exactly
+      # 1 item, but found 0" because upload-artifact@v4 strips the longest
+      # common prefix only, so multi-source paths preserve their tail dirs.
+      - name: Stage Windows installers for upload
+        run: |
+          set -euo pipefail
+          mkdir -p windows-staging
+          cp composeApp/build/compose/binaries/main/exe/*.exe windows-staging/
+          cp composeApp/build/compose/binaries/main/msi/*.msi windows-staging/
+          ls -la windows-staging/
+        shell: bash
+
       - name: Upload Windows installers
         id: upload-windows
         uses: actions/upload-artifact@v4
         with:
           name: windows-installers
-          path: |
-            composeApp/build/compose/binaries/main/exe/*.exe
-            composeApp/build/compose/binaries/main/msi/*.msi
+          path: windows-staging/*
           if-no-files-found: error
           retention-days: 30
           compression-level: 6

--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -120,7 +120,7 @@ jobs:
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: 'GitHub-Store'
           signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
-          artifact-configuration-slug: 'initial-version'
+          artifact-configuration-slug: 'initial'
           github-artifact-id: ${{ needs.build-windows.outputs.windows-artifact-id }}
           wait-for-completion: true
           output-artifact-directory: signed-artifacts

--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -95,6 +95,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write
 
     steps:
       # Fail loudly if any SignPath config is missing instead of letting the
@@ -146,6 +147,21 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           compression-level: 0
+
+      # Remove the unsigned upload so only the SignPath-signed installers are
+      # downloadable from the run page and end up in the draft release.
+      # Without this, both windows-installers (unsigned) and
+      # windows-installers-signed coexist as 30-day artifacts.
+      - name: Delete unsigned Windows artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_ID: ${{ needs.build-windows.outputs.windows-artifact-id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api -X DELETE "repos/${REPO}/actions/artifacts/${ARTIFACT_ID}"
+          echo "Deleted unsigned artifact id=${ARTIFACT_ID}"
+        shell: bash
 
   build-macos:
     strategy:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Windows installer outputs into a single staged package uploaded as one artifact.
  * Updated Windows signing configuration to use the revised signing target name.
  * Expanded signing job permissions to allow write actions.
  * Automatically remove the unsigned installer artifact after signing so only signed installers remain.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/580)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->