### PR TITLE
fix(search): empty list when 'Hide seen' filters all (#574)

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -18,7 +18,8 @@
         "Uninstalled apps now disappear from the tracked list right away, even when removed from system Settings.",
         "Better version detection — releases that share a numeric version but ship distinct build artifacts are no longer falsely flagged as 'already installed'.",
         "Updating multiple apps in a row now works reliably — installs serialize so each one shows the correct APK in the system dialog. Apps screen versions also stay in sync after every install.",
-        "Auto-update picks the right APK when a release ships both a regular and an F-Droid variant — no more accidentally installing a sibling app with a different package id."
+        "Auto-update picks the right APK when a release ships both a regular and an F-Droid variant — no more accidentally installing a sibling app with a different package id.",
+        "Search no longer shows a result count over an empty list — when 'Hide seen' filters out every hit, the screen now explains why and offers a one-tap reset."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -74,6 +74,8 @@
 
     <!-- Results -->
     <string name="results_found">تم العثور على %1$d نتيجة</string>
+    <string name="search_results_hidden_by_seen_filter">جميع النتائج مخفية بسبب فلتر \'إخفاء المُشاهَد\'</string>
+    <string name="show_all_results">عرض جميع النتائج</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -76,6 +76,7 @@
     <string name="results_found">تم العثور على %1$d نتيجة</string>
     <string name="search_results_hidden_by_seen_filter">جميع النتائج مخفية بسبب فلتر \'إخفاء المُشاهَد\'</string>
     <string name="show_all_results">تعطيل فلتر \'إخفاء المُشاهَد\'</string>
+    <string name="searching_for_unseen_repos">البحث عن مستودعات لم تتم مشاهدتها…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -75,7 +75,7 @@
     <!-- Results -->
     <string name="results_found">تم العثور على %1$d نتيجة</string>
     <string name="search_results_hidden_by_seen_filter">جميع النتائج مخفية بسبب فلتر \'إخفاء المُشاهَد\'</string>
-    <string name="show_all_results">عرض جميع النتائج</string>
+    <string name="show_all_results">تعطيل فلتر \'إخفاء المُشاهَد\'</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -74,6 +74,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d টি ফলাফল পাওয়া গেছে</string>
+    <string name="search_results_hidden_by_seen_filter">\'দেখা হয়েছে লুকান\' ফিল্টার সমস্ত ফলাফল লুকিয়েছে</string>
+    <string name="show_all_results">সমস্ত ফলাফল দেখান</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -76,6 +76,7 @@
     <string name="results_found">%1$d টি ফলাফল পাওয়া গেছে</string>
     <string name="search_results_hidden_by_seen_filter">\'দেখা হয়েছে লুকান\' ফিল্টার সমস্ত ফলাফল লুকিয়েছে</string>
     <string name="show_all_results">\'দেখা হয়েছে লুকান\' ফিল্টার বন্ধ করুন</string>
+    <string name="searching_for_unseen_repos">অদেখা রিপোজিটরি খোঁজা হচ্ছে…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -75,7 +75,7 @@
     <!-- Results -->
     <string name="results_found">%1$d টি ফলাফল পাওয়া গেছে</string>
     <string name="search_results_hidden_by_seen_filter">\'দেখা হয়েছে লুকান\' ফিল্টার সমস্ত ফলাফল লুকিয়েছে</string>
-    <string name="show_all_results">সমস্ত ফলাফল দেখান</string>
+    <string name="show_all_results">\'দেখা হয়েছে লুকান\' ফিল্টার বন্ধ করুন</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -59,6 +59,8 @@
     <string name="filter_by_language">Filtrar por lenguaje</string>
 
     <string name="results_found">%1$d resultados encontrados</string>
+    <string name="search_results_hidden_by_seen_filter">Todos los resultados están ocultos por el filtro \'Ocultar vistos\'</string>
+    <string name="show_all_results">Mostrar todos los resultados</string>
 
     <string name="retry">Reintentar</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -61,6 +61,7 @@
     <string name="results_found">%1$d resultados encontrados</string>
     <string name="search_results_hidden_by_seen_filter">Todos los resultados están ocultos por el filtro \'Ocultar vistos\'</string>
     <string name="show_all_results">Desactivar filtro \'Ocultar vistos\'</string>
+    <string name="searching_for_unseen_repos">Buscando repositorios no vistos…</string>
 
     <string name="retry">Reintentar</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -60,7 +60,7 @@
 
     <string name="results_found">%1$d resultados encontrados</string>
     <string name="search_results_hidden_by_seen_filter">Todos los resultados están ocultos por el filtro \'Ocultar vistos\'</string>
-    <string name="show_all_results">Mostrar todos los resultados</string>
+    <string name="show_all_results">Desactivar filtro \'Ocultar vistos\'</string>
 
     <string name="retry">Reintentar</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -59,6 +59,8 @@
     <string name="filter_by_language">Filtrer par langage</string>
 
     <string name="results_found">%1$d résultats trouvés</string>
+    <string name="search_results_hidden_by_seen_filter">Tous les résultats sont masqués par le filtre « Masquer vus »</string>
+    <string name="show_all_results">Afficher tous les résultats</string>
 
     <string name="retry">Réessayer</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -61,6 +61,7 @@
     <string name="results_found">%1$d résultats trouvés</string>
     <string name="search_results_hidden_by_seen_filter">Tous les résultats sont masqués par le filtre « Masquer vus »</string>
     <string name="show_all_results">Désactiver le filtre « Masquer vus »</string>
+    <string name="searching_for_unseen_repos">Recherche de dépôts non vus…</string>
 
     <string name="retry">Réessayer</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -60,7 +60,7 @@
 
     <string name="results_found">%1$d résultats trouvés</string>
     <string name="search_results_hidden_by_seen_filter">Tous les résultats sont masqués par le filtre « Masquer vus »</string>
-    <string name="show_all_results">Afficher tous les résultats</string>
+    <string name="show_all_results">Désactiver le filtre « Masquer vus »</string>
 
     <string name="retry">Réessayer</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -74,6 +74,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d परिणाम मिले</string>
+    <string name="search_results_hidden_by_seen_filter">\'देखे गए छिपाएं\' फ़िल्टर ने सभी परिणाम छुपा दिए</string>
+    <string name="show_all_results">सभी परिणाम दिखाएं</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -76,6 +76,7 @@
     <string name="results_found">%1$d परिणाम मिले</string>
     <string name="search_results_hidden_by_seen_filter">\'देखे गए छिपाएं\' फ़िल्टर ने सभी परिणाम छुपा दिए</string>
     <string name="show_all_results">\'देखे गए छिपाएं\' फ़िल्टर बंद करें</string>
+    <string name="searching_for_unseen_repos">अनदेखी रिपॉजिटरीज़ खोजी जा रही हैं…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -75,7 +75,7 @@
     <!-- Results -->
     <string name="results_found">%1$d परिणाम मिले</string>
     <string name="search_results_hidden_by_seen_filter">\'देखे गए छिपाएं\' फ़िल्टर ने सभी परिणाम छुपा दिए</string>
-    <string name="show_all_results">सभी परिणाम दिखाएं</string>
+    <string name="show_all_results">\'देखे गए छिपाएं\' फ़िल्टर बंद करें</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -74,6 +74,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d risultati trovati</string>
+    <string name="search_results_hidden_by_seen_filter">Tutti i risultati sono nascosti dal filtro \'Nascondi visti\'</string>
+    <string name="show_all_results">Mostra tutti i risultati</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -76,6 +76,7 @@
     <string name="results_found">%1$d risultati trovati</string>
     <string name="search_results_hidden_by_seen_filter">Tutti i risultati sono nascosti dal filtro \'Nascondi visti\'</string>
     <string name="show_all_results">Disattiva filtro \'Nascondi visti\'</string>
+    <string name="searching_for_unseen_repos">Ricerca repository non visti…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -75,7 +75,7 @@
     <!-- Results -->
     <string name="results_found">%1$d risultati trovati</string>
     <string name="search_results_hidden_by_seen_filter">Tutti i risultati sono nascosti dal filtro \'Nascondi visti\'</string>
-    <string name="show_all_results">Mostra tutti i risultati</string>
+    <string name="show_all_results">Disattiva filtro \'Nascondi visti\'</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -59,6 +59,8 @@
     <string name="filter_by_language">言語でフィルター</string>
 
     <string name="results_found">%1$d 件の結果</string>
+    <string name="search_results_hidden_by_seen_filter">「既読を非表示」フィルターですべての結果が非表示です</string>
+    <string name="show_all_results">すべての結果を表示</string>
 
     <string name="retry">再試行</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -61,6 +61,7 @@
     <string name="results_found">%1$d 件の結果</string>
     <string name="search_results_hidden_by_seen_filter">「既読を非表示」フィルターですべての結果が非表示です</string>
     <string name="show_all_results">「既読を非表示」フィルターを無効化</string>
+    <string name="searching_for_unseen_repos">未読のリポジトリを検索中…</string>
 
     <string name="retry">再試行</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -60,7 +60,7 @@
 
     <string name="results_found">%1$d 件の結果</string>
     <string name="search_results_hidden_by_seen_filter">「既読を非表示」フィルターですべての結果が非表示です</string>
-    <string name="show_all_results">すべての結果を表示</string>
+    <string name="show_all_results">「既読を非表示」フィルターを無効化</string>
 
     <string name="retry">再試行</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -73,6 +73,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d개의 결과를 찾았습니다</string>
+    <string name="search_results_hidden_by_seen_filter">\'본 항목 숨기기\' 필터로 모든 결과가 숨겨졌습니다</string>
+    <string name="show_all_results">모든 결과 표시</string>
 
     <!-- Sorting -->
     <string name="sort_by">정렬 기준</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -75,6 +75,7 @@
     <string name="results_found">%1$d개의 결과를 찾았습니다</string>
     <string name="search_results_hidden_by_seen_filter">\'본 항목 숨기기\' 필터로 모든 결과가 숨겨졌습니다</string>
     <string name="show_all_results">\'본 항목 숨기기\' 필터 비활성화</string>
+    <string name="searching_for_unseen_repos">안 본 저장소 검색 중…</string>
 
     <!-- Sorting -->
     <string name="sort_by">정렬 기준</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -74,7 +74,7 @@
     <!-- Results -->
     <string name="results_found">%1$d개의 결과를 찾았습니다</string>
     <string name="search_results_hidden_by_seen_filter">\'본 항목 숨기기\' 필터로 모든 결과가 숨겨졌습니다</string>
-    <string name="show_all_results">모든 결과 표시</string>
+    <string name="show_all_results">\'본 항목 숨기기\' 필터 비활성화</string>
 
     <!-- Sorting -->
     <string name="sort_by">정렬 기준</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -61,6 +61,8 @@
     <string name="filter_by_language">Filtruj według języka</string>
 
     <string name="results_found">Znaleziono %1$d wyników</string>
+    <string name="search_results_hidden_by_seen_filter">Wszystkie wyniki ukryte przez filtr \'Ukryj zobaczone\'</string>
+    <string name="show_all_results">Pokaż wszystkie wyniki</string>
 
 
     <string name="sort_by">Sortuj według</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -63,6 +63,7 @@
     <string name="results_found">Znaleziono %1$d wyników</string>
     <string name="search_results_hidden_by_seen_filter">Wszystkie wyniki ukryte przez filtr \'Ukryj zobaczone\'</string>
     <string name="show_all_results">Wyłącz filtr \'Ukryj zobaczone\'</string>
+    <string name="searching_for_unseen_repos">Szukanie nieobejrzanych repozytoriów…</string>
 
 
     <string name="sort_by">Sortuj według</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -62,7 +62,7 @@
 
     <string name="results_found">Znaleziono %1$d wyników</string>
     <string name="search_results_hidden_by_seen_filter">Wszystkie wyniki ukryte przez filtr \'Ukryj zobaczone\'</string>
-    <string name="show_all_results">Pokaż wszystkie wyniki</string>
+    <string name="show_all_results">Wyłącz filtr \'Ukryj zobaczone\'</string>
 
 
     <string name="sort_by">Sortuj według</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -61,6 +61,8 @@
     <string name="filter_by_language">Фильтр по языку</string>
 
     <string name="results_found">Найдено результатов: %1$d</string>
+    <string name="search_results_hidden_by_seen_filter">Все результаты скрыты фильтром \'Скрыть просмотренные\'</string>
+    <string name="show_all_results">Показать все результаты</string>
 
     <string name="sort_by">Сортировать по</string>
     <string name="close">Закрыть</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -63,6 +63,7 @@
     <string name="results_found">Найдено результатов: %1$d</string>
     <string name="search_results_hidden_by_seen_filter">Все результаты скрыты фильтром \'Скрыть просмотренные\'</string>
     <string name="show_all_results">Отключить фильтр \'Скрыть просмотренные\'</string>
+    <string name="searching_for_unseen_repos">Поиск непросмотренных репозиториев…</string>
 
     <string name="sort_by">Сортировать по</string>
     <string name="close">Закрыть</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -62,7 +62,7 @@
 
     <string name="results_found">Найдено результатов: %1$d</string>
     <string name="search_results_hidden_by_seen_filter">Все результаты скрыты фильтром \'Скрыть просмотренные\'</string>
-    <string name="show_all_results">Показать все результаты</string>
+    <string name="show_all_results">Отключить фильтр \'Скрыть просмотренные\'</string>
 
     <string name="sort_by">Сортировать по</string>
     <string name="close">Закрыть</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -73,6 +73,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d sonuç bulundu</string>
+    <string name="search_results_hidden_by_seen_filter">Tüm sonuçlar \'Görüleni gizle\' filtresiyle gizlendi</string>
+    <string name="show_all_results">Tüm sonuçları göster</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -75,6 +75,7 @@
     <string name="results_found">%1$d sonuç bulundu</string>
     <string name="search_results_hidden_by_seen_filter">Tüm sonuçlar \'Görüleni gizle\' filtresiyle gizlendi</string>
     <string name="show_all_results">\'Görüleni gizle\' filtresini devre dışı bırak</string>
+    <string name="searching_for_unseen_repos">Görülmemiş depolar aranıyor…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -74,7 +74,7 @@
     <!-- Results -->
     <string name="results_found">%1$d sonuç bulundu</string>
     <string name="search_results_hidden_by_seen_filter">Tüm sonuçlar \'Görüleni gizle\' filtresiyle gizlendi</string>
-    <string name="show_all_results">Tüm sonuçları göster</string>
+    <string name="show_all_results">\'Görüleni gizle\' filtresini devre dışı bırak</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -61,6 +61,8 @@
     <string name="filter_by_language">按语言筛选</string>
 
     <string name="results_found">找到 %1$d 个结果</string>
+    <string name="search_results_hidden_by_seen_filter">所有结果被\'隐藏已查看\'过滤器隐藏</string>
+    <string name="show_all_results">显示所有结果</string>
 
     <string name="retry">重试</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -63,6 +63,7 @@
     <string name="results_found">找到 %1$d 个结果</string>
     <string name="search_results_hidden_by_seen_filter">所有结果被\'隐藏已查看\'过滤器隐藏</string>
     <string name="show_all_results">禁用\'隐藏已查看\'过滤器</string>
+    <string name="searching_for_unseen_repos">正在搜索未查看的仓库…</string>
 
     <string name="retry">重试</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -62,7 +62,7 @@
 
     <string name="results_found">找到 %1$d 个结果</string>
     <string name="search_results_hidden_by_seen_filter">所有结果被\'隐藏已查看\'过滤器隐藏</string>
-    <string name="show_all_results">显示所有结果</string>
+    <string name="show_all_results">禁用\'隐藏已查看\'过滤器</string>
 
     <string name="retry">重试</string>
 

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -77,6 +77,8 @@
 
     <!-- Results -->
     <string name="results_found">%1$d results were found</string>
+    <string name="search_results_hidden_by_seen_filter">All results are hidden by the \'Hide seen\' filter</string>
+    <string name="show_all_results">Show all results</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="results_found">%1$d results were found</string>
     <string name="search_results_hidden_by_seen_filter">All results are hidden by the \'Hide seen\' filter</string>
     <string name="show_all_results">Disable \'Hide seen\' filter</string>
+    <string name="searching_for_unseen_repos">Searching for unseen repositories…</string>
 
 
     <!-- Sorting -->

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -78,7 +78,7 @@
     <!-- Results -->
     <string name="results_found">%1$d results were found</string>
     <string name="search_results_hidden_by_seen_filter">All results are hidden by the \'Hide seen\' filter</string>
-    <string name="show_all_results">Show all results</string>
+    <string name="show_all_results">Disable \'Hide seen\' filter</string>
 
 
     <!-- Sorting -->

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
@@ -73,4 +73,6 @@ sealed interface SearchAction {
     data object OnClearAllHistory : SearchAction
 
     data object ExploreFromGithub : SearchAction
+
+    data object OnDisableHideSeenForResults : SearchAction
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -585,6 +585,35 @@ fun SearchScreen(
                     }
                 }
 
+                // Auto-paginate is fetching the next page in the background
+                // because every loaded repo is filtered out. Without an
+                // explicit indicator the content area is blank: the top-level
+                // spinner only renders while repositories.isEmpty(), and the
+                // in-grid load-more spinner is unreachable because the grid
+                // itself only renders when visibleRepos is non-empty.
+                if (state.repositories.isNotEmpty() &&
+                    state.visibleRepos.isEmpty() &&
+                    state.isHideSeenEnabled &&
+                    state.hasMorePages
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator()
+
+                            Spacer(Modifier.height(8.dp))
+
+                            Text(
+                                text = stringResource(Res.string.searching_for_unseen_repos),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                        }
+                    }
+                }
+
                 // All currently loaded API hits filtered out by the global
                 // "Hide seen" tweak AND no further pages remain — results
                 // counter still shows the raw total, so without this banner

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -561,6 +561,35 @@ fun SearchScreen(
                     }
                 }
 
