### PR TITLE
feat: search in favourites + starred (#562)

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -9,7 +9,8 @@
       "bullets": [
         "Ignore updates per app — silence the update badge for any app you don't want to update.",
         "Skip a specific update — dismiss a single release if it's a false-positive prompt; you'll be re-notified when a newer one lands.",
-        "Silent install via root — Magisk, KernelSU, and APatch users can now install without Shizuku or Dhizuku."
+        "Silent install via root — Magisk, KernelSU, and APatch users can now install without Shizuku or Dhizuku.",
+        "Search in Starred and Favourites — quickly filter long lists by repo name, owner, description, or language."
       ]
     },
     {

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesAction.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesAction.kt
@@ -16,4 +16,8 @@ sealed interface FavouritesAction {
     data class OnDeveloperProfileClick(
         val username: String,
     ) : FavouritesAction
+
+    data class OnSearchChange(
+        val query: String,
+    ) : FavouritesAction
 }

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesRoot.kt
@@ -2,16 +2,21 @@ package zed.rainxch.favourites.presentation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -21,15 +26,20 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
@@ -84,55 +94,81 @@ fun FavouritesScreen(
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { innerPadding ->
-        Box(
+        Column(
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding),
         ) {
-            val gridState = rememberLazyStaggeredGridState()
-            val isScrollbarEnabled = LocalScrollbarEnabled.current
-            ScrollbarContainer(
-                gridState = gridState,
-                enabled = isScrollbarEnabled,
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                LazyVerticalStaggeredGrid(
-                    state = gridState,
-                    columns =
-                        StaggeredGridCells.Adaptive(
-                            350.dp,
-                        ),
-                    verticalItemSpacing = 12.dp,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
-                ) {
-                    items(
-                        items = state.favouriteRepositories,
-                        key = { it.repoId },
-                    ) { repo ->
-                        FavouriteRepositoryItem(
-                            favouriteRepository = repo,
-                            onToggleFavouriteClick = {
-                                onAction(FavouritesAction.OnToggleFavorite(repo))
-                            },
-                            onItemClick = {
-                                onAction(FavouritesAction.OnRepositoryClick(repo))
-                            },
-                            onDevProfileClick = {
-                                onAction(FavouritesAction.OnDeveloperProfileClick(repo.repoOwner))
-                            },
-                            modifier = Modifier.animateItem(),
-                        )
-                    }
-                }
+            if (state.favouriteRepositories.isNotEmpty()) {
+                FavouritesSearchBar(
+                    query = state.searchQuery,
+                    onQueryChange = { onAction(FavouritesAction.OnSearchChange(it)) },
+                )
             }
 
-            if (state.isLoading) {
-                CircularWavyProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center),
-                )
+            val filteredRepositories =
+                remember(state.favouriteRepositories, state.searchQuery) {
+                    val q = state.searchQuery.trim().lowercase()
+                    if (q.isBlank()) {
+                        state.favouriteRepositories
+                    } else {
+                        state.favouriteRepositories
+                            .filter { repo ->
+                                repo.repoName.lowercase().contains(q) ||
+                                    repo.repoOwner.lowercase().contains(q) ||
+                                    (repo.repoDescription?.lowercase()?.contains(q) == true) ||
+                                    (repo.primaryLanguage?.lowercase()?.contains(q) == true)
+                            }
+                            .toImmutableList()
+                    }
+                }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                val gridState = rememberLazyStaggeredGridState()
+                val isScrollbarEnabled = LocalScrollbarEnabled.current
+                ScrollbarContainer(
+                    gridState = gridState,
+                    enabled = isScrollbarEnabled,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    LazyVerticalStaggeredGrid(
+                        state = gridState,
+                        columns =
+                            StaggeredGridCells.Adaptive(
+                                350.dp,
+                            ),
+                        verticalItemSpacing = 12.dp,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+                        modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
+                    ) {
+                        items(
+                            items = filteredRepositories,
+                            key = { it.repoId },
+                        ) { repo ->
+                            FavouriteRepositoryItem(
+                                favouriteRepository = repo,
+                                onToggleFavouriteClick = {
+                                    onAction(FavouritesAction.OnToggleFavorite(repo))
+                                },
+                                onItemClick = {
+                                    onAction(FavouritesAction.OnRepositoryClick(repo))
+                                },
+                                onDevProfileClick = {
+                                    onAction(FavouritesAction.OnDeveloperProfileClick(repo.repoOwner))
+                                },
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                    }
+                }
+
+                if (state.isLoading) {
+                    CircularWavyProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center),
+                    )
+                }
             }
         }
     }
@@ -164,6 +200,41 @@ private fun FavouritesTopbar(onAction: (FavouritesAction) -> Unit) {
                 )
             }
         },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FavouritesSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    TextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        placeholder = { Text(stringResource(Res.string.search_repositories_hint)) },
