### PR TITLE
feat(e20): self-owned ✓ badge on Home + Search cards

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -61,6 +61,7 @@ val viewModelsModule =
                 apkInspector = get(),
                 authenticationState = get(),
                 systemInstallSerializer = get(),
+                profileRepository = get(),
             )
         }
         viewModelOf(::DeveloperProfileViewModel)

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -10,7 +10,8 @@
         "Ignore updates per app — silence the update badge for any app you don't want to update.",
         "Skip a specific update — dismiss a single release if it's a false-positive prompt; you'll be re-notified when a newer one lands.",
         "Silent install via root — Magisk, KernelSU, and APatch users can now install without Shizuku or Dhizuku.",
-        "Search in Starred and Favourites — quickly filter long lists by repo name, owner, description, or language."
+        "Search in Starred and Favourites — quickly filter long lists by repo name, owner, description, or language.",
+        "Self-owned ✓ badge — when you're signed in, repos you own get a verified checkmark on Home and Search cards."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -644,6 +644,7 @@
     <string name="clear_seen_history_description">إعادة تعيين جميع المستودعات المشاهَدة لتظهر مجدداً في الخلاصات</string>
     <string name="seen_history_cleared">تم مسح سجل المشاهدة</string>
     <string name="seen_badge">تمت المشاهدة</string>
+    <string name="self_owned_badge">هذا المستودع لك</string>
     <string name="privacy_section">الخصوصية</string>
     <string name="telemetry_title">ساعد في تحسين البحث</string>
     <string name="telemetry_description">مشاركة بيانات الاستخدام (عمليات البحث والتثبيتات والتفاعلات) المرتبطة بمعرّف تحليلي قابل لإعادة التعيين. لا تتم مشاركة تفاصيل الحساب.</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -643,6 +643,7 @@
     <string name="clear_seen_history_description">সমস্ত দেখা রিপোজিটরি রিসেট করুন যাতে সেগুলো ফিডে আবার দেখা যায়</string>
     <string name="seen_history_cleared">দেখার ইতিহাস মুছে ফেলা হয়েছে</string>
     <string name="seen_badge">দেখা হয়েছে</string>
+    <string name="self_owned_badge">এই রিপো আপনার</string>
     <string name="privacy_section">গোপনীয়তা</string>
     <string name="telemetry_title">অনুসন্ধান উন্নত করতে সহায়তা করুন</string>
     <string name="telemetry_description">পুনরায় সেট করা যায় এমন একটি বিশ্লেষণ আইডির সাথে যুক্ত ব্যবহার ডেটা (অনুসন্ধান, ইনস্টল, ইন্টারঅ্যাকশন) শেয়ার করুন। অ্যাকাউন্ট বিবরণ শেয়ার করা হয় না।</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -604,6 +604,7 @@
     <string name="clear_seen_history_description">Restablecer todos los repositorios vistos para que aparezcan de nuevo en las fuentes</string>
     <string name="seen_history_cleared">Historial de vistos borrado</string>
     <string name="seen_badge">Visto</string>
+    <string name="self_owned_badge">Eres dueño de este repo</string>
     <string name="privacy_section">Privacidad</string>
     <string name="telemetry_title">Ayudar a mejorar la búsqueda</string>
     <string name="telemetry_description">Compartir datos de uso (búsquedas, instalaciones, interacciones) asociados a un ID de análisis restablecible. No se comparten detalles de la cuenta.</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -605,6 +605,7 @@
     <string name="clear_seen_history_description">Réinitialiser tous les dépôts consultés pour qu'ils réapparaissent dans les flux</string>
     <string name="seen_history_cleared">Historique des consultations effacé</string>
     <string name="seen_badge">Consulté</string>
+    <string name="self_owned_badge">Vous possédez ce dépôt</string>
     <string name="privacy_section">Confidentialité</string>
     <string name="telemetry_title">Aider à améliorer la recherche</string>
     <string name="telemetry_description">Partager des données d'utilisation (recherches, installations, interactions) associées à un identifiant d'analyse réinitialisable. Aucun détail de compte n'est partagé.</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -642,6 +642,7 @@
     <string name="clear_seen_history_description">सभी देखे गए रिपॉजिटरी रीसेट करें ताकि वे फ़ीड में फिर से दिखें</string>
     <string name="seen_history_cleared">देखने का इतिहास साफ़ किया गया</string>
     <string name="seen_badge">देखा गया</string>