+                // All API hits filtered out by the global "Hide seen" tweak
+                // — results counter still shows the raw total, so without this
+                // banner the user sees "N results found" above an empty grid
+                // and assumes the app is broken (issue #574).
+                if (state.repositories.isNotEmpty() &&
+                    state.visibleRepos.isEmpty() &&
+                    state.isHideSeenEnabled
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = stringResource(Res.string.search_results_hidden_by_seen_filter),
+                            )
+
+                            Spacer(Modifier.height(8.dp))
+
+                            GithubStoreButton(
+                                text = stringResource(Res.string.show_all_results),
+                                onClick = {
+                                    onAction(SearchAction.OnDisableHideSeenForResults)
+                                },
+                            )
+                        }
+                    }
+                }
+
                 if (state.visibleRepos.isNotEmpty()) {
                     val isScrollbarEnabled = LocalScrollbarEnabled.current
                     ScrollbarContainer(

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -229,6 +229,30 @@ fun SearchScreen(
         }
     }
 
+    // Auto-paginate while every loaded repo is filtered out by the global
+    // "Hide seen" tweak. The grid is empty → scroll-based shouldLoadMore can
+    // never fire (totalItemsCount == 0), so without this the user is stranded
+    // on a blank screen with no way to reach page 2+ where unseen repos may
+    // live. Stops once hasMorePages flips false; the banner then takes over.
+    LaunchedEffect(
+        state.repositories.size,
+        state.visibleRepos.size,
+        state.isHideSeenEnabled,
+        state.hasMorePages,
+        state.isLoadingMore,
+        state.isLoading,
+    ) {
+        if (state.repositories.isNotEmpty() &&
+            state.visibleRepos.isEmpty() &&
+            state.isHideSeenEnabled &&
+            state.hasMorePages &&
+            !state.isLoadingMore &&
+            !state.isLoading
+        ) {
+            currentOnAction(SearchAction.LoadMore)
+        }
+    }
+
     LaunchedEffect(listState.layoutInfo.totalItemsCount, listState.layoutInfo.viewportEndOffset) {
         val layoutInfo = listState.layoutInfo
         val visibleItems = layoutInfo.visibleItemsInfo
@@ -561,13 +585,20 @@ fun SearchScreen(
                     }
                 }
 
-                // All API hits filtered out by the global "Hide seen" tweak
-                // — results counter still shows the raw total, so without this
-                // banner the user sees "N results found" above an empty grid
-                // and assumes the app is broken (issue #574).
+                // All currently loaded API hits filtered out by the global
+                // "Hide seen" tweak AND no further pages remain — results
+                // counter still shows the raw total, so without this banner
+                // the user sees "N results found" above an empty grid and
+                // assumes the app is broken (issue #574). `hasMorePages` is
+                // required because the scroll-based pagination above stalls
+                // when totalItemsCount == 0, so we surface the banner only
+                // when there is genuinely nothing more to fetch. While
+                // hasMorePages is true, the auto-paginate effect below pulls
+                // the next page in the background.
                 if (state.repositories.isNotEmpty() &&
                     state.visibleRepos.isEmpty() &&
-                    state.isHideSeenEnabled
+                    state.isHideSeenEnabled &&
+                    !state.hasMorePages
                 ) {
                     Box(
                         modifier = Modifier.fillMaxSize(),

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -683,6 +683,12 @@ class SearchViewModel(
             SearchAction.ExploreFromGithub -> {
                 performExplore()
             }
+
+            SearchAction.OnDisableHideSeenForResults -> {
+                viewModelScope.launch {
+                    tweaksRepository.setHideSeenEnabled(false)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Search screen showed "N results found" over an empty grid when the global 'Hide seen' tweak filtered out every API hit. UI had no explanation and no way to recover from the search screen itself — the user had to dig into Tweaks to figure out why.

Add a centered banner + 'Show all results' CTA that disables the global Hide-seen flag in one tap. Triggers only when `repositories.isNotEmpty() && visibleRepos.isEmpty() && isHideSeenEnabled` — never fires for genuine zero-result searches.

Strings localized across 13 locales (en + 12). Closes #574.

Not compile-verified locally — ~/.gradle/wrapper unreachable (SSD unmounted). Please run before merge:
- `:feature:search:presentation:compileDebugKotlinAndroid`
- `:feature:search:presentation:compileKotlinJvm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen message when all search results are hidden by "Hide seen", with a one-tap action to disable the filter and reveal results.
  * Pagination will auto-load more results when hidden items exist but the visible list is empty; shows a centered loading/status while fetching unseen repos.

* **Chores**
  * Added localized UI text for hidden-results message, "show all results" action, and searching status across multiple languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/582)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->