### PR TITLE
feat(e14): first-time coachmark on per-app release-channel chip

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -341,6 +341,17 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getChannelChipCoachmarkShown(): Flow<Boolean> =
+        preferences.data.map { prefs ->
+            prefs[CHANNEL_CHIP_COACHMARK_SHOWN_KEY] ?: false
+        }
+
+    override suspend fun setChannelChipCoachmarkShown(shown: Boolean) {
+        preferences.edit { prefs ->
+            prefs[CHANNEL_CHIP_COACHMARK_SHOWN_KEY] = shown
+        }
+    }
+
     override fun getBatteryOptimizationPromptDismissed(): Flow<Boolean> =
         preferences.data.map { prefs ->
             prefs[BATTERY_OPT_PROMPT_DISMISSED_KEY] ?: false
@@ -445,6 +456,7 @@ class TweaksRepositoryImpl(
         private val EXTERNAL_MATCH_SEARCH_ENABLED_KEY = booleanPreferencesKey("external_match_search_enabled")
         private val EXTERNAL_IMPORT_BANNER_DISMISSED_AT_KEY = intPreferencesKey("external_import_banner_dismissed_at")
         private val APK_INSPECT_COACHMARK_SHOWN_KEY = booleanPreferencesKey("apk_inspect_coachmark_shown")
+        private val CHANNEL_CHIP_COACHMARK_SHOWN_KEY = booleanPreferencesKey("channel_chip_coachmark_shown")
         private val BATTERY_OPT_PROMPT_DISMISSED_KEY = booleanPreferencesKey("battery_opt_prompt_dismissed")
         private val LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY = intPreferencesKey("last_seen_whats_new_version_code")
         private val ANNOUNCEMENTS_DISMISSED_IDS_KEY = stringSetPreferencesKey("announcements_dismissed_ids")

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -114,6 +114,16 @@ interface TweaksRepository {
     suspend fun setApkInspectCoachmarkShown(shown: Boolean)
 
     /**
+     * One-shot flag for the release-channel coachmark on the Details
+     * screen. Survey signal — users don't realise the per-app channel
+     * chip toggles betas. `false` until shown at least once; permanent
+     * `true` after dismissal.
+     */
+    fun getChannelChipCoachmarkShown(): Flow<Boolean>
+
+    suspend fun setChannelChipCoachmarkShown(shown: Boolean)
+
+    /**
      * One-shot watermark for the battery-optimization prompt on
      * aggressive-OEM ROMs (Oppo / OnePlus / Realme / Xiaomi / vivo /
      * Honor). `false` until the user has either granted the exemption

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -28,7 +28,8 @@
       "type": "IMPROVED",
       "bullets": [
         "More reliable background updates on Oppo, OnePlus, Realme, Xiaomi, vivo, and Honor — Tweaks now offers a one-tap battery-optimization shortcut and update workers run with expedited priority.",
-        "Dhizuku silent install on Android 14+ — the app now retries automatically without installer attribution when the system would otherwise demand a confirmation tap."
+        "Dhizuku silent install on Android 14+ — the app now retries automatically without installer attribution when the system would otherwise demand a confirmation tap.",
+        "First-time coachmark on the per-app release-channel chip — explains how to switch between stable and beta builds, surfaces the toggle users were missing."
       ]
     }
   ]

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -602,8 +602,8 @@
     <string name="import_apps_title">استيراد التطبيقات</string>
     <string name="import_apps_description">الصق ملف JSON المُصدَّر لاستعادة التطبيقات المتتبعة</string>
     <string name="import_apps_hint">الصق JSON المُصدَّر هنا…</string>
-    <string name="include_pre_releases_title">تضمين الإصدارات التجريبية</string>
-    <string name="include_pre_releases_description">تتبع الإصدارات التجريبية عند التحقق من التحديثات. عند التعطيل، يتم اعتبار الإصدارات المستقرة فقط.</string>
+    <string name="include_pre_releases_title">قناة البيتا الافتراضية</string>
+    <string name="include_pre_releases_description">تشمل التطبيقات التي تتعقبها حديثاً إصدارات البيتا افتراضياً. التطبيقات المتعقَّبة مسبقاً تحتفظ بإعدادها الخاص (بدّله من شاشة التفاصيل).</string>
     <string name="confirm_uninstall_title">إلغاء تثبيت التطبيق؟</string>
     <string name="confirm_uninstall_message">هل أنت متأكد من إلغاء تثبيت %1$s؟ لا يمكن التراجع عن هذا الإجراء وقد تُفقد بيانات التطبيق.</string>
     <string name="invalid_github_url">رابط GitHub غير صالح. استخدم التنسيق: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -767,6 +767,9 @@
     <!-- Pre-release channel UX -->
     <string name="channel_chip_include_betas">تضمين الإصدارات التجريبية</string>
     <string name="channel_chip_stable_only">الإصدار المستقر فقط</string>
+    <string name="channel_chip_coachmark_title">اختر قناة الإصدار</string>
+    <string name="channel_chip_coachmark_body">اضغط للتبديل بين الإصدارات المستقرة وإصدارات البيتا لهذا التطبيق.</string>
+    <string name="channel_chip_coachmark_dismiss">حسناً</string>
     <string name="channel_toggle_cd">تبديل الإصدارات التجريبية لهذا التطبيق</string>
     <string name="action_switch_to_stable">التبديل إلى الإصدار المستقر %1$s</string>
     <string name="stalled_project_warning_months">لا يوجد إصدار مستقر منذ %1$d أشهر</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -601,8 +601,8 @@
     <string name="import_apps_title">অ্যাপ আমদানি করুন</string>
     <string name="import_apps_description">ট্র্যাক করা অ্যাপ পুনরুদ্ধার করতে রপ্তানি করা JSON পেস্ট করুন</string>
     <string name="import_apps_hint">রপ্তানি করা JSON এখানে পেস্ট করুন…</string>
-    <string name="include_pre_releases_title">প্রি-রিলিজ অন্তর্ভুক্ত করুন</string>
-    <string name="include_pre_releases_description">আপডেট পরীক্ষার সময় প্রি-রিলিজ সংস্করণ ট্র্যাক করুন। নিষ্ক্রিয় থাকলে, শুধুমাত্র স্থিতিশীল রিলিজ বিবেচনা করা হয়।</string>
+    <string name="include_pre_releases_title">ডিফল্ট বেটা চ্যানেল</string>
+    <string name="include_pre_releases_description">নতুন ট্র্যাক করা অ্যাপ ডিফল্টভাবে বেটা বিল্ড অন্তর্ভুক্ত করবে। ইতিমধ্যে ট্র্যাক করা অ্যাপ তাদের নিজস্ব সেটিং রাখবে (অ্যাপের বিস্তারিত স্ক্রিনে পরিবর্তন করুন)।</string>
     <string name="confirm_uninstall_title">অ্যাপ আনইনস্টল করবেন?</string>
     <string name="confirm_uninstall_message">আপনি কি নিশ্চিত যে %1$s আনইনস্টল করতে চান? এই ক্রিয়া পূর্বাবস্থায় ফেরানো যাবে না এবং অ্যাপের ডেটা হারিয়ে যেতে পারে।</string>
     <string name="invalid_github_url">অবৈধ GitHub URL। ফর্ম্যাট ব্যবহার করুন: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -767,6 +767,9 @@
     <!-- Pre-release channel UX -->
     <string name="channel_chip_include_betas">বেটা অন্তর্ভুক্ত করুন</string>
     <string name="channel_chip_stable_only">শুধুমাত্র স্থিতিশীল</string>
+    <string name="channel_chip_coachmark_title">আপনার রিলিজ চ্যানেল বাছুন</string>
+    <string name="channel_chip_coachmark_body">এই অ্যাপের স্থিতিশীল রিলিজ এবং বেটা বিল্ডের মধ্যে স্যুইচ করতে আলতো চাপুন।</string>
+    <string name="channel_chip_coachmark_dismiss">বুঝেছি</string>
     <string name="channel_toggle_cd">এই অ্যাপের জন্য বেটা রিলিজ টগল করুন</string>
     <string name="action_switch_to_stable">স্থিতিশীল %1$s-এ যান</string>
     <string name="stalled_project_warning_months">%1$d মাসে কোনো স্থিতিশীল রিলিজ নেই</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -562,8 +562,8 @@
     <string name="import_apps_title">Importar apps</string>
     <string name="import_apps_description">Pega el JSON exportado para restaurar tus apps rastreadas</string>
     <string name="import_apps_hint">Pega el JSON exportado aquí…</string>
-    <string name="include_pre_releases_title">Incluir pre-lanzamientos</string>
-    <string name="include_pre_releases_description">Rastrear versiones pre-lanzamiento al buscar actualizaciones. Si está desactivado, solo se consideran las versiones estables.</string>
+    <string name="include_pre_releases_title">Canal beta predeterminado</string>
+    <string name="include_pre_releases_description">Las apps recién seguidas incluyen compilaciones beta por defecto. Las ya seguidas conservan su propio canal (cámbialo en la pantalla de Detalles de la app).</string>
     <string name="confirm_uninstall_title">¿Desinstalar app?</string>
     <string name="confirm_uninstall_message">¿Estás seguro de que quieres desinstalar %1$s? Esta acción no se puede deshacer y los datos de la app podrían perderse.</string>
     <string name="invalid_github_url">URL de GitHub no válida. Usa el formato: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -731,6 +731,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Incluir betas</string>
     <string name="channel_chip_stable_only">Solo estable</string>
+    <string name="channel_chip_coachmark_title">Elige tu canal de lanzamiento</string>
+    <string name="channel_chip_coachmark_body">Toca para alternar entre lanzamientos estables y compilaciones beta de esta app.</string>
+    <string name="channel_chip_coachmark_dismiss">Entendido</string>
     <string name="channel_toggle_cd">Alternar versiones beta de esta aplicación</string>
     <string name="action_switch_to_stable">Cambiar a %1$s estable</string>
     <string name="stalled_project_warning_months">Sin versión estable en %1$d meses</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -563,8 +563,8 @@
     <string name="import_apps_title">Importer des apps</string>
     <string name="import_apps_description">Collez le JSON exporté pour restaurer vos apps suivies</string>
     <string name="import_apps_hint">Collez le JSON exporté ici…</string>
-    <string name="include_pre_releases_title">Inclure les pré-versions</string>
-    <string name="include_pre_releases_description">Suivre les versions pré-release lors de la vérification des mises à jour. Désactivé, seules les versions stables sont prises en compte.</string>
+    <string name="include_pre_releases_title">Canal bêta par défaut</string>
+    <string name="include_pre_releases_description">Les apps nouvellement suivies incluent les versions bêta par défaut. Les apps déjà suivies conservent leur propre paramètre (modifiable dans Détails de l\'app).</string>
     <string name="confirm_uninstall_title">Désinstaller l'app ?</string>
     <string name="confirm_uninstall_message">Êtes-vous sûr de vouloir désinstaller %1$s ? Cette action est irréversible et les données de l'app pourraient être perdues.</string>
     <string name="invalid_github_url">URL GitHub invalide. Utilisez le format : github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -732,6 +732,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Inclure les bêtas</string>
     <string name="channel_chip_stable_only">Stable uniquement</string>
+    <string name="channel_chip_coachmark_title">Choisissez votre canal de version</string>
+    <string name="channel_chip_coachmark_body">Touchez pour basculer entre les versions stables et les bêtas pour cette app.</string>
+    <string name="channel_chip_coachmark_dismiss">Compris</string>
     <string name="channel_toggle_cd">Activer/désactiver les versions bêta de cette application</string>
     <string name="action_switch_to_stable">Passer à %1$s stable</string>
     <string name="stalled_project_warning_months">Aucune version stable depuis %1$d mois</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -600,8 +600,8 @@
     <string name="import_apps_title">ऐप्स आयात करें</string>
     <string name="import_apps_description">अपने ट्रैक किए गए ऐप्स को पुनर्स्थापित करने के लिए निर्यात किया गया JSON पेस्ट करें</string>
     <string name="import_apps_hint">निर्यात किया गया JSON यहाँ पेस्ट करें…</string>
-    <string name="include_pre_releases_title">प्री-रिलीज़ शामिल करें</string>
-    <string name="include_pre_releases_description">अपडेट की जाँच करते समय प्री-रिलीज़ संस्करणों को ट्रैक करें। अक्षम होने पर, केवल स्थिर रिलीज़ पर विचार किया जाता है।</string>
+    <string name="include_pre_releases_title">डिफ़ॉल्ट बीटा चैनल</string>
+    <string name="include_pre_releases_description">नए ट्रैक किए गए ऐप डिफ़ॉल्ट रूप से बीटा बिल्ड शामिल करते हैं। पहले से ट्रैक किए गए ऐप अपनी सेटिंग रखते हैं (ऐप के विवरण स्क्रीन से बदलें)।</string>
     <string name="confirm_uninstall_title">ऐप अनइंस्टॉल करें?</string>
     <string name="confirm_uninstall_message">क्या आप वाकई %1$s को अनइंस्टॉल करना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती और ऐप डेटा खो सकता है।</string>
     <string name="invalid_github_url">अमान्य GitHub URL। प्रारूप का उपयोग करें: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -772,7 +772,7 @@
     <string name="channel_chip_stable_only">केवल स्थिर</string>
     <string name="channel_chip_coachmark_title">अपना रिलीज़ चैनल चुनें</string>
     <string name="channel_chip_coachmark_body">इस ऐप के स्थिर रिलीज़ और बीटा बिल्ड के बीच स्विच करने के लिए टैप करें।</string>
-    <string name="channel_chip_coachmark_dismiss">ठीक है</string>
+    <string name="channel_chip_coachmark_dismiss">समझ गया</string>
     <string name="channel_toggle_cd">इस ऐप के बीटा रिलीज़ टॉगल करें</string>
     <string name="action_switch_to_stable">%1$s स्थिर पर स्विच करें</string>
     <string name="stalled_project_warning_months">%1$d महीनों में कोई स्थिर रिलीज़ नहीं</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -770,6 +770,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">बीटा शामिल करें</string>
     <string name="channel_chip_stable_only">केवल स्थिर</string>
+    <string name="channel_chip_coachmark_title">अपना रिलीज़ चैनल चुनें</string>
+    <string name="channel_chip_coachmark_body">इस ऐप के स्थिर रिलीज़ और बीटा बिल्ड के बीच स्विच करने के लिए टैप करें।</string>
+    <string name="channel_chip_coachmark_dismiss">ठीक है</string>
     <string name="channel_toggle_cd">इस ऐप के बीटा रिलीज़ टॉगल करें</string>
     <string name="action_switch_to_stable">%1$s स्थिर पर स्विच करें</string>
     <string name="stalled_project_warning_months">%1$d महीनों में कोई स्थिर रिलीज़ नहीं</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -601,8 +601,8 @@
     <string name="import_apps_title">Importa app</string>
     <string name="import_apps_description">Incolla il JSON esportato per ripristinare le app monitorate</string>
     <string name="import_apps_hint">Incolla il JSON esportato qui…</string>
-    <string name="include_pre_releases_title">Includi pre-release</string>
-    <string name="include_pre_releases_description">Monitora le versioni pre-release durante il controllo aggiornamenti. Se disabilitato, vengono considerate solo le versioni stabili.</string>
+    <string name="include_pre_releases_title">Canale beta predefinito</string>
+    <string name="include_pre_releases_description">Le app appena tracciate includono build beta per impostazione predefinita. Le app già tracciate mantengono il proprio canale (modificalo nella schermata Dettagli).</string>
     <string name="confirm_uninstall_title">Disinstallare l'app?</string>
     <string name="confirm_uninstall_message">Sei sicuro di voler disinstallare %1$s? Questa azione non può essere annullata e i dati dell'app potrebbero andare persi.</string>
     <string name="invalid_github_url">URL GitHub non valido. Usa il formato: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -771,6 +771,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Includi beta</string>
     <string name="channel_chip_stable_only">Solo stabile</string>
+    <string name="channel_chip_coachmark_title">Scegli il canale di rilascio</string>
+    <string name="channel_chip_coachmark_body">Tocca per passare tra rilasci stabili e build beta per questa app.</string>
+    <string name="channel_chip_coachmark_dismiss">Ho capito</string>
     <string name="channel_toggle_cd">Attiva/disattiva le versioni beta per questa app</string>
     <string name="action_switch_to_stable">Passa a %1$s stabile</string>
     <string name="stalled_project_warning_months">Nessuna versione stabile da %1$d mesi</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -564,8 +564,8 @@
     <string name="import_apps_title">アプリをインポート</string>
     <string name="import_apps_description">エクスポートしたJSONを貼り付けて追跡中のアプリを復元</string>
     <string name="import_apps_hint">エクスポートしたJSONをここに貼り付け…</string>
-    <string name="include_pre_releases_title">プレリリースを含める</string>
-    <string name="include_pre_releases_description">アップデート確認時にプレリリース版を追跡します。無効の場合、安定版リリースのみが対象となります。</string>
+    <string name="include_pre_releases_title">デフォルトのベータチャンネル</string>
+    <string name="include_pre_releases_description">新しく追跡したアプリはデフォルトでベータビルドを含みます。既に追跡中のアプリは独自の設定を保持します（アプリの詳細画面で変更可能）。</string>
     <string name="confirm_uninstall_title">アプリをアンインストールしますか？</string>
     <string name="confirm_uninstall_message">%1$sをアンインストールしてよろしいですか？この操作は元に戻せず、アプリのデータが失われる可能性があります。</string>
     <string name="invalid_github_url">無効なGitHub URL。形式を使用してください：github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -731,6 +731,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">ベータを含む</string>
     <string name="channel_chip_stable_only">安定版のみ</string>
+    <string name="channel_chip_coachmark_title">リリースチャンネルを選択</string>
+    <string name="channel_chip_coachmark_body">このアプリの安定版とベータビルドを切り替えるにはタップ。</string>
+    <string name="channel_chip_coachmark_dismiss">了解</string>
     <string name="channel_toggle_cd">このアプリのベータリリースを切り替え</string>
     <string name="action_switch_to_stable">%1$s の安定版に切り替え</string>
     <string name="stalled_project_warning_months">%1$d か月間、安定版リリースなし</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -599,8 +599,8 @@
     <string name="import_apps_title">앱 가져오기</string>
     <string name="import_apps_description">내보낸 JSON을 붙여넣어 추적 중인 앱을 복원하세요</string>
     <string name="import_apps_hint">내보낸 JSON을 여기에 붙여넣기…</string>
-    <string name="include_pre_releases_title">사전 릴리스 포함</string>
-    <string name="include_pre_releases_description">업데이트 확인 시 사전 릴리스 버전을 추적합니다. 비활성화하면 안정적인 릴리스만 고려됩니다.</string>
+    <string name="include_pre_releases_title">기본 베타 채널</string>
+    <string name="include_pre_releases_description">새로 추적한 앱은 기본적으로 베타 빌드를 포함합니다. 이미 추적 중인 앱은 자체 설정을 유지합니다(앱 세부 정보 화면에서 전환).</string>
     <string name="confirm_uninstall_title">앱을 제거하시겠습니까?</string>
     <string name="confirm_uninstall_message">%1$s을(를) 제거하시겠습니까? 이 작업은 취소할 수 없으며 앱 데이터가 손실될 수 있습니다.</string>
     <string name="invalid_github_url">잘못된 GitHub URL입니다. 형식: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -766,6 +766,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">베타 포함</string>
     <string name="channel_chip_stable_only">안정 버전만</string>
+    <string name="channel_chip_coachmark_title">릴리스 채널 선택</string>
+    <string name="channel_chip_coachmark_body">이 앱의 안정 릴리스와 베타 빌드를 전환하려면 탭하세요.</string>
+    <string name="channel_chip_coachmark_dismiss">확인</string>
     <string name="channel_toggle_cd">이 앱의 베타 릴리스 전환</string>
     <string name="action_switch_to_stable">%1$s 안정 버전으로 전환</string>
     <string name="stalled_project_warning_months">%1$d개월간 안정 릴리스 없음</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -565,8 +565,8 @@
     <string name="import_apps_title">Importuj aplikacje</string>
     <string name="import_apps_description">Wklej wyeksportowany JSON, aby przywrócić śledzone aplikacje</string>
     <string name="import_apps_hint">Wklej wyeksportowany JSON tutaj…</string>
-    <string name="include_pre_releases_title">Uwzględnij wersje wstępne</string>
-    <string name="include_pre_releases_description">Śledź wersje wstępne podczas sprawdzania aktualizacji. Po wyłączeniu uwzględniane są tylko stabilne wydania.</string>
+    <string name="include_pre_releases_title">Domyślny kanał beta</string>
+    <string name="include_pre_releases_description">Nowo śledzone aplikacje domyślnie zawierają wersje beta. Już śledzone aplikacje zachowują własne ustawienie (zmień je na ekranie Szczegółów aplikacji).</string>
     <string name="confirm_uninstall_title">Odinstalować aplikację?</string>
     <string name="confirm_uninstall_message">Czy na pewno chcesz odinstalować %1$s? Tej czynności nie można cofnąć, a dane aplikacji mogą zostać utracone.</string>
     <string name="invalid_github_url">Nieprawidłowy URL GitHub. Użyj formatu: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -739,6 +739,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Uwzględnij wersje beta</string>
     <string name="channel_chip_stable_only">Tylko stabilne</string>
+    <string name="channel_chip_coachmark_title">Wybierz kanał wydań</string>
+    <string name="channel_chip_coachmark_body">Dotknij, aby przełączać między stabilnymi wydaniami a wersjami beta tej aplikacji.</string>
+    <string name="channel_chip_coachmark_dismiss">OK</string>
     <string name="channel_toggle_cd">Przełącz wydania beta dla tej aplikacji</string>
     <string name="action_switch_to_stable">Przejdź do stabilnej wersji %1$s</string>
     <string name="stalled_project_warning_months">Brak stabilnego wydania od %1$d miesięcy</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -565,8 +565,8 @@
     <string name="import_apps_title">Импорт приложений</string>
     <string name="import_apps_description">Вставьте экспортированный JSON для восстановления отслеживаемых приложений</string>
     <string name="import_apps_hint">Вставьте экспортированный JSON…</string>
-    <string name="include_pre_releases_title">Включить пре-релизы</string>
-    <string name="include_pre_releases_description">Отслеживать пре-релизные версии при проверке обновлений. При отключении учитываются только стабильные релизы.</string>
+    <string name="include_pre_releases_title">Канал бета по умолчанию</string>
+    <string name="include_pre_releases_description">Вновь отслеживаемые приложения по умолчанию включают бета-сборки. Ранее отслеживаемые приложения сохраняют своё значение (переключите на экране Подробностей приложения).</string>
     <string name="confirm_uninstall_title">Удалить приложение?</string>
     <string name="confirm_uninstall_message">Вы уверены, что хотите удалить %1$s? Это действие нельзя отменить, данные приложения могут быть утеряны.</string>
     <string name="invalid_github_url">Неверный URL GitHub. Используйте формат: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -739,6 +739,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Включить бета-версии</string>
     <string name="channel_chip_stable_only">Только стабильные</string>
+    <string name="channel_chip_coachmark_title">Выберите канал релизов</string>
+    <string name="channel_chip_coachmark_body">Нажмите, чтобы переключаться между стабильными релизами и бета-сборками этого приложения.</string>
+    <string name="channel_chip_coachmark_dismiss">Понятно</string>
     <string name="channel_toggle_cd">Переключить бета-релизы для этого приложения</string>
     <string name="action_switch_to_stable">Перейти на стабильную %1$s</string>
     <string name="stalled_project_warning_months">Нет стабильного релиза уже %1$d месяцев</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -599,8 +599,8 @@
     <string name="import_apps_title">Uygulamaları içe aktar</string>
     <string name="import_apps_description">Takip edilen uygulamaları geri yüklemek için dışa aktarılan JSON'u yapıştırın</string>
     <string name="import_apps_hint">Dışa aktarılan JSON'u buraya yapıştırın…</string>
-    <string name="include_pre_releases_title">Ön sürümleri dahil et</string>
-    <string name="include_pre_releases_description">Güncelleme kontrolünde ön sürümleri takip edin. Devre dışı bırakıldığında, yalnızca kararlı sürümler dikkate alınır.</string>
+    <string name="include_pre_releases_title">Varsayılan beta kanalı</string>
+    <string name="include_pre_releases_description">Yeni takip edilen uygulamalar varsayılan olarak beta sürümleri içerir. Önceden takip edilen uygulamalar kendi ayarını korur (uygulamanın Ayrıntılar ekranından değiştirin).</string>
     <string name="confirm_uninstall_title">Uygulama kaldırılsın mı?</string>
     <string name="confirm_uninstall_message">%1$s uygulamasını kaldırmak istediğinizden emin misiniz? Bu işlem geri alınamaz ve uygulama verileri kaybolabilir.</string>
     <string name="invalid_github_url">Geçersiz GitHub URL'si. Biçim: github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -768,6 +768,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">Beta sürümleri dahil et</string>
     <string name="channel_chip_stable_only">Yalnızca kararlı</string>
+    <string name="channel_chip_coachmark_title">Sürüm kanalını seçin</string>
+    <string name="channel_chip_coachmark_body">Bu uygulamanın kararlı sürümleri ile beta sürümleri arasında geçiş yapmak için dokunun.</string>
+    <string name="channel_chip_coachmark_dismiss">Anladım</string>
     <string name="channel_toggle_cd">Bu uygulama için beta sürümlerini aç/kapat</string>
     <string name="action_switch_to_stable">%1$s kararlı sürümüne geç</string>
     <string name="stalled_project_warning_months">%1$d aydır kararlı sürüm yok</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -565,8 +565,8 @@
     <string name="import_apps_title">导入应用</string>
     <string name="import_apps_description">粘贴导出的JSON以恢复跟踪的应用</string>
     <string name="import_apps_hint">在此粘贴导出的JSON…</string>
-    <string name="include_pre_releases_title">包含预发布版本</string>
-    <string name="include_pre_releases_description">检查更新时跟踪预发布版本。禁用后，仅考虑稳定版本。</string>
+    <string name="include_pre_releases_title">默认测试版渠道</string>
+    <string name="include_pre_releases_description">新追踪的应用默认包含测试版。已追踪的应用保留各自设置（在应用详情页切换）。</string>
     <string name="confirm_uninstall_title">卸载应用？</string>
     <string name="confirm_uninstall_message">确定要卸载%1$s吗？此操作无法撤销，应用数据可能会丢失。</string>
     <string name="invalid_github_url">无效的GitHub URL。请使用格式：github.com/owner/repo</string>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -733,6 +733,9 @@
          ═══════════════════════════════════════════════════════════════ -->
     <string name="channel_chip_include_betas">包含测试版</string>
     <string name="channel_chip_stable_only">仅稳定版</string>
+    <string name="channel_chip_coachmark_title">选择发布渠道</string>
+    <string name="channel_chip_coachmark_body">点按以在此应用的稳定版和测试版之间切换。</string>
+    <string name="channel_chip_coachmark_dismiss">知道了</string>
     <string name="channel_toggle_cd">切换此应用的测试版发布</string>
     <string name="action_switch_to_stable">切换到 %1$s 稳定版</string>
     <string name="stalled_project_warning_months">%1$d 个月内无稳定版发布</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -739,8 +739,8 @@
     <string name="import_apps_description">Paste the exported JSON to restore your tracked apps</string>
     <string name="import_apps_hint">Paste exported JSON here…</string>
 
-    <string name="include_pre_releases_title">Include pre-releases</string>
-    <string name="include_pre_releases_description">Track pre-release versions when checking for updates. When disabled, only stable releases are considered.</string>
+    <string name="include_pre_releases_title">Default beta channel</string>
+    <string name="include_pre_releases_description">Newly tracked apps include beta builds by default. Already-tracked apps keep their own per-app channel setting (toggle it on the app\'s Details screen).</string>
     <string name="confirm_uninstall_title">Uninstall app?</string>
     <string name="confirm_uninstall_message">Are you sure you want to uninstall %1$s? This action cannot be undone and app data may be lost.</string>
     <string name="confirm_discard_pending_title">Discard pending install?</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -481,6 +481,9 @@
     <!-- Pre-release channel UX (Details screen) -->
     <string name="channel_chip_include_betas">Include betas</string>
     <string name="channel_chip_stable_only">Stable only</string>
+    <string name="channel_chip_coachmark_title">Choose your release channel</string>
+    <string name="channel_chip_coachmark_body">Tap to switch between stable releases and beta builds for this app.</string>
+    <string name="channel_chip_coachmark_dismiss">Got it</string>
     <string name="channel_toggle_cd">Toggle beta releases for this app</string>
     <string name="action_switch_to_stable">Switch to stable %1$s</string>
     <string name="stalled_project_warning_months">No stable release in %1$d months</string>

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
@@ -152,4 +152,11 @@ sealed interface DetailsAction {
      * coachmark only ever shows once.
      */
     data object OnAcknowledgeApkInspectCoachmark : DetailsAction
+
+    /**
+     * Acknowledges the release-channel chip coachmark. Fired on
+     * tap/dismiss or when the user toggles the channel chip itself.
+     * Persists so the coachmark only ever shows once.
+     */
+    data object OnAcknowledgeChannelChipCoachmark : DetailsAction
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -128,6 +128,12 @@ data class DetailsState(
      * pulse + tooltip animation in the install button row.
      */
     val isApkInspectCoachmarkPending: Boolean = false,
+    /**
+     * One-shot flag — `false` until the user has seen the
+     * release-channel coachmark. Drives the pulse + tooltip on the
+     * `ChannelChip` so users discover the per-app channel toggle.
+     */
+    val isChannelChipCoachmarkPending: Boolean = false,
 ) {
     val filteredReleases: List<GithubRelease>
         get() =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -556,7 +556,12 @@ class DetailsViewModel(
     }
 
     private fun acknowledgeChannelChipCoachmark() {
-        if (!_state.value.isChannelChipCoachmarkPending) return
+        // Persist unconditionally — `state.update` with the same value is a
+        // no-op, and `setChannelChipCoachmarkShown(true)` is idempotent.
+        // Skipping persistence when in-memory `pending` is already false
+        // (e.g., toggle + dismiss race) leaves the DataStore flag at false
+        // if the very first persist failed, so the coachmark would
+        // re-appear on next launch.
         _state.update { it.copy(isChannelChipCoachmarkPending = false) }
         viewModelScope.launch {
             runCatching { tweaksRepository.setChannelChipCoachmarkShown(true) }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -145,6 +145,7 @@ class DetailsViewModel(
                 if (!hasLoadedInitialData) {
                     loadInitial()
                     observeApkInspectCoachmark()
+                    observeChannelChipCoachmark()
                     observeCurrentUserForBadge()
 
                     hasLoadedInitialData = true
@@ -463,6 +464,10 @@ class DetailsViewModel(
             }
 
             DetailsAction.ToggleIncludeBetas -> {
+                // Tapping the chip is the strongest possible signal that
+                // the user has discovered the toggle. No need to keep
+                // pulsing it after that.
+                acknowledgeChannelChipCoachmark()
                 toggleIncludeBetas()
             }
 
@@ -482,6 +487,10 @@ class DetailsViewModel(
 
             DetailsAction.OnAcknowledgeApkInspectCoachmark -> {
                 acknowledgeApkInspectCoachmark()
+            }
+
+            DetailsAction.OnAcknowledgeChannelChipCoachmark -> {
+                acknowledgeChannelChipCoachmark()
             }
         }
     }
@@ -542,6 +551,17 @@ class DetailsViewModel(
             runCatching { tweaksRepository.setApkInspectCoachmarkShown(true) }
                 .onFailure { t ->
                     logger.warn("Failed to persist APK inspect coachmark flag: ${t.message}")
+                }
+        }
+    }
+
+    private fun acknowledgeChannelChipCoachmark() {
+        if (!_state.value.isChannelChipCoachmarkPending) return
+        _state.update { it.copy(isChannelChipCoachmarkPending = false) }
+        viewModelScope.launch {
+            runCatching { tweaksRepository.setChannelChipCoachmarkShown(true) }
+                .onFailure { t ->
+                    logger.warn("Failed to persist channel chip coachmark flag: ${t.message}")
                 }
         }
     }
@@ -845,6 +865,22 @@ class DetailsViewModel(
                 firstStable.installedApp?.isReallyInstalled() == true
             if (!installedAtOpen) return@launch
             _state.update { it.copy(isApkInspectCoachmarkPending = true) }
+        }
+    }
+
+    private fun observeChannelChipCoachmark() {
+        viewModelScope.launch {
+            val alreadyShown =
+                runCatching { tweaksRepository.getChannelChipCoachmarkShown().first() }
+                    .getOrDefault(true)
+            if (alreadyShown) return@launch
+            // ChannelChip only renders when the app is tracked
+            // (`installedApp != null` in `ReleaseChannel.releaseChannel`).
+            // No point pulsing a non-existent chip — defer to a future
+            // visit where the user actually has the app installed.
+            val firstStable = _state.first { !it.isLoading }
+            if (firstStable.installedApp == null) return@launch
+            _state.update { it.copy(isChannelChipCoachmarkPending = true) }
         }
     }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/ReleaseChannel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/ReleaseChannel.kt
@@ -1,7 +1,13 @@
 package zed.rainxch.details.presentation.components.sections
 
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -10,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -23,17 +30,26 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.details.presentation.DetailsAction
 import zed.rainxch.details.presentation.DetailsState
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.action_switch_to_stable
+import zed.rainxch.githubstore.core.presentation.res.channel_chip_coachmark_body
+import zed.rainxch.githubstore.core.presentation.res.channel_chip_coachmark_dismiss
+import zed.rainxch.githubstore.core.presentation.res.channel_chip_coachmark_title
 import zed.rainxch.githubstore.core.presentation.res.channel_chip_include_betas
 import zed.rainxch.githubstore.core.presentation.res.channel_chip_stable_only
 import zed.rainxch.githubstore.core.presentation.res.merged_whats_changed_title
@@ -86,27 +102,37 @@ fun LazyListScope.releaseChannel(
                             } else {
                                 stringResource(Res.string.channel_chip_stable_only)
                             }
-                        ChannelChip(
-                            label = channelLabel,
-                            icon = Icons.Default.Science,
-                            // Visually signal the "hot" channel when the user
-                            // has opted into betas; keep it muted when they're
-                            // on the default stable-only track.
-                            tint =
-                                if (includeBetas) {
-                                    MaterialTheme.colorScheme.tertiary
-                                } else {
-                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                },
-                            onClick = { onAction(DetailsAction.ToggleIncludeBetas) },
-                            // Mirror the visible label so screen readers hear
-                            // the current channel ("Include betas" / "Stable
-                            // only") instead of the previous static
-                            // "Toggle beta releases for this app" string,
-                            // which gave no indication of which side the
-                            // toggle is currently on.
-                            contentDescriptionText = channelLabel,
-                        )
+                        val pulse by rememberChipPulse(active = state.isChannelChipCoachmarkPending)
+                        Box(modifier = Modifier.scale(pulse)) {
+                            ChannelChip(
+                                label = channelLabel,
+                                icon = Icons.Default.Science,
+                                // Visually signal the "hot" channel when the user
+                                // has opted into betas; keep it muted when they're
+                                // on the default stable-only track.
+                                tint =
+                                    if (includeBetas) {
+                                        MaterialTheme.colorScheme.tertiary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    },
+                                onClick = { onAction(DetailsAction.ToggleIncludeBetas) },
+                                // Mirror the visible label so screen readers hear
+                                // the current channel ("Include betas" / "Stable
+                                // only") instead of the previous static
+                                // "Toggle beta releases for this app" string,
+                                // which gave no indication of which side the
+                                // toggle is currently on.
+                                contentDescriptionText = channelLabel,
+                            )
+                            if (state.isChannelChipCoachmarkPending) {
+                                ChannelChipCoachmark(
+                                    onDismiss = {
+                                        onAction(DetailsAction.OnAcknowledgeChannelChipCoachmark)
+                                    },
+                                )
+                            }
+                        }
                     }
 
                     if (showSwitchToStable) {
@@ -253,6 +279,82 @@ private fun ChannelChip(
                 style = MaterialTheme.typography.labelMedium,
                 color = tint,
             )
+        }
+    }
+}
+
+@Composable
+private fun rememberChipPulse(active: Boolean) =
+    rememberInfiniteTransition(label = "channel-chip-pulse")
+        .animateFloat(
+            initialValue = 1f,
+            targetValue = if (active) 1.06f else 1f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(durationMillis = 1100),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+            label = "channel-chip-pulse-scale",
+        )
+
+@Composable
+private fun ChannelChipCoachmark(onDismiss: () -> Unit) {
+    Popup(
+        alignment = Alignment.TopStart,
+        offset = androidx.compose.ui.unit.IntOffset(x = 0, y = -220),
+        properties =
+            PopupProperties(
+                focusable = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false,
+            ),
+        onDismissRequest = onDismiss,
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.primary,
+            shadowElevation = 6.dp,
+            modifier = Modifier.width(280.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Science,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        text = stringResource(Res.string.channel_chip_coachmark_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                Text(
+                    text = stringResource(Res.string.channel_chip_coachmark_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(
+                            text = stringResource(Res.string.channel_chip_coachmark_dismiss),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Per Sprint 2 brief E14. Survey #17 — users don't realise the per-app channel chip on Details toggles beta releases. Add discoverability nudge.

Scope (this PR):
- One-shot `channel_chip_coachmark_shown` flag in TweaksRepository / DataStore.
- DetailsViewModel.observeChannelChipCoachmark gates a pending flag on `installedApp != null` so the chip is actually rendered when the pulse fires.
- Pulse animation + Material 3 Popup tooltip above the chip, dismissable via "Got it" button.
- Acknowledged implicitly on toggle tap (`DetailsAction.ToggleIncludeBetas`) or explicitly via `OnAcknowledgeChannelChipCoachmark`. Either path flips the persistent flag — coachmark never re-fires.
- 13-locale strings + 1.8.2 what's-new bullet.

Out of scope:
- Default-channel preference already exists (`TweaksRepository.getIncludePreReleases()`, applied to new tracks in InstallationManagerImpl) — only the discoverability half of E14 was missing.
- "Ask each time" mode deferred — would need install-flow prompt UI, separate scope.

Compile-verified: `:composeApp:compileDebugKotlinAndroid` BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One‑time coachmark on the Details screen that pulses the release‑channel chip and supports acknowledging/dismissing when switching between stable and beta.

* **Localization**
  * Updated “default beta channel” copy and added coachmark strings across multiple locales (13 languages).

* **Documentation**
  * What's New updated to include coachmark guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/586)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->