### PR TITLE
fix(strings): bare %d → %1$d in time formatters (CMP)

### DIFF
--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -255,9 +255,9 @@
     <string name="star_repos_hint">Marca repositorios con lanzamientos instalables en GitHub para verlos aquí</string>
     <string name="last_synced">Última sincronización</string>
     <string name="just_now">Justo ahora</string>
-    <string name="minutes_ago">Hace %d min</string>
-    <string name="hours_ago">Hace %d h</string>
-    <string name="days_ago">Hace %d d</string>
+    <string name="minutes_ago">Hace %1$d min</string>
+    <string name="hours_ago">Hace %1$d h</string>
+    <string name="days_ago">Hace %1$d d</string>
     <string name="dismiss">Cerrar</string>
     <string name="sync_starred_failed">No se pudieron sincronizar los repositorios destacados</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -255,9 +255,9 @@
     <string name="star_repos_hint">Ajoutez des dépôts avec des versions installables sur GitHub pour les voir ici</string>
     <string name="last_synced">Dernière synchronisation</string>
     <string name="just_now">À l’instant</string>
-    <string name="minutes_ago">Il y a %d min</string>
-    <string name="hours_ago">Il y a %d h</string>
-    <string name="days_ago">Il y a %d j</string>
+    <string name="minutes_ago">Il y a %1$d min</string>
+    <string name="hours_ago">Il y a %1$d h</string>
+    <string name="days_ago">Il y a %1$d j</string>
     <string name="dismiss">Fermer</string>
     <string name="sync_starred_failed">Échec de la synchronisation des dépôts favoris</string>
 

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -404,9 +404,9 @@
     <string name="star_repos_hint">Star repositories on GitHub with installable releases to see them here</string>
     <string name="last_synced">Last synced</string>
     <string name="just_now">Just now</string>
-    <string name="minutes_ago">%d min ago</string>
-    <string name="hours_ago">%d h ago</string>
-    <string name="days_ago">%d d ago</string>
+    <string name="minutes_ago">%1$d min ago</string>
+    <string name="hours_ago">%1$d h ago</string>
+    <string name="days_ago">%1$d d ago</string>
     <string name="dismiss">Dismiss</string>
     <string name="sync_starred_failed">Failed to sync starred repos</string>
 


### PR DESCRIPTION
Starred screen showed `"%d h ago"` literally because the en/es/fr translations of `hours_ago` / `minutes_ago` / `days_ago` used bare `%d` instead of positional `%1$d`. Compose Multiplatform's resource formatter requires positional indices for reliable cross-platform substitution — bare `%d` works on JVM via java.lang.String.format but is undefined on Native/iOS where CMP's custom formatter expects `%[idx$]conversion`.

Audited all 14 locale files via regex — only these 9 entries were affected (en/es/fr × 3 keys); the other 10 locales already used `%1$d`.

Compile-verified: `:core:presentation` + `:feature:starred:presentation` (Android + JVM targets) BUILD SUCCESSFUL.

Follow-up scope (not in this PR): `*_hours_ago` / `*_days_ago` keys still use the `"hour(s)"` parenthetical hack — should become `<plurals>` for proper Slavic/Romance pluralization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relative time string formatting (minutes, hours, days) across all supported language translations to ensure correct localized display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/583)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->