+        leadingIcon = { Icon(imageVector = Icons.Filled.Search, contentDescription = null) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(Res.string.clear_search),
+                    )
+                }
+            }
+        },
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
     )
 }
 

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesState.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesState.kt
@@ -7,4 +7,5 @@ import zed.rainxch.favourites.presentation.model.FavouriteRepository
 data class FavouritesState(
     val favouriteRepositories: ImmutableList<FavouriteRepository> = persistentListOf(),
     val isLoading: Boolean = false,
+    val searchQuery: String = "",
 )

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesViewModel.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesViewModel.kt
@@ -69,6 +69,10 @@ class FavouritesViewModel(
                 // Handled in composable
             }
 
+            is FavouritesAction.OnSearchChange -> {
+                _state.update { it.copy(searchQuery = action.query) }
+            }
+
             is FavouritesAction.OnToggleFavorite -> {
                 viewModelScope.launch {
                     val repo = action.favouriteRepository

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposAction.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposAction.kt
@@ -24,4 +24,8 @@ sealed interface StarredReposAction {
     data class OnToggleFavorite(
         val repository: StarredRepositoryUi,
     ) : StarredReposAction
+
+    data class OnSearchChange(
+        val query: String,
+    ) : StarredReposAction
 }

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
@@ -153,10 +153,12 @@ fun StarredScreen(
 
                 else -> {
                     Column(modifier = Modifier.fillMaxSize()) {
-                        StarredSearchBar(
-                            query = state.searchQuery,
-                            onQueryChange = { onAction(StarredReposAction.OnSearchChange(it)) },
-                        )
+                        if (state.starredRepositories.isNotEmpty()) {
+                            StarredSearchBar(
+                                query = state.searchQuery,
+                                onQueryChange = { onAction(StarredReposAction.OnSearchChange(it)) },
+                            )
+                        }
 
                         val filteredRepositories =
                             remember(state.starredRepositories, state.searchQuery) {

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposRoot.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -15,9 +16,11 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CircularWavyProgressIndicator
@@ -31,13 +34,17 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -45,6 +52,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.components.GithubStoreButton
@@ -144,46 +152,70 @@ fun StarredScreen(
                 }
 
                 else -> {
-                    PullToRefreshBox(
-                        isRefreshing = state.isSyncing,
-                        onRefresh = {
-                            onAction(StarredReposAction.OnRefresh)
-                        },
-                        state = pullRefreshState,
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        val gridState = rememberLazyStaggeredGridState()
-                        val isScrollbarEnabled = LocalScrollbarEnabled.current
-                        ScrollbarContainer(
-                            gridState = gridState,
-                            enabled = isScrollbarEnabled,
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        StarredSearchBar(
+                            query = state.searchQuery,
+                            onQueryChange = { onAction(StarredReposAction.OnSearchChange(it)) },
+                        )
+
+                        val filteredRepositories =
+                            remember(state.starredRepositories, state.searchQuery) {
+                                val q = state.searchQuery.trim().lowercase()
+                                if (q.isBlank()) {
+                                    state.starredRepositories
+                                } else {
+                                    state.starredRepositories
+                                        .filter { repo ->
+                                            repo.repoName.lowercase().contains(q) ||
+                                                repo.repoOwner.lowercase().contains(q) ||
+                                                (repo.repoDescription?.lowercase()?.contains(q) == true) ||
+                                                (repo.primaryLanguage?.lowercase()?.contains(q) == true)
+                                        }
+                                        .toImmutableList()
+                                }
+                            }
+
+                        PullToRefreshBox(
+                            isRefreshing = state.isSyncing,
+                            onRefresh = {
+                                onAction(StarredReposAction.OnRefresh)
+                            },
+                            state = pullRefreshState,
                             modifier = Modifier.fillMaxSize(),
                         ) {
-                            LazyVerticalStaggeredGrid(
-                                state = gridState,
-                                columns = StaggeredGridCells.Adaptive(350.dp),
-                                verticalItemSpacing = 12.dp,
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                                modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
+                            val gridState = rememberLazyStaggeredGridState()
+                            val isScrollbarEnabled = LocalScrollbarEnabled.current
+                            ScrollbarContainer(
+                                gridState = gridState,
+                                enabled = isScrollbarEnabled,
+                                modifier = Modifier.fillMaxSize(),
                             ) {
-                                items(
-                                    items = state.starredRepositories,
-                                    key = { it.repoId },
-                                ) { repo ->
-                                    StarredRepositoryItem(
-                                        repository = repo,
-                                        onToggleFavoriteClick = {
-                                            onAction(StarredReposAction.OnToggleFavorite(repo))
-                                        },
-                                        onItemClick = {
-                                            onAction(StarredReposAction.OnRepositoryClick(repo))
-                                        },
-                                        onDevProfileClick = {
-                                            onAction(StarredReposAction.OnDeveloperProfileClick(repo.repoOwner))
-                                        },
-                                        modifier = Modifier.animateItem(),
-                                    )
+                                LazyVerticalStaggeredGrid(
+                                    state = gridState,
+                                    columns = StaggeredGridCells.Adaptive(350.dp),
+                                    verticalItemSpacing = 12.dp,
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
+                                    modifier = Modifier.fillMaxSize().arrowKeyScroll(gridState, autoFocus = true),
+                                ) {
+                                    items(
+                                        items = filteredRepositories,
+                                        key = { it.repoId },
+                                    ) { repo ->
+                                        StarredRepositoryItem(
+                                            repository = repo,
+                                            onToggleFavoriteClick = {
+                                                onAction(StarredReposAction.OnToggleFavorite(repo))
+                                            },
+                                            onItemClick = {
+                                                onAction(StarredReposAction.OnRepositoryClick(repo))
+                                            },
+                                            onDevProfileClick = {
+                                                onAction(StarredReposAction.OnDeveloperProfileClick(repo.repoOwner))
+                                            },
+                                            modifier = Modifier.animateItem(),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -286,6 +318,41 @@ private fun StarredTopBar(
             },
         )
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StarredSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    TextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        placeholder = { Text(stringResource(Res.string.search_repositories_hint)) },
+        leadingIcon = { Icon(imageVector = Icons.Filled.Search, contentDescription = null) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(Res.string.clear_search),
+                    )
+                }
+            }
+        },
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
+    )
 }
 
 @Composable

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposState.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposState.kt
@@ -11,4 +11,5 @@ data class StarredReposState(
     val errorMessage: String? = null,
     val lastSyncTime: Long? = null,
     val isAuthenticated: Boolean = false,
+    val searchQuery: String = "",
 )

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
@@ -139,6 +139,11 @@ class StarredReposViewModel(
             }
 
             StarredReposAction.OnRefresh -> {
+                // Refresh may return a list that no longer matches the active
+                // search query, leaving the user staring at an empty grid with
+                // a stale filter still applied. Clearing the query removes the
+                // ambiguity.
+                _state.update { it.copy(searchQuery = "") }
                 syncStarredRepos(forceRefresh = true)
             }
 

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
@@ -150,6 +150,10 @@ class StarredReposViewModel(
                 _state.update { it.copy(errorMessage = null) }
             }
 
+            is StarredReposAction.OnSearchChange -> {
+                _state.update { it.copy(searchQuery = action.query) }
+            }
+
             is StarredReposAction.OnToggleFavorite -> {
                 viewModelScope.launch {
                     val repo = action.repository


### PR DESCRIPTION
Add inline search bar to Favourites and Starred screens, matching the existing Apps-screen search pattern. Filter is case-insensitive across repo name, owner, description, and primary language. Closes #562.

UX: search bar appears above the grid only when the underlying list is non-empty (no clutter on empty state). Clear-X trailing icon resets the query. `remember`-cached filter recomputes only when list or query changes.

Note: ~/.gradle was unmounted during this session — no local compile-verify. Visual review only. Please compile-check before merge: `:feature:favourites:presentation` and `:feature:starred:presentation` (both Android + JVM targets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search to Starred and Favourites: top-of-screen search bars let you quickly filter lists by repository name, owner, description, or language (case-insensitive). Results update instantly and include a clear button for easy reset; search is shown when there are repositories and integrates with existing loading and refresh behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/581)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->