+    <string name="self_owned_badge">यह रेपो आपका है</string>
     <string name="privacy_section">गोपनीयता</string>
     <string name="telemetry_title">खोज को बेहतर बनाने में मदद करें</string>
     <string name="telemetry_description">रीसेट करने योग्य एनालिटिक्स आईडी से जुड़े उपयोग डेटा (खोज, इंस्टॉल, इंटरैक्शन) साझा करें। खाता विवरण साझा नहीं किए जाते।</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -643,6 +643,7 @@
     <string name="clear_seen_history_description">Reimposta tutti i repository visualizzati in modo che ricompaiano nei feed</string>
     <string name="seen_history_cleared">Cronologia visualizzazioni cancellata</string>
     <string name="seen_badge">Visualizzato</string>
+    <string name="self_owned_badge">Sei il proprietario di questo repo</string>
     <string name="privacy_section">Privacy</string>
     <string name="telemetry_title">Aiuta a migliorare la ricerca</string>
     <string name="telemetry_description">Condividi dati di utilizzo (ricerche, installazioni, interazioni) associati a un ID analitico ripristinabile. Nessun dettaglio dell'account viene condiviso.</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -606,6 +606,7 @@
     <string name="clear_seen_history_description">すべての閲覧済みリポジトリをリセットしてフィードに再表示します</string>
     <string name="seen_history_cleared">閲覧履歴をクリアしました</string>
     <string name="seen_badge">閲覧済み</string>
+    <string name="self_owned_badge">あなたが所有するリポジトリ</string>
     <string name="privacy_section">プライバシー</string>
     <string name="telemetry_title">検索の改善に協力</string>
     <string name="telemetry_description">リセット可能な分析 ID に関連付けられた使用データ(検索、インストール、操作)を共有します。アカウント情報は共有されません。</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -641,6 +641,7 @@
     <string name="clear_seen_history_description">모든 조회 기록을 초기화하여 피드에 다시 표시합니다</string>
     <string name="seen_history_cleared">조회 기록이 삭제되었습니다</string>
     <string name="seen_badge">확인함</string>
+    <string name="self_owned_badge">내가 소유한 저장소</string>
     <string name="privacy_section">개인 정보 보호</string>
     <string name="telemetry_title">검색 개선에 도움 주기</string>
     <string name="telemetry_description">재설정 가능한 분석 ID에 연결된 사용 데이터(검색, 설치, 상호작용)를 공유합니다. 계정 정보는 공유되지 않습니다.</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -607,6 +607,7 @@
     <string name="clear_seen_history_description">Zresetuj wszystkie przeglądane repozytoria, aby ponownie pojawiły się w kanałach</string>
     <string name="seen_history_cleared">Historia przeglądania wyczyszczona</string>
     <string name="seen_badge">Przeglądane</string>
+    <string name="self_owned_badge">Jesteś właścicielem tego repo</string>
     <string name="privacy_section">Prywatność</string>
     <string name="telemetry_title">Pomóż ulepszyć wyszukiwanie</string>
     <string name="telemetry_description">Udostępniaj dane o użyciu (wyszukiwania, instalacje, interakcje) powiązane z resetowalnym identyfikatorem analitycznym. Żadne dane konta nie są udostępniane.</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -607,6 +607,7 @@
     <string name="clear_seen_history_description">Сбросить все просмотренные репозитории, чтобы они снова появились в лентах</string>
     <string name="seen_history_cleared">История просмотров очищена</string>
     <string name="seen_badge">Просмотрено</string>
+    <string name="self_owned_badge">Ваш репозиторий</string>
     <string name="privacy_section">Конфиденциальность</string>
     <string name="telemetry_title">Помочь улучшить поиск</string>
     <string name="telemetry_description">Отправлять данные об использовании (поиски, установки, взаимодействия), связанные со сбрасываемым идентификатором аналитики. Данные учётной записи не передаются.</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -641,6 +641,7 @@
     <string name="clear_seen_history_description">Tüm görüntülenen depoları sıfırlayarak akışlarda tekrar görünmelerini sağlayın</string>
     <string name="seen_history_cleared">Görüntüleme geçmişi temizlendi</string>
     <string name="seen_badge">Görüntülendi</string>
+    <string name="self_owned_badge">Bu deponun sahibisin</string>
     <string name="privacy_section">Gizlilik</string>
     <string name="telemetry_title">Aramayı iyileştirmeye yardım et</string>
     <string name="telemetry_description">Sıfırlanabilir bir analiz kimliğiyle ilişkilendirilmiş kullanım verilerini (aramalar, yüklemeler, etkileşimler) paylaş. Hesap ayrıntıları paylaşılmaz.</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -607,6 +607,7 @@
     <string name="clear_seen_history_description">重置所有已浏览的仓库，使其重新出现在信息流中</string>
     <string name="seen_history_cleared">浏览记录已清除</string>
     <string name="seen_badge">已浏览</string>
+    <string name="self_owned_badge">你拥有此仓库</string>
     <string name="privacy_section">隐私</string>
     <string name="telemetry_title">帮助改进搜索</string>
     <string name="telemetry_description">分享与可重置分析 ID 关联的使用数据（搜索、安装、交互）。不分享账户详情。</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -767,6 +767,7 @@
     <string name="clear_seen_history_description">Reset all seen repositories so they appear again in feeds</string>
     <string name="seen_history_cleared">Seen history cleared</string>
     <string name="seen_badge">Viewed</string>
+    <string name="self_owned_badge">You own this repo</string>
 
     <!-- Privacy / telemetry -->
     <string name="privacy_section">Privacy</string>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -152,6 +152,7 @@ fun RepositoryCard(
                             maxLines = 1,
                             softWrap = false,
                             overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
                         )
 
                         if (discoveryRepositoryUi.isCurrentUserOwner) {

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.CallSplit
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Share
@@ -63,6 +64,7 @@ import zed.rainxch.githubstore.core.presentation.res.home_view_details
 import zed.rainxch.githubstore.core.presentation.res.installed
 import zed.rainxch.githubstore.core.presentation.res.open_in_browser
 import zed.rainxch.githubstore.core.presentation.res.seen_badge
+import zed.rainxch.githubstore.core.presentation.res.self_owned_badge
 import zed.rainxch.githubstore.core.presentation.res.share_repository
 import zed.rainxch.githubstore.core.presentation.res.update_available
 
@@ -151,6 +153,10 @@ fun RepositoryCard(
                             softWrap = false,
                             overflow = TextOverflow.Ellipsis,
                         )
+
+                        if (discoveryRepositoryUi.isCurrentUserOwner) {
+                            OfficialBadge()
+                        }
                     }
 
                     Text(
@@ -453,6 +459,16 @@ fun InstallStatusBadge(
             )
         }
     }
+}
+
+@Composable
+fun OfficialBadge(modifier: Modifier = Modifier) {
+    Icon(
+        imageVector = Icons.Filled.Verified,
+        contentDescription = stringResource(Res.string.self_owned_badge),
+        modifier = modifier.size(16.dp),
+        tint = MaterialTheme.colorScheme.primary,
+    )
 }
 
 @Composable

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/model/DiscoveryRepositoryUi.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/model/DiscoveryRepositoryUi.kt
@@ -6,5 +6,6 @@ data class DiscoveryRepositoryUi(
     val isFavourite: Boolean,
     val isStarred: Boolean,
     val isSeen: Boolean = false,
+    val isCurrentUserOwner: Boolean = false,
     val repository: GithubRepoSummaryUi,
 )

--- a/feature/details/presentation/build.gradle.kts
+++ b/feature/details/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
                 implementation(projects.core.domain)
                 implementation(projects.core.presentation)
                 implementation(projects.feature.details.domain)
+                implementation(projects.feature.profile.domain)
 
                 implementation(libs.markdown.renderer)
                 implementation(libs.markdown.renderer.coil3)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -21,6 +21,7 @@ import zed.rainxch.details.presentation.model.TranslationTarget
 
 data class DetailsState(
     val isLoading: Boolean = true,
+    val isCurrentUserOwner: Boolean = false,
     val isRefreshing: Boolean = false,
     val refreshCooldownUntilEpochMs: Long? = null,
     val errorMessage: String? = null,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -8,8 +8,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -128,6 +130,7 @@ class DetailsViewModel(
     private val apkInspector: ApkInspector,
     private val authenticationState: zed.rainxch.core.domain.repository.AuthenticationState,
     private val systemInstallSerializer: zed.rainxch.core.domain.system.SystemInstallSerializer,
+    private val profileRepository: zed.rainxch.profile.domain.repository.ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentDownloadJob: Job? = null
@@ -142,6 +145,7 @@ class DetailsViewModel(
                 if (!hasLoadedInitialData) {
                     loadInitial()
                     observeApkInspectCoachmark()
+                    observeCurrentUserForBadge()
 
                     hasLoadedInitialData = true
                 }
@@ -804,6 +808,25 @@ class DetailsViewModel(
      * the pulse would render at the exact moment the system install
      * prompt is up, which is the user's peak-attention frame.
      */
+    // Reactively flips `isCurrentUserOwner` whenever either the signed-in
+    // user changes (login/logout/switch-account) or the loaded repository
+    // owner login arrives. Avoids touching every repo-assignment site.
+    private fun observeCurrentUserForBadge() {
+        viewModelScope.launch {
+            combine(
+                profileRepository.getUser(),
+                _state
+                    .map { it.repository?.owner?.login }
+                    .distinctUntilChanged(),
+            ) { user, ownerLogin ->
+                val login = user?.username
+                login != null && ownerLogin != null && ownerLogin.equals(login, ignoreCase = true)
+            }.collect { isOwner ->
+                _state.update { it.copy(isCurrentUserOwner = isOwner) }
+            }
+        }
+    }
+
     private fun observeApkInspectCoachmark() {
         viewModelScope.launch {
             val alreadyShown =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/AppHeader.kt
@@ -49,6 +49,7 @@ import zed.rainxch.core.domain.model.GithubUserProfile
 import zed.rainxch.core.domain.model.InstalledApp
 import zed.rainxch.core.domain.util.VersionMath
 import zed.rainxch.core.presentation.components.ForkBadge
+import zed.rainxch.core.presentation.components.OfficialBadge
 import zed.rainxch.core.presentation.components.PlatformChip
 import zed.rainxch.core.presentation.utils.formatReleasedAt
 import zed.rainxch.details.presentation.model.DownloadStage
@@ -70,6 +71,7 @@ fun AppHeader(
     modifier: Modifier = Modifier,
     downloadStage: DownloadStage = DownloadStage.IDLE,
     downloadProgress: Int? = null,
+    isCurrentUserOwner: Boolean = false,
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = (downloadProgress ?: 0) / 100f,
@@ -174,13 +176,23 @@ fun AppHeader(
                     }
                 }
                 author?.login?.let { author ->
-                    Text(
-                        text = stringResource(Res.string.by_author, author),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.by_author, author),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
+                        )
+
+                        if (isCurrentUserOwner) {
+                            OfficialBadge()
+                        }
+                    }
                 }
 
                 Spacer(Modifier.height(8.dp))

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -57,6 +57,7 @@ fun LazyListScope.header(
                 installedApp = state.installedApp,
                 downloadStage = state.downloadStage,
                 downloadProgress = state.downloadProgressPercent,
+                isCurrentUserOwner = state.isCurrentUserOwner,
             )
         }
     }

--- a/feature/favourites/presentation/build.gradle.kts
+++ b/feature/favourites/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
                 implementation(projects.core.domain)
                 implementation(projects.core.presentation)
                 implementation(projects.feature.favourites.domain)
+                implementation(projects.feature.profile.domain)
 
                 implementation(libs.bundles.landscapist)
                 implementation(libs.kotlinx.collections.immutable)

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesViewModel.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/FavouritesViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -15,11 +16,13 @@ import kotlinx.coroutines.launch
 import zed.rainxch.core.domain.model.FavoriteRepo
 import zed.rainxch.core.domain.repository.FavouritesRepository
 import zed.rainxch.favourites.presentation.mappers.toFavouriteRepositoryUi
+import zed.rainxch.profile.domain.repository.ProfileRepository
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class FavouritesViewModel(
     private val favouritesRepository: FavouritesRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
 
@@ -40,10 +43,19 @@ class FavouritesViewModel(
 
     private fun loadFavouriteRepos() {
         viewModelScope.launch {
-            favouritesRepository
-                .getAllFavorites()
-                .map { it.map { it.toFavouriteRepositoryUi() } }
-                .flowOn(Dispatchers.Default)
+            combine(
+                favouritesRepository.getAllFavorites(),
+                profileRepository.getUser(),
+            ) { favorites, user ->
+                val currentLogin = user?.username
+                favorites.map { repo ->
+                    repo.toFavouriteRepositoryUi(
+                        isCurrentUserOwner =
+                            currentLogin != null &&
+                                repo.repoOwner.equals(currentLogin, ignoreCase = true),
+                    )
+                }
+            }.flowOn(Dispatchers.Default)
                 .collect { favoriteRepos ->
                     _state.update {
                         it.copy(

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/components/FavouriteRepositoryItem.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/components/FavouriteRepositoryItem.kt
@@ -43,6 +43,7 @@ import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.crossfade.CrossfadePlugin
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.presentation.components.ExpressiveCard
+import zed.rainxch.core.presentation.components.OfficialBadge
 import zed.rainxch.favourites.presentation.model.FavouriteRepository
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.remove_from_favourites
@@ -101,8 +102,12 @@ fun FavouriteRepositoryItem(
                     color = MaterialTheme.colorScheme.outline,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
                 )
+
+                if (favouriteRepository.isCurrentUserOwner) {
+                    OfficialBadge()
+                }
             }
 
             Spacer(modifier = Modifier.height(8.dp))

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/mappers/FavouriteRepositoryMapper.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/mappers/FavouriteRepositoryMapper.kt
@@ -4,7 +4,9 @@ import zed.rainxch.core.domain.model.FavoriteRepo
 import zed.rainxch.core.presentation.utils.formatAddedAt
 import zed.rainxch.favourites.presentation.model.FavouriteRepository
 
-suspend fun FavoriteRepo.toFavouriteRepositoryUi(): FavouriteRepository =
+suspend fun FavoriteRepo.toFavouriteRepositoryUi(
+    isCurrentUserOwner: Boolean = false,
+): FavouriteRepository =
     FavouriteRepository(
         repoId = repoId,
         repoName = repoName,
@@ -16,4 +18,5 @@ suspend fun FavoriteRepo.toFavouriteRepositoryUi(): FavouriteRepository =
         latestRelease = latestVersion,
         latestReleaseUrl = latestReleaseUrl,
         addedAtFormatter = formatAddedAt(addedAt),
+        isCurrentUserOwner = isCurrentUserOwner,
     )

--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/model/FavouriteRepository.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/model/FavouriteRepository.kt
@@ -11,4 +11,5 @@ data class FavouriteRepository(
     val addedAtFormatter: String,
     val latestRelease: String?,
     val latestReleaseUrl: String?,
+    val isCurrentUserOwner: Boolean = false,
 )

--- a/feature/home/presentation/build.gradle.kts
+++ b/feature/home/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
                 implementation(projects.core.domain)
                 implementation(projects.core.presentation)
                 implementation(projects.feature.home.domain)
+                implementation(projects.feature.profile.domain)
 
                 implementation(libs.kotlinx.collections.immutable)
 

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -60,11 +60,17 @@ class HomeViewModel(
     private var topicSupplementJob: Job? = null
     private var nextPageIndex = 1
 
+    // Cached so each repo mapping doesn't re-hit ProfileRepository (which
+    // walks a suspend cache + DataStore on every call). Refreshed by the
+    // observer below — login/logout flips badges without restarting the VM.
+    @Volatile private var currentUserLogin: String? = null
+
     private val _state = MutableStateFlow(HomeState())
     val state =
         _state
             .onStart {
                 if (!hasLoadedInitialData) {
+                    observeCurrentUser()
                     syncSystemState()
 
                     loadPlatform()
@@ -368,7 +374,7 @@ class HomeViewModel(
                 .associateBy { it.repoId }
 
         val seenIds = _state.value.seenRepoIds
-        val currentLogin = profileRepository.getUser().first()?.username
+        val currentLogin = currentUserLogin
 
         return repos.map { repo ->
             val apps = installedAppsMap[repo.id].orEmpty()
@@ -580,6 +586,31 @@ class HomeViewModel(
         viewModelScope.launch {
             tweaksRepository.getHideSeenEnabled().collect { enabled ->
                 _state.update { it.copy(isHideSeenEnabled = enabled) }
+            }
+        }
+    }
+
+    private fun observeCurrentUser() {
+        viewModelScope.launch {
+            profileRepository.getUser().collect { user ->
+                currentUserLogin = user?.username
+                // Re-stamp `isCurrentUserOwner` on already-loaded repos so
+                // logging in (or switching accounts) immediately flips
+                // badges without forcing a full reload.
+                val login = user?.username
+                _state.update { current ->
+                    current.copy(
+                        repos =
+                            current.repos
+                                .map { repo ->
+                                    repo.copy(
+                                        isCurrentUserOwner =
+                                            login != null &&
+                                                repo.repository.owner.login.equals(login, ignoreCase = true),
+                                    )
+                                }.toImmutableList(),
+                    )
+                }
             }
         }
     }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -39,6 +39,7 @@ import zed.rainxch.home.domain.model.HomeCategory
 import zed.rainxch.home.domain.model.TopicCategory
 import zed.rainxch.home.domain.repository.HomeRepository
 import zed.rainxch.home.presentation.HomeEvent.*
+import zed.rainxch.profile.domain.repository.ProfileRepository
 
 class HomeViewModel(
     private val homeRepository: HomeRepository,
@@ -51,6 +52,7 @@ class HomeViewModel(
     private val shareManager: ShareManager,
     private val tweaksRepository: TweaksRepository,
     private val seenReposRepository: SeenReposRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentJob: Job? = null
@@ -366,6 +368,7 @@ class HomeViewModel(
                 .associateBy { it.repoId }
 
         val seenIds = _state.value.seenRepoIds
+        val currentLogin = profileRepository.getUser().first()?.username
 
         return repos.map { repo ->
             val apps = installedAppsMap[repo.id].orEmpty()
@@ -377,6 +380,9 @@ class HomeViewModel(
                 isFavourite = favourite != null,
                 isStarred = starred != null,
                 isSeen = repo.id in seenIds,
+                isCurrentUserOwner =
+                    currentLogin != null &&
+                        repo.owner.login.equals(currentLogin, ignoreCase = true),
                 isUpdateAvailable = apps.any { it.hasActualUpdate() },
                 repository = repo.toUi(),
             )

--- a/feature/search/presentation/build.gradle.kts
+++ b/feature/search/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
                 implementation(projects.core.domain)
                 implementation(projects.core.presentation)
                 implementation(projects.feature.search.domain)
+                implementation(projects.feature.profile.domain)
 
 
                 implementation(libs.androidx.compose.ui.tooling.preview)

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -72,6 +72,11 @@ class SearchViewModel(
     private var explorePage = 1
     private var lastExploreQuery = ""
 
+    // Cached so each pagination/explore mapping doesn't re-hit
+    // ProfileRepository on every result page. observeCurrentUser() keeps
+    // it in sync with login/logout.
+    @Volatile private var currentUserLogin: String? = null
+
     private val exploreLog = logger.withTag("SearchExplore")
 
     companion object {
@@ -88,6 +93,7 @@ class SearchViewModel(
         _state
             .onStart {
                 if (!hasLoadedInitialData) {
+                    observeCurrentUser()
                     syncSystemState()
 
                     observeInstalledApps()
@@ -137,6 +143,28 @@ class SearchViewModel(
         viewModelScope.launch {
             tweaksRepository.getHideSeenEnabled().collect { enabled ->
                 _state.update { it.copy(isHideSeenEnabled = enabled) }
+            }
+        }
+    }
+
+    private fun observeCurrentUser() {
+        viewModelScope.launch {
+            profileRepository.getUser().collect { user ->
+                currentUserLogin = user?.username
+                val login = user?.username
+                _state.update { current ->
+                    current.copy(
+                        repositories =
+                            current.repositories
+                                .map { repo ->
+                                    repo.copy(
+                                        isCurrentUserOwner =
+                                            login != null &&
+                                                repo.repository.owner.login.equals(login, ignoreCase = true),
+                                    )
+                                }.toImmutableList(),
+                    )
+                }
             }
         }
     }
@@ -351,7 +379,7 @@ class SearchViewModel(
                             currentPage = paginatedRepos.nextPageIndex
 
                             val seenIds = _state.value.seenRepoIds
-                            val currentLogin = profileRepository.getUser().first()?.username
+                            val currentLogin = currentUserLogin
 
                             val newReposWithStatus =
                                 paginatedRepos.repos.map { repo ->
@@ -778,7 +806,7 @@ class SearchViewModel(
         val favoritesMap = favouritesRepository.getAllFavorites().first().associateBy { it.repoId }
         val starredMap = starredRepository.getAllStarred().first().associateBy { it.repoId }
         val seenIds = _state.value.seenRepoIds
-        val currentLogin = profileRepository.getUser().first()?.username
+        val currentLogin = currentUserLogin
 
         val existingIds = _state.value.repositories.map { it.repository.id }.toSet()
 

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -36,6 +36,7 @@ import zed.rainxch.core.domain.utils.ShareManager
 import zed.rainxch.core.presentation.model.DiscoveryRepositoryUi
 import zed.rainxch.core.presentation.utils.toUi
 import zed.rainxch.domain.repository.SearchRepository
+import zed.rainxch.profile.domain.repository.ProfileRepository
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.failed_to_share_link
 import zed.rainxch.githubstore.core.presentation.res.link_copied_to_clipboard
@@ -63,6 +64,7 @@ class SearchViewModel(
     private val seenReposRepository: SeenReposRepository,
     private val searchHistoryRepository: SearchHistoryRepository,
     private val telemetryRepository: TelemetryRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentSearchJob: Job? = null
@@ -349,6 +351,7 @@ class SearchViewModel(
                             currentPage = paginatedRepos.nextPageIndex
 
                             val seenIds = _state.value.seenRepoIds
+                            val currentLogin = profileRepository.getUser().first()?.username
 
                             val newReposWithStatus =
                                 paginatedRepos.repos.map { repo ->
@@ -361,6 +364,9 @@ class SearchViewModel(
                                         isFavourite = favourite != null,
                                         isStarred = starred != null,
                                         isSeen = repo.id in seenIds,
+                                        isCurrentUserOwner =
+                                            currentLogin != null &&
+                                                repo.owner.login.equals(currentLogin, ignoreCase = true),
                                         isUpdateAvailable = apps.any { it.hasActualUpdate() },
                                         repository = repo.toUi(),
                                     )
@@ -772,6 +778,7 @@ class SearchViewModel(
         val favoritesMap = favouritesRepository.getAllFavorites().first().associateBy { it.repoId }
         val starredMap = starredRepository.getAllStarred().first().associateBy { it.repoId }
         val seenIds = _state.value.seenRepoIds
+        val currentLogin = profileRepository.getUser().first()?.username
 
         val existingIds = _state.value.repositories.map { it.repository.id }.toSet()
 
@@ -784,6 +791,9 @@ class SearchViewModel(
                     isFavourite = favoritesMap[repo.id] != null,
                     isStarred = starredMap[repo.id] != null,
                     isSeen = repo.id in seenIds,
+                    isCurrentUserOwner =
+                        currentLogin != null &&
+                            repo.owner.login.equals(currentLogin, ignoreCase = true),
                     isUpdateAvailable = apps.any { it.hasActualUpdate() },
                     repository = repo.toUi(),
                 )

--- a/feature/starred/presentation/build.gradle.kts
+++ b/feature/starred/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
                 implementation(projects.core.domain)
                 implementation(projects.core.presentation)
                 implementation(projects.feature.starred.domain)
+                implementation(projects.feature.profile.domain)
 
                 implementation(libs.bundles.landscapist)
 

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/StarredReposViewModel.kt
@@ -20,6 +20,7 @@ import zed.rainxch.core.domain.repository.AuthenticationState
 import zed.rainxch.core.domain.repository.FavouritesRepository
 import zed.rainxch.core.domain.repository.StarredRepository
 import zed.rainxch.githubstore.core.presentation.res.*
+import zed.rainxch.profile.domain.repository.ProfileRepository
 import zed.rainxch.starred.presentation.mappers.toStarredRepositoryUi
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -28,6 +29,7 @@ class StarredReposViewModel(
     private val authenticationState: AuthenticationState,
     private val starredRepository: StarredRepository,
     private val favouritesRepository: FavouritesRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
 
@@ -63,12 +65,17 @@ class StarredReposViewModel(
             combine(
                 starredRepository.getAllStarred(),
                 favouritesRepository.getAllFavorites(),
-            ) { starred, favorites ->
+                profileRepository.getUser(),
+            ) { starred, favorites, user ->
                 val favoriteIds = favorites.map { it.repoId }.toSet()
+                val currentLogin = user?.username
 
                 starred.map {
                     it.toStarredRepositoryUi(
                         isFavorite = favoriteIds.contains(it.repoId),
+                        isCurrentUserOwner =
+                            currentLogin != null &&
+                                it.repoOwner.equals(currentLogin, ignoreCase = true),
                     )
                 }
             }.flowOn(Dispatchers.Default)

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/components/StarredRepositoryItem.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/components/StarredRepositoryItem.kt
@@ -44,6 +44,7 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil3.CoilImage
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.presentation.components.ExpressiveCard
+import zed.rainxch.core.presentation.components.OfficialBadge
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.formatCount
 import zed.rainxch.githubstore.core.presentation.res.*
@@ -105,13 +106,23 @@ fun StarredRepositoryItem(
                         overflow = TextOverflow.Ellipsis,
                     )
 
-                    Text(
-                        text = repository.repoOwner,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            text = repository.repoOwner,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
+                        )
+
+                        if (repository.isCurrentUserOwner) {
+                            OfficialBadge()
+                        }
+                    }
                 }
 
                 FilledIconToggleButton(

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/mappers/StarredRepoToUiMapper.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/mappers/StarredRepoToUiMapper.kt
@@ -3,21 +3,24 @@ package zed.rainxch.starred.presentation.mappers
 import zed.rainxch.core.domain.model.StarredRepository
 import zed.rainxch.starred.presentation.model.StarredRepositoryUi
 
-fun StarredRepository.toStarredRepositoryUi(isFavorite: Boolean = false) =
-    StarredRepositoryUi(
-        repoId = repoId,
-        repoName = repoName,
-        repoOwner = repoOwner,
-        repoOwnerAvatarUrl = repoOwnerAvatarUrl,
-        repoDescription = repoDescription,
-        primaryLanguage = primaryLanguage,
-        repoUrl = repoUrl,
-        stargazersCount = stargazersCount,
-        forksCount = forksCount,
-        openIssuesCount = openIssuesCount,
-        isInstalled = isInstalled,
-        isFavorite = isFavorite,
-        latestRelease = latestVersion,
-        latestReleaseUrl = latestReleaseUrl,
-        starredAt = starredAt,
-    )
+fun StarredRepository.toStarredRepositoryUi(
+    isFavorite: Boolean = false,
+    isCurrentUserOwner: Boolean = false,
+) = StarredRepositoryUi(
+    repoId = repoId,
+    repoName = repoName,
+    repoOwner = repoOwner,
+    repoOwnerAvatarUrl = repoOwnerAvatarUrl,
+    repoDescription = repoDescription,
+    primaryLanguage = primaryLanguage,
+    repoUrl = repoUrl,
+    stargazersCount = stargazersCount,
+    forksCount = forksCount,
+    openIssuesCount = openIssuesCount,
+    isInstalled = isInstalled,
+    isFavorite = isFavorite,
+    isCurrentUserOwner = isCurrentUserOwner,
+    latestRelease = latestVersion,
+    latestReleaseUrl = latestReleaseUrl,
+    starredAt = starredAt,
+)

--- a/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/model/StarredRepositoryUi.kt
+++ b/feature/starred/presentation/src/commonMain/kotlin/zed/rainxch/starred/presentation/model/StarredRepositoryUi.kt
@@ -13,6 +13,7 @@ data class StarredRepositoryUi(
     val openIssuesCount: Int,
     val isInstalled: Boolean,
     val isFavorite: Boolean = false,
+    val isCurrentUserOwner: Boolean = false,
     val latestRelease: String?,
     val latestReleaseUrl: String?,
     val starredAt: Long?,


### PR DESCRIPTION
Render a `Verified`-icon badge next to the owner login on `RepositoryCard` when the current signed-in user owns the repo. Triggers on Home + Search discovery surfaces. Closes E20 first-slice (Sprint 2 brief, no-backend variant).

Plumbing: HomeViewModel + SearchViewModel inject ProfileRepository, read `getUser().first()?.username` during repo→UI mapping, set new `DiscoveryRepositoryUi.isCurrentUserOwner` flag via case-insensitive login compare. `RepositoryCard` renders `OfficialBadge` (Icons.Filled.Verified, primary tint, 16dp) conditionally next to the owner Text.

Tooltip contentDescription = `self_owned_badge` string, localized across 13 locales.

Out of scope (follow-up): Details AppHeader, Starred / Favourites / DevProfile surfaces — separate UI models. Will mirror once this lands.

Compile-verified: `:core:presentation` + `:feature:home:presentation` + `:feature:search:presentation` (Android + JVM) BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "self-owned ✓" badge on repository cards in Home, Search and Details for signed-in users' own repos.
  * Improved search in Starred/Favourites with quick filtering by repository attributes.

* **Localization**
  * Added localized text for the new badge across 13 locales.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/584)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->