### PR TITLE
feat(e11): manual hide controls — long-press to hide repos

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -19,6 +19,7 @@ import zed.rainxch.search.presentation.SearchViewModel
 import zed.rainxch.starred.presentation.StarredReposViewModel
 import zed.rainxch.tweaks.presentation.TweaksViewModel
 import zed.rainxch.tweaks.presentation.feedback.FeedbackViewModel
+import zed.rainxch.tweaks.presentation.hidden.HiddenRepositoriesViewModel
 import zed.rainxch.tweaks.presentation.mirror.AutoSuggestMirrorViewModel
 import zed.rainxch.tweaks.presentation.mirror.MirrorPickerViewModel
 import zed.rainxch.tweaks.presentation.skipped.SkippedUpdatesViewModel
@@ -76,6 +77,7 @@ val viewModelsModule =
         viewModelOf(::StarredPickerViewModel)
         viewModelOf(::AutoSuggestMirrorViewModel)
         viewModelOf(::SkippedUpdatesViewModel)
+        viewModelOf(::HiddenRepositoriesViewModel)
         viewModelOf(::WhatsNewViewModel)
         viewModelOf(::AnnouncementsViewModel)
         viewModel {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -46,6 +46,7 @@ import zed.rainxch.recentlyviewed.presentation.RecentlyViewedRoot
 import zed.rainxch.search.presentation.SearchRoot
 import zed.rainxch.starred.presentation.StarredReposRoot
 import zed.rainxch.tweaks.presentation.TweaksRoot
+import zed.rainxch.tweaks.presentation.hidden.HiddenRepositoriesRoot
 import zed.rainxch.tweaks.presentation.mirror.AutoSuggestMirrorViewModel
 import zed.rainxch.tweaks.presentation.mirror.MirrorPickerRoot
 import zed.rainxch.tweaks.presentation.mirror.components.AutoSuggestMirrorSheet
@@ -382,11 +383,22 @@ fun AppNavigation(
                                 launchSingleTop = true
                             }
                         },
+                        onNavigateToHiddenRepositories = {
+                            navController.navigate(GithubStoreGraph.HiddenRepositoriesScreen) {
+                                launchSingleTop = true
+                            }
+                        },
                     )
                 }
 
                 composable<GithubStoreGraph.SkippedUpdatesScreen> {
                     SkippedUpdatesRoot(
+                        onNavigateBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable<GithubStoreGraph.HiddenRepositoriesScreen> {
+                    HiddenRepositoriesRoot(
                         onNavigateBack = { navController.popBackStack() },
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -57,6 +57,9 @@ sealed interface GithubStoreGraph {
     data object SkippedUpdatesScreen : GithubStoreGraph
 
     @Serializable
+    data object HiddenRepositoriesScreen : GithubStoreGraph
+
+    @Serializable
     data object WhatsNewHistoryScreen : GithubStoreGraph
 
     @Serializable

--- a/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/17.json
+++ b/core/data/schemas/zed.rainxch.core.data.local.db.AppDatabase/17.json
@@ -1,0 +1,841 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "35f065ecb88f6bd274236292119e7819",
+    "entities": [
+      {
+        "tableName": "installed_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `installedVersion` TEXT NOT NULL, `installedAssetName` TEXT, `installedAssetUrl` TEXT, `latestVersion` TEXT, `latestAssetName` TEXT, `latestAssetUrl` TEXT, `latestAssetSize` INTEGER, `appName` TEXT NOT NULL, `installSource` TEXT NOT NULL, `signingFingerprint` TEXT, `installedAt` INTEGER NOT NULL, `lastCheckedAt` INTEGER NOT NULL, `lastUpdatedAt` INTEGER NOT NULL, `isUpdateAvailable` INTEGER NOT NULL, `updateCheckEnabled` INTEGER NOT NULL, `releaseNotes` TEXT, `systemArchitecture` TEXT NOT NULL, `fileExtension` TEXT NOT NULL, `isPendingInstall` INTEGER NOT NULL, `installedVersionName` TEXT, `installedVersionCode` INTEGER NOT NULL, `latestVersionName` TEXT, `latestVersionCode` INTEGER, `latestReleasePublishedAt` TEXT, `includePreReleases` INTEGER NOT NULL, `assetFilterRegex` TEXT, `fallbackToOlderReleases` INTEGER NOT NULL DEFAULT 0, `preferredAssetVariant` TEXT, `preferredVariantStale` INTEGER NOT NULL DEFAULT 0, `preferredAssetTokens` TEXT, `assetGlobPattern` TEXT, `pickedAssetIndex` INTEGER, `pickedAssetSiblingCount` INTEGER, `pendingInstallFilePath` TEXT, `pendingInstallVersion` TEXT, `pendingInstallAssetName` TEXT, `skippedReleaseTag` TEXT DEFAULT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersion",
+            "columnName": "installedVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAssetName",
+            "columnName": "installedAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAssetUrl",
+            "columnName": "installedAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetName",
+            "columnName": "latestAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetUrl",
+            "columnName": "latestAssetUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestAssetSize",
+            "columnName": "latestAssetSize",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSource",
+            "columnName": "installSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signingFingerprint",
+            "columnName": "signingFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckedAt",
+            "columnName": "lastCheckedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedAt",
+            "columnName": "lastUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpdateAvailable",
+            "columnName": "isUpdateAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateCheckEnabled",
+            "columnName": "updateCheckEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "releaseNotes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "systemArchitecture",
+            "columnName": "systemArchitecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileExtension",
+            "columnName": "fileExtension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPendingInstall",
+            "columnName": "isPendingInstall",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedVersionName",
+            "columnName": "installedVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installedVersionCode",
+            "columnName": "installedVersionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestVersionName",
+            "columnName": "latestVersionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersionCode",
+            "columnName": "latestVersionCode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestReleasePublishedAt",
+            "columnName": "latestReleasePublishedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includePreReleases",
+            "columnName": "includePreReleases",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetFilterRegex",
+            "columnName": "assetFilterRegex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fallbackToOlderReleases",
+            "columnName": "fallbackToOlderReleases",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetVariant",
+            "columnName": "preferredAssetVariant",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preferredVariantStale",
+            "columnName": "preferredVariantStale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "preferredAssetTokens",
+            "columnName": "preferredAssetTokens",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assetGlobPattern",
+            "columnName": "assetGlobPattern",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickedAssetIndex",
+            "columnName": "pickedAssetIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pickedAssetSiblingCount",
+            "columnName": "pickedAssetSiblingCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pendingInstallFilePath",
+            "columnName": "pendingInstallFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstallVersion",
+            "columnName": "pendingInstallVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pendingInstallAssetName",
+            "columnName": "pendingInstallAssetName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "skippedReleaseTag",
+            "columnName": "skippedReleaseTag",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "favorite_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "update_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `packageName` TEXT NOT NULL, `appName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoName` TEXT NOT NULL, `fromVersion` TEXT NOT NULL, `toVersion` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `updateSource` TEXT NOT NULL, `success` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromVersion",
+            "columnName": "fromVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toVersion",
+            "columnName": "toVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateSource",
+            "columnName": "updateSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "starred_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `stargazersCount` INTEGER NOT NULL, `forksCount` INTEGER NOT NULL, `openIssuesCount` INTEGER NOT NULL, `isInstalled` INTEGER NOT NULL, `installedPackageName` TEXT, `latestVersion` TEXT, `latestReleaseUrl` TEXT, `starredAt` INTEGER, `addedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stargazersCount",
+            "columnName": "stargazersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forksCount",
+            "columnName": "forksCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openIssuesCount",
+            "columnName": "openIssuesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "isInstalled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedPackageName",
+            "columnName": "installedPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestVersion",
+            "columnName": "latestVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestReleaseUrl",
+            "columnName": "latestReleaseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "starredAt",
+            "columnName": "starredAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "cache_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `jsonData` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jsonData",
+            "columnName": "jsonData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "seen_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `repoDescription` TEXT, `primaryLanguage` TEXT, `repoUrl` TEXT NOT NULL, `seenAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoDescription",
+            "columnName": "repoDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryLanguage",
+            "columnName": "primaryLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL, PRIMARY KEY(`query`))",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query"
+          ]
+        }
+      },
+      {
+        "tableName": "external_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `state` TEXT NOT NULL, `repoOwner` TEXT, `repoName` TEXT, `matchSource` TEXT, `matchConfidence` REAL, `signingFingerprint` TEXT, `installerKind` TEXT, `firstSeenAt` INTEGER NOT NULL, `lastReviewedAt` INTEGER NOT NULL, `skipExpiresAt` INTEGER, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchSource",
+            "columnName": "matchSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchConfidence",
+            "columnName": "matchConfidence",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "signingFingerprint",
+            "columnName": "signingFingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installerKind",
+            "columnName": "installerKind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReviewedAt",
+            "columnName": "lastReviewedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipExpiresAt",
+            "columnName": "skipExpiresAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_external_links_repoOwner_repoName",
+            "unique": false,
+            "columnNames": [
+              "repoOwner",
+              "repoName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_external_links_repoOwner_repoName` ON `${TABLE_NAME}` (`repoOwner`, `repoName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "signing_fingerprints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fingerprint` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoName` TEXT NOT NULL, `source` TEXT NOT NULL, `observedAt` INTEGER NOT NULL, PRIMARY KEY(`fingerprint`))",
+        "fields": [
+          {
+            "fieldPath": "fingerprint",
+            "columnName": "fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "observedAt",
+            "columnName": "observedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fingerprint"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_signing_fingerprints_repoOwner_repoName",
+            "unique": false,
+            "columnNames": [
+              "repoOwner",
+              "repoName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_signing_fingerprints_repoOwner_repoName` ON `${TABLE_NAME}` (`repoOwner`, `repoName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hidden_repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`repoId` INTEGER NOT NULL, `repoName` TEXT NOT NULL, `repoOwner` TEXT NOT NULL, `repoOwnerAvatarUrl` TEXT NOT NULL, `hiddenAt` INTEGER NOT NULL, PRIMARY KEY(`repoId`))",
+        "fields": [
+          {
+            "fieldPath": "repoId",
+            "columnName": "repoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoName",
+            "columnName": "repoName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwner",
+            "columnName": "repoOwner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoOwnerAvatarUrl",
+            "columnName": "repoOwnerAvatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hiddenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "repoId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '35f065ecb88f6bd274236292119e7819')"
+    ]
+  }
+}

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
@@ -18,6 +18,7 @@ import zed.rainxch.core.data.local.db.migrations.MIGRATION_12_13
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_13_14
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_14_15
 import zed.rainxch.core.data.local.db.migrations.MIGRATION_15_16
+import zed.rainxch.core.data.local.db.migrations.MIGRATION_16_17
 
 fun initDatabase(context: Context): AppDatabase {
     val appContext = context.applicationContext
@@ -43,5 +44,6 @@ fun initDatabase(context: Context): AppDatabase {
             MIGRATION_13_14,
             MIGRATION_14_15,
             MIGRATION_15_16,
+            MIGRATION_16_17,
         ).build()
 }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_16_17.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/migrations/MIGRATION_16_17.kt
@@ -1,0 +1,21 @@
+package zed.rainxch.core.data.local.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_16_17 =
+    object : Migration(16, 17) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS hidden_repos (
+                    repoId INTEGER NOT NULL PRIMARY KEY,
+                    repoName TEXT NOT NULL,
+                    repoOwner TEXT NOT NULL,
+                    repoOwnerAvatarUrl TEXT NOT NULL,
+                    hiddenAt INTEGER NOT NULL
+                )
+                """.trimIndent(),
+            )
+        }
+    }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -31,6 +31,7 @@ import zed.rainxch.core.data.local.db.dao.ExternalLinkDao
 import zed.rainxch.core.data.local.db.dao.FavoriteRepoDao
 import zed.rainxch.core.data.local.db.dao.InstalledAppDao
 import zed.rainxch.core.data.local.db.dao.SearchHistoryDao
+import zed.rainxch.core.data.local.db.dao.HiddenRepoDao
 import zed.rainxch.core.data.local.db.dao.SeenRepoDao
 import zed.rainxch.core.data.local.db.dao.SigningFingerprintDao
 import zed.rainxch.core.data.local.db.dao.StarredRepoDao
@@ -57,6 +58,7 @@ import zed.rainxch.core.data.repository.DeviceIdentityRepositoryImpl
 import zed.rainxch.core.data.repository.RateLimitRepositoryImpl
 import zed.rainxch.core.data.repository.SearchHistoryRepositoryImpl
 import zed.rainxch.core.data.repository.TelemetryRepositoryImpl
+import zed.rainxch.core.data.repository.HiddenReposRepositoryImpl
 import zed.rainxch.core.data.repository.SeenReposRepositoryImpl
 import zed.rainxch.core.data.repository.StarredRepositoryImpl
 import zed.rainxch.core.data.repository.AnnouncementsCacheStoreImpl
@@ -85,6 +87,7 @@ import zed.rainxch.core.domain.repository.MirrorRepository
 import zed.rainxch.core.domain.repository.ProxyRepository
 import zed.rainxch.core.domain.repository.RateLimitRepository
 import zed.rainxch.core.domain.repository.SearchHistoryRepository
+import zed.rainxch.core.domain.repository.HiddenReposRepository
 import zed.rainxch.core.domain.repository.SeenReposRepository
 import zed.rainxch.core.domain.repository.StarredRepository
 import zed.rainxch.core.domain.repository.TelemetryRepository
@@ -187,6 +190,12 @@ val coreModule =
         single<SeenReposRepository> {
             SeenReposRepositoryImpl(
                 seenRepoDao = get(),
+            )
+        }
+
+        single<HiddenReposRepository> {
+            HiddenReposRepositoryImpl(
+                hiddenRepoDao = get(),
             )
         }
 
@@ -424,6 +433,10 @@ val databaseModule =
 
         single<SeenRepoDao> {
             get<AppDatabase>().seenRepoDao
+        }
+
+        single<HiddenRepoDao> {
+            get<AppDatabase>().hiddenRepoDao
         }
 
         single<SearchHistoryDao> {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/AppDatabase.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/AppDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.RoomDatabase
 import zed.rainxch.core.data.local.db.dao.CacheDao
 import zed.rainxch.core.data.local.db.dao.ExternalLinkDao
 import zed.rainxch.core.data.local.db.dao.FavoriteRepoDao
+import zed.rainxch.core.data.local.db.dao.HiddenRepoDao
 import zed.rainxch.core.data.local.db.dao.InstalledAppDao
 import zed.rainxch.core.data.local.db.dao.SearchHistoryDao
 import zed.rainxch.core.data.local.db.dao.SeenRepoDao
@@ -14,6 +15,7 @@ import zed.rainxch.core.data.local.db.dao.UpdateHistoryDao
 import zed.rainxch.core.data.local.db.entities.CacheEntryEntity
 import zed.rainxch.core.data.local.db.entities.ExternalLinkEntity
 import zed.rainxch.core.data.local.db.entities.FavoriteRepoEntity
+import zed.rainxch.core.data.local.db.entities.HiddenRepoEntity
 import zed.rainxch.core.data.local.db.entities.InstalledAppEntity
 import zed.rainxch.core.data.local.db.entities.SearchHistoryEntity
 import zed.rainxch.core.data.local.db.entities.SeenRepoEntity
@@ -32,8 +34,9 @@ import zed.rainxch.core.data.local.db.entities.UpdateHistoryEntity
         SearchHistoryEntity::class,
         ExternalLinkEntity::class,
         SigningFingerprintEntity::class,
+        HiddenRepoEntity::class,
     ],
-    version = 16,
+    version = 17,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -46,4 +49,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract val searchHistoryDao: SearchHistoryDao
     abstract val externalLinkDao: ExternalLinkDao
     abstract val signingFingerprintDao: SigningFingerprintDao
+    abstract val hiddenRepoDao: HiddenRepoDao
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/HiddenRepoDao.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/HiddenRepoDao.kt
@@ -1,0 +1,26 @@
+package zed.rainxch.core.data.local.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import zed.rainxch.core.data.local.db.entities.HiddenRepoEntity
+
+@Dao
+interface HiddenRepoDao {
+    @Query("SELECT repoId FROM hidden_repos")
+    fun getAllHiddenRepoIds(): Flow<List<Long>>
+
+    @Query("SELECT * FROM hidden_repos ORDER BY hiddenAt DESC")
+    fun getAllHiddenRepos(): Flow<List<HiddenRepoEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: HiddenRepoEntity)
+
+    @Query("DELETE FROM hidden_repos WHERE repoId = :repoId")
+    suspend fun deleteById(repoId: Long)
+
+    @Query("DELETE FROM hidden_repos")
+    suspend fun clearAll()
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/entities/HiddenRepoEntity.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/entities/HiddenRepoEntity.kt
@@ -1,0 +1,14 @@
+package zed.rainxch.core.data.local.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "hidden_repos")
+data class HiddenRepoEntity(
+    @PrimaryKey
+    val repoId: Long,
+    val repoName: String,
+    val repoOwner: String,
+    val repoOwnerAvatarUrl: String,
+    val hiddenAt: Long,
+)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HiddenReposRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HiddenReposRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package zed.rainxch.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import zed.rainxch.core.data.local.db.dao.HiddenRepoDao
+import zed.rainxch.core.data.local.db.entities.HiddenRepoEntity
+import zed.rainxch.core.domain.model.HiddenRepo
+import zed.rainxch.core.domain.repository.HiddenReposRepository
+
+class HiddenReposRepositoryImpl(
+    private val hiddenRepoDao: HiddenRepoDao,
+) : HiddenReposRepository {
+    override fun getAllHiddenRepoIds(): Flow<Set<Long>> =
+        hiddenRepoDao.getAllHiddenRepoIds().map { it.toSet() }
+
+    override fun getAllHiddenRepos(): Flow<List<HiddenRepo>> =
+        hiddenRepoDao.getAllHiddenRepos().map { entities ->
+            entities.map { it.toDomain() }
+        }
+
+    override suspend fun hide(
+        repoId: Long,
+        repoName: String,
+        repoOwner: String,
+        repoOwnerAvatarUrl: String,
+    ) {
+        hiddenRepoDao.insert(
+            HiddenRepoEntity(
+                repoId = repoId,
+                repoName = repoName,
+                repoOwner = repoOwner,
+                repoOwnerAvatarUrl = repoOwnerAvatarUrl,
+                hiddenAt = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun unhide(repoId: Long) {
+        hiddenRepoDao.deleteById(repoId)
+    }
+
+    override suspend fun clearAll() {
+        hiddenRepoDao.clearAll()
+    }
+
+    private fun HiddenRepoEntity.toDomain(): HiddenRepo =
+        HiddenRepo(
+            repoId = repoId,
+            repoName = repoName,
+            repoOwner = repoOwner,
+            repoOwnerAvatarUrl = repoOwnerAvatarUrl,
+            hiddenAt = hiddenAt,
+        )
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/SeenReposRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/SeenReposRepositoryImpl.kt
@@ -20,15 +20,35 @@ class SeenReposRepositoryImpl(
         }
 
     override suspend fun markAsSeen(repo: GithubRepoSummary) {
+        markAsSeen(
+            repoId = repo.id,
+            repoName = repo.name,
+            repoOwner = repo.owner.login,
+            repoOwnerAvatarUrl = repo.owner.avatarUrl,
+            repoDescription = repo.description,
+            primaryLanguage = repo.language,
+            repoUrl = repo.htmlUrl,
+        )
+    }
+
+    override suspend fun markAsSeen(
+        repoId: Long,
+        repoName: String,
+        repoOwner: String,
+        repoOwnerAvatarUrl: String,
+        repoDescription: String?,
+        primaryLanguage: String?,
+        repoUrl: String,
+    ) {
         seenRepoDao.insert(
             SeenRepoEntity(
-                repoId = repo.id,
-                repoName = repo.name,
-                repoOwner = repo.owner.login,
-                repoOwnerAvatarUrl = repo.owner.avatarUrl,
-                repoDescription = repo.description,
-                primaryLanguage = repo.language,
-                repoUrl = repo.htmlUrl,
+                repoId = repoId,
+                repoName = repoName,
+                repoOwner = repoOwner,
+                repoOwnerAvatarUrl = repoOwnerAvatarUrl,
+                repoDescription = repoDescription,
+                primaryLanguage = primaryLanguage,
+                repoUrl = repoUrl,
                 seenAt = System.currentTimeMillis(),
             ),
         )

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HiddenRepo.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HiddenRepo.kt
@@ -1,0 +1,9 @@
+package zed.rainxch.core.domain.model
+
+data class HiddenRepo(
+    val repoId: Long,
+    val repoName: String,
+    val repoOwner: String,
+    val repoOwnerAvatarUrl: String,
+    val hiddenAt: Long,
+)

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/HiddenReposRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/HiddenReposRepository.kt
@@ -1,0 +1,21 @@
+package zed.rainxch.core.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import zed.rainxch.core.domain.model.HiddenRepo
+
+interface HiddenReposRepository {
+    fun getAllHiddenRepoIds(): Flow<Set<Long>>
+
+    fun getAllHiddenRepos(): Flow<List<HiddenRepo>>
+
+    suspend fun hide(
+        repoId: Long,
+        repoName: String,
+        repoOwner: String,
+        repoOwnerAvatarUrl: String,
+    )
+
+    suspend fun unhide(repoId: Long)
+
+    suspend fun clearAll()
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/SeenReposRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/SeenReposRepository.kt
@@ -11,6 +11,21 @@ interface SeenReposRepository {
 
     suspend fun markAsSeen(repo: GithubRepoSummary)
 
+    /**
+     * Primitive-arg overload for surfaces that only hold the UI model
+     * (Home / Search cards) and would otherwise have to reconstitute a
+     * full [GithubRepoSummary] just to mark a repo seen.
+     */
+    suspend fun markAsSeen(
+        repoId: Long,
+        repoName: String,
+        repoOwner: String,
+        repoOwnerAvatarUrl: String,
+        repoDescription: String?,
+        primaryLanguage: String?,
+        repoUrl: String,
+    )
+
     suspend fun removeFromHistory(repoId: Long)
 
     suspend fun clearAll()

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -11,7 +11,8 @@
         "Skip a specific update — dismiss a single release if it's a false-positive prompt; you'll be re-notified when a newer one lands.",
         "Silent install via root — Magisk, KernelSU, and APatch users can now install without Shizuku or Dhizuku.",
         "Search in Starred and Favourites — quickly filter long lists by repo name, owner, description, or language.",
-        "Self-owned ✓ badge — when you're signed in, repos you own get a verified checkmark on Home and Search cards."
+        "Self-owned ✓ badge — when you're signed in, repos you own get a verified checkmark on Home and Search cards.",
+        "Hide repository — long-press any repo card on Home or Search to hide it from discovery. The repo stays in your library if you have it installed."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1162,4 +1162,7 @@
     <string name="hidden_repositories_unhidden_snackbar">تم إظهار %1$s</string>
     <string name="hidden_repositories_unhidden_all_snackbar">تم إظهار جميع المستودعات</string>
     <string name="hidden_repositories_unhide_failure">تعذر الإظهار. حاول مرة أخرى.</string>
+    <string name="open_on_github">فتح في GitHub</string>
+    <string name="mark_as_viewed">وضع علامة مشاهد</string>
+    <string name="mark_as_unviewed">إلغاء علامة مشاهد</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1152,4 +1152,14 @@
     <string name="skipped_updates_unskip_action">إلغاء التخطّي</string>
     <string name="skipped_updates_unskipped_snackbar">تم تفعيل الإشعار لـ %1$s</string>
     <string name="skipped_updates_unskip_failure">تعذّر تحديث التفضيل</string>
+    <string name="hidden_repositories_title">المستودعات المخفية</string>
+    <string name="hidden_repositories_entry_description">إدارة المستودعات التي أخفيتها من الرئيسية والبحث.</string>
+    <string name="hidden_repositories_count">%1$d مخفي</string>
+    <string name="hidden_repositories_empty_title">لا توجد مستودعات مخفية</string>
+    <string name="hidden_repositories_empty_description">اضغط مطولاً على بطاقة مستودع في الرئيسية أو البحث لإخفائه من الاستكشاف.</string>
+    <string name="hidden_repositories_unhide_action">إظهار</string>
+    <string name="hidden_repositories_unhide_all">إظهار الكل</string>
+    <string name="hidden_repositories_unhidden_snackbar">تم إظهار %1$s</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">تم إظهار جميع المستودعات</string>
+    <string name="hidden_repositories_unhide_failure">تعذر الإظهار. حاول مرة أخرى.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -645,6 +645,9 @@
     <string name="seen_history_cleared">تم مسح سجل المشاهدة</string>
     <string name="seen_badge">تمت المشاهدة</string>
     <string name="self_owned_badge">هذا المستودع لك</string>
+    <string name="hide_repository">إخفاء المستودع</string>
+    <string name="repository_hidden">تم إخفاء المستودع</string>
+    <string name="undo_hide">تراجع</string>
     <string name="privacy_section">الخصوصية</string>
     <string name="telemetry_title">ساعد في تحسين البحث</string>
     <string name="telemetry_description">مشاركة بيانات الاستخدام (عمليات البحث والتثبيتات والتفاعلات) المرتبطة بمعرّف تحليلي قابل لإعادة التعيين. لا تتم مشاركة تفاصيل الحساب.</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -644,6 +644,9 @@
     <string name="seen_history_cleared">দেখার ইতিহাস মুছে ফেলা হয়েছে</string>
     <string name="seen_badge">দেখা হয়েছে</string>
     <string name="self_owned_badge">এই রিপো আপনার</string>
+    <string name="hide_repository">রিপোজিটরি লুকান</string>
+    <string name="repository_hidden">রিপোজিটরি লুকানো হয়েছে</string>
+    <string name="undo_hide">পূর্বাবস্থা</string>
     <string name="privacy_section">গোপনীয়তা</string>
     <string name="telemetry_title">অনুসন্ধান উন্নত করতে সহায়তা করুন</string>
     <string name="telemetry_description">পুনরায় সেট করা যায় এমন একটি বিশ্লেষণ আইডির সাথে যুক্ত ব্যবহার ডেটা (অনুসন্ধান, ইনস্টল, ইন্টারঅ্যাকশন) শেয়ার করুন। অ্যাকাউন্ট বিবরণ শেয়ার করা হয় না।</string>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1128,4 +1128,14 @@
     <string name="skipped_updates_unskip_action">এড়িয়ে যাবেন না</string>
     <string name="skipped_updates_unskipped_snackbar">%1$s এর জন্য আপডেট প্রম্পট আবার চালু</string>
     <string name="skipped_updates_unskip_failure">পছন্দ আপডেট করা যায়নি</string>
+    <string name="hidden_repositories_title">লুকানো রিপোজিটরি</string>
+    <string name="hidden_repositories_entry_description">হোম ও সার্চ থেকে লুকানো রিপোজিটরি পরিচালনা করুন।</string>
+    <string name="hidden_repositories_count">%1$d লুকানো</string>
+    <string name="hidden_repositories_empty_title">কোনো লুকানো রিপোজিটরি নেই</string>
+    <string name="hidden_repositories_empty_description">হোম বা সার্চে রিপোজিটরি কার্ডে দীর্ঘক্ষণ চাপ দিয়ে আবিষ্কার থেকে লুকান।</string>
+    <string name="hidden_repositories_unhide_action">দেখান</string>
+    <string name="hidden_repositories_unhide_all">সব দেখান</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s এখন দৃশ্যমান</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">সব রিপোজিটরি দৃশ্যমান</string>
+    <string name="hidden_repositories_unhide_failure">দৃশ্যমান করা যায়নি। আবার চেষ্টা করুন।</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1138,4 +1138,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s এখন দৃশ্যমান</string>
     <string name="hidden_repositories_unhidden_all_snackbar">সব রিপোজিটরি দৃশ্যমান</string>
     <string name="hidden_repositories_unhide_failure">দৃশ্যমান করা যায়নি। আবার চেষ্টা করুন।</string>
+    <string name="open_on_github">GitHub-এ খুলুন</string>
+    <string name="mark_as_viewed">দেখা হিসেবে চিহ্নিত করুন</string>
+    <string name="mark_as_unviewed">অদেখা হিসেবে চিহ্নিত করুন</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1100,4 +1100,14 @@
     <string name="skipped_updates_unskip_action">No saltar</string>
     <string name="skipped_updates_unskipped_snackbar">Aviso de actualización reactivado para %1$s</string>
     <string name="skipped_updates_unskip_failure">No se pudo actualizar la preferencia</string>
+    <string name="hidden_repositories_title">Repositorios ocultos</string>
+    <string name="hidden_repositories_entry_description">Gestiona los repositorios que ocultaste de Inicio y Búsqueda.</string>
+    <string name="hidden_repositories_count">%1$d oculto(s)</string>
+    <string name="hidden_repositories_empty_title">Sin repositorios ocultos</string>
+    <string name="hidden_repositories_empty_description">Mantén pulsada una tarjeta de repositorio en Inicio o Búsqueda para ocultarla.</string>
+    <string name="hidden_repositories_unhide_action">Mostrar</string>
+    <string name="hidden_repositories_unhide_all">Mostrar todos</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s vuelto a mostrar</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Todos los repositorios mostrados</string>
+    <string name="hidden_repositories_unhide_failure">No se pudo mostrar. Inténtalo de nuevo.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1110,4 +1110,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s vuelto a mostrar</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Todos los repositorios mostrados</string>
     <string name="hidden_repositories_unhide_failure">No se pudo mostrar. Inténtalo de nuevo.</string>
+    <string name="open_on_github">Abrir en GitHub</string>
+    <string name="mark_as_viewed">Marcar como visto</string>
+    <string name="mark_as_unviewed">Marcar como no visto</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -605,6 +605,9 @@
     <string name="seen_history_cleared">Historial de vistos borrado</string>
     <string name="seen_badge">Visto</string>
     <string name="self_owned_badge">Eres dueño de este repo</string>
+    <string name="hide_repository">Ocultar repositorio</string>
+    <string name="repository_hidden">Repositorio ocultado</string>
+    <string name="undo_hide">Deshacer</string>
     <string name="privacy_section">Privacidad</string>
     <string name="telemetry_title">Ayudar a mejorar la búsqueda</string>
     <string name="telemetry_description">Compartir datos de uso (búsquedas, instalaciones, interacciones) asociados a un ID de análisis restablecible. No se comparten detalles de la cuenta.</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1101,4 +1101,14 @@
     <string name="skipped_updates_unskip_action">Ne plus ignorer</string>
     <string name="skipped_updates_unskipped_snackbar">Avis réactivé pour %1$s</string>
     <string name="skipped_updates_unskip_failure">Impossible de mettre à jour la préférence</string>
+    <string name="hidden_repositories_title">Dépôts masqués</string>
+    <string name="hidden_repositories_entry_description">Gérez les dépôts masqués depuis Accueil et Recherche.</string>
+    <string name="hidden_repositories_count">%1$d masqué(s)</string>
+    <string name="hidden_repositories_empty_title">Aucun dépôt masqué</string>
+    <string name="hidden_repositories_empty_description">Appuyez longuement sur une carte de dépôt dans Accueil ou Recherche pour la masquer.</string>
+    <string name="hidden_repositories_unhide_action">Afficher</string>
+    <string name="hidden_repositories_unhide_all">Tout afficher</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s réaffiché</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Tous les dépôts réaffichés</string>
+    <string name="hidden_repositories_unhide_failure">Impossible d\'afficher. Réessayez.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1111,4 +1111,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s réaffiché</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Tous les dépôts réaffichés</string>
     <string name="hidden_repositories_unhide_failure">Impossible d\'afficher. Réessayez.</string>
+    <string name="open_on_github">Ouvrir sur GitHub</string>
+    <string name="mark_as_viewed">Marquer comme vu</string>
+    <string name="mark_as_unviewed">Marquer comme non vu</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -606,6 +606,9 @@
     <string name="seen_history_cleared">Historique des consultations effacé</string>
     <string name="seen_badge">Consulté</string>
     <string name="self_owned_badge">Vous possédez ce dépôt</string>
+    <string name="hide_repository">Masquer le dépôt</string>
+    <string name="repository_hidden">Dépôt masqué</string>
+    <string name="undo_hide">Annuler</string>
     <string name="privacy_section">Confidentialité</string>
     <string name="telemetry_title">Aider à améliorer la recherche</string>
     <string name="telemetry_description">Partager des données d'utilisation (recherches, installations, interactions) associées à un identifiant d'analyse réinitialisable. Aucun détail de compte n'est partagé.</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1139,4 +1139,14 @@
     <string name="skipped_updates_unskip_action">मत छोड़ें</string>
     <string name="skipped_updates_unskipped_snackbar">%1$s के लिए अपडेट प्रॉम्प्ट चालू</string>
     <string name="skipped_updates_unskip_failure">प्राथमिकता अपडेट नहीं हो सकी</string>
+    <string name="hidden_repositories_title">छिपे हुए रिपॉजिटरी</string>
+    <string name="hidden_repositories_entry_description">होम और सर्च से छिपाए गए रिपॉजिटरी प्रबंधित करें।</string>
+    <string name="hidden_repositories_count">%1$d छिपे हुए</string>
+    <string name="hidden_repositories_empty_title">कोई छिपा रिपॉजिटरी नहीं</string>
+    <string name="hidden_repositories_empty_description">होम या सर्च में रेपो कार्ड पर लंबा दबाकर इसे डिस्कवरी से छिपाएं।</string>
+    <string name="hidden_repositories_unhide_action">दिखाएं</string>
+    <string name="hidden_repositories_unhide_all">सभी दिखाएं</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s फिर से दृश्यमान</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">सभी रिपॉजिटरी अब दृश्यमान</string>
+    <string name="hidden_repositories_unhide_failure">दिखाया नहीं जा सका। पुनः प्रयास करें।</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -643,6 +643,9 @@
     <string name="seen_history_cleared">देखने का इतिहास साफ़ किया गया</string>
     <string name="seen_badge">देखा गया</string>
     <string name="self_owned_badge">यह रेपो आपका है</string>
+    <string name="hide_repository">रिपॉजिटरी छिपाएं</string>
+    <string name="repository_hidden">रिपॉजिटरी छिपाई गई</string>
+    <string name="undo_hide">पूर्ववत्</string>
     <string name="privacy_section">गोपनीयता</string>
     <string name="telemetry_title">खोज को बेहतर बनाने में मदद करें</string>
     <string name="telemetry_description">रीसेट करने योग्य एनालिटिक्स आईडी से जुड़े उपयोग डेटा (खोज, इंस्टॉल, इंटरैक्शन) साझा करें। खाता विवरण साझा नहीं किए जाते।</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1149,4 +1149,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s फिर से दृश्यमान</string>
     <string name="hidden_repositories_unhidden_all_snackbar">सभी रिपॉजिटरी अब दृश्यमान</string>
     <string name="hidden_repositories_unhide_failure">दिखाया नहीं जा सका। पुनः प्रयास करें।</string>
+    <string name="open_on_github">GitHub पर खोलें</string>
+    <string name="mark_as_viewed">देखा हुआ चिह्नित करें</string>
+    <string name="mark_as_unviewed">अनदेखा चिह्नित करें</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1150,4 +1150,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s di nuovo visibile</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Tutti i repository di nuovo visibili</string>
     <string name="hidden_repositories_unhide_failure">Impossibile mostrare. Riprova.</string>
+    <string name="open_on_github">Apri su GitHub</string>
+    <string name="mark_as_viewed">Segna come visto</string>
+    <string name="mark_as_unviewed">Segna come non visto</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1140,4 +1140,14 @@
     <string name="skipped_updates_unskip_action">Non ignorare</string>
     <string name="skipped_updates_unskipped_snackbar">Avviso riattivato per %1$s</string>
     <string name="skipped_updates_unskip_failure">Impossibile aggiornare la preferenza</string>
+    <string name="hidden_repositories_title">Repository nascosti</string>
+    <string name="hidden_repositories_entry_description">Gestisci i repository nascosti da Home e Ricerca.</string>
+    <string name="hidden_repositories_count">%1$d nascosti</string>
+    <string name="hidden_repositories_empty_title">Nessun repository nascosto</string>
+    <string name="hidden_repositories_empty_description">Tieni premuta una scheda repository in Home o Ricerca per nasconderla.</string>
+    <string name="hidden_repositories_unhide_action">Mostra</string>
+    <string name="hidden_repositories_unhide_all">Mostra tutti</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s di nuovo visibile</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Tutti i repository di nuovo visibili</string>
+    <string name="hidden_repositories_unhide_failure">Impossibile mostrare. Riprova.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -644,6 +644,9 @@
     <string name="seen_history_cleared">Cronologia visualizzazioni cancellata</string>
     <string name="seen_badge">Visualizzato</string>
     <string name="self_owned_badge">Sei il proprietario di questo repo</string>
+    <string name="hide_repository">Nascondi repository</string>
+    <string name="repository_hidden">Repository nascosto</string>
+    <string name="undo_hide">Annulla</string>
     <string name="privacy_section">Privacy</string>
     <string name="telemetry_title">Aiuta a migliorare la ricerca</string>
     <string name="telemetry_description">Condividi dati di utilizzo (ricerche, installazioni, interazioni) associati a un ID analitico ripristinabile. Nessun dettaglio dell'account viene condiviso.</string>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1095,4 +1095,14 @@
     <string name="skipped_updates_unskip_action">スキップしない</string>
     <string name="skipped_updates_unskipped_snackbar">%1$s のアップデート通知を再び有効にしました</string>
     <string name="skipped_updates_unskip_failure">設定を更新できませんでした</string>
+    <string name="hidden_repositories_title">非表示のリポジトリ</string>
+    <string name="hidden_repositories_entry_description">ホームと検索で非表示にしたリポジトリを管理。</string>
+    <string name="hidden_repositories_count">%1$d 件非表示</string>
+    <string name="hidden_repositories_empty_title">非表示のリポジトリはありません</string>
+    <string name="hidden_repositories_empty_description">ホームや検索でリポジトリカードを長押しすると検索結果から非表示にできます。</string>
+    <string name="hidden_repositories_unhide_action">表示する</string>
+    <string name="hidden_repositories_unhide_all">すべて表示</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s を再表示しました</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">すべてのリポジトリを再表示しました</string>
+    <string name="hidden_repositories_unhide_failure">再表示できませんでした。もう一度お試しください。</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1105,4 +1105,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s を再表示しました</string>
     <string name="hidden_repositories_unhidden_all_snackbar">すべてのリポジトリを再表示しました</string>
     <string name="hidden_repositories_unhide_failure">再表示できませんでした。もう一度お試しください。</string>
+    <string name="open_on_github">GitHub で開く</string>
+    <string name="mark_as_viewed">既読にする</string>
+    <string name="mark_as_unviewed">未読にする</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -607,6 +607,9 @@
     <string name="seen_history_cleared">閲覧履歴をクリアしました</string>
     <string name="seen_badge">閲覧済み</string>
     <string name="self_owned_badge">あなたが所有するリポジトリ</string>
+    <string name="hide_repository">リポジトリを非表示</string>
+    <string name="repository_hidden">リポジトリを非表示にしました</string>
+    <string name="undo_hide">元に戻す</string>
     <string name="privacy_section">プライバシー</string>
     <string name="telemetry_title">検索の改善に協力</string>
     <string name="telemetry_description">リセット可能な分析 ID に関連付けられた使用データ(検索、インストール、操作)を共有します。アカウント情報は共有されません。</string>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1140,4 +1140,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s 다시 표시됨</string>
     <string name="hidden_repositories_unhidden_all_snackbar">모든 저장소가 다시 표시됨</string>
     <string name="hidden_repositories_unhide_failure">표시할 수 없습니다. 다시 시도하세요.</string>
+    <string name="open_on_github">GitHub에서 열기</string>
+    <string name="mark_as_viewed">본 항목으로 표시</string>
+    <string name="mark_as_unviewed">본 항목 해제</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1130,4 +1130,14 @@
     <string name="skipped_updates_unskip_action">건너뛰지 않기</string>
     <string name="skipped_updates_unskipped_snackbar">%1$s에 대한 업데이트 알림 다시 사용 설정</string>
     <string name="skipped_updates_unskip_failure">설정을 업데이트할 수 없습니다</string>
+    <string name="hidden_repositories_title">숨긴 저장소</string>
+    <string name="hidden_repositories_entry_description">홈과 검색에서 숨긴 저장소를 관리합니다.</string>
+    <string name="hidden_repositories_count">%1$d개 숨김</string>
+    <string name="hidden_repositories_empty_title">숨긴 저장소 없음</string>
+    <string name="hidden_repositories_empty_description">홈 또는 검색에서 저장소 카드를 길게 눌러 탐색에서 숨길 수 있습니다.</string>
+    <string name="hidden_repositories_unhide_action">표시</string>
+    <string name="hidden_repositories_unhide_all">모두 표시</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s 다시 표시됨</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">모든 저장소가 다시 표시됨</string>
+    <string name="hidden_repositories_unhide_failure">표시할 수 없습니다. 다시 시도하세요.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -642,6 +642,9 @@
     <string name="seen_history_cleared">조회 기록이 삭제되었습니다</string>
     <string name="seen_badge">확인함</string>
     <string name="self_owned_badge">내가 소유한 저장소</string>
+    <string name="hide_repository">저장소 숨기기</string>
+    <string name="repository_hidden">저장소가 숨겨졌습니다</string>
+    <string name="undo_hide">실행 취소</string>
     <string name="privacy_section">개인 정보 보호</string>
     <string name="telemetry_title">검색 개선에 도움 주기</string>
     <string name="telemetry_description">재설정 가능한 분석 ID에 연결된 사용 데이터(검색, 설치, 상호작용)를 공유합니다. 계정 정보는 공유되지 않습니다.</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1121,4 +1121,14 @@
     <string name="skipped_updates_unskip_action">Nie pomijaj</string>
     <string name="skipped_updates_unskipped_snackbar">Powiadomienie włączone dla %1$s</string>
     <string name="skipped_updates_unskip_failure">Nie udało się zmienić preferencji</string>
+    <string name="hidden_repositories_title">Ukryte repozytoria</string>
+    <string name="hidden_repositories_entry_description">Zarządzaj repozytoriami ukrytymi na Ekranie głównym i w Wyszukiwarce.</string>
+    <string name="hidden_repositories_count">%1$d ukryte</string>
+    <string name="hidden_repositories_empty_title">Brak ukrytych repozytoriów</string>
+    <string name="hidden_repositories_empty_description">Przytrzymaj kartę repozytorium na Ekranie głównym lub w Wyszukiwarce, aby ukryć ją z odkrywania.</string>
+    <string name="hidden_repositories_unhide_action">Pokaż</string>
+    <string name="hidden_repositories_unhide_all">Pokaż wszystkie</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s znów widoczne</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Wszystkie repozytoria znów widoczne</string>
+    <string name="hidden_repositories_unhide_failure">Nie udało się pokazać. Spróbuj ponownie.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -608,6 +608,9 @@
     <string name="seen_history_cleared">Historia przeglądania wyczyszczona</string>
     <string name="seen_badge">Przeglądane</string>
     <string name="self_owned_badge">Jesteś właścicielem tego repo</string>
+    <string name="hide_repository">Ukryj repozytorium</string>
+    <string name="repository_hidden">Repozytorium ukryte</string>
+    <string name="undo_hide">Cofnij</string>
     <string name="privacy_section">Prywatność</string>
     <string name="telemetry_title">Pomóż ulepszyć wyszukiwanie</string>
     <string name="telemetry_description">Udostępniaj dane o użyciu (wyszukiwania, instalacje, interakcje) powiązane z resetowalnym identyfikatorem analitycznym. Żadne dane konta nie są udostępniane.</string>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1131,4 +1131,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s znów widoczne</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Wszystkie repozytoria znów widoczne</string>
     <string name="hidden_repositories_unhide_failure">Nie udało się pokazać. Spróbuj ponownie.</string>
+    <string name="open_on_github">Otwórz w GitHub</string>
+    <string name="mark_as_viewed">Oznacz jako obejrzane</string>
+    <string name="mark_as_unviewed">Oznacz jako nieobejrzane</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -608,6 +608,9 @@
     <string name="seen_history_cleared">История просмотров очищена</string>
     <string name="seen_badge">Просмотрено</string>
     <string name="self_owned_badge">Ваш репозиторий</string>
+    <string name="hide_repository">Скрыть репозиторий</string>
+    <string name="repository_hidden">Репозиторий скрыт</string>
+    <string name="undo_hide">Отменить</string>
     <string name="privacy_section">Конфиденциальность</string>
     <string name="telemetry_title">Помочь улучшить поиск</string>
     <string name="telemetry_description">Отправлять данные об использовании (поиски, установки, взаимодействия), связанные со сбрасываемым идентификатором аналитики. Данные учётной записи не передаются.</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1121,4 +1121,14 @@
     <string name="skipped_updates_unskip_action">Не пропускать</string>
     <string name="skipped_updates_unskipped_snackbar">Уведомление снова включено для %1$s</string>
     <string name="skipped_updates_unskip_failure">Не удалось обновить настройку</string>
+    <string name="hidden_repositories_title">Скрытые репозитории</string>
+    <string name="hidden_repositories_entry_description">Управление репозиториями, скрытыми с Главной и Поиска.</string>
+    <string name="hidden_repositories_count">%1$d скрыто</string>
+    <string name="hidden_repositories_empty_title">Нет скрытых репозиториев</string>
+    <string name="hidden_repositories_empty_description">Удерживайте карточку репозитория на Главной или в Поиске, чтобы скрыть её из обзора.</string>
+    <string name="hidden_repositories_unhide_action">Показать</string>
+    <string name="hidden_repositories_unhide_all">Показать все</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s снова виден</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Все репозитории снова видны</string>
+    <string name="hidden_repositories_unhide_failure">Не удалось показать. Повторите попытку.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1131,4 +1131,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s снова виден</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Все репозитории снова видны</string>
     <string name="hidden_repositories_unhide_failure">Не удалось показать. Повторите попытку.</string>
+    <string name="open_on_github">Открыть на GitHub</string>
+    <string name="mark_as_viewed">Отметить как просмотренный</string>
+    <string name="mark_as_unviewed">Снять отметку</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1137,4 +1137,14 @@
     <string name="skipped_updates_unskip_action">Atlamayı kaldır</string>
     <string name="skipped_updates_unskipped_snackbar">%1$s için güncelleme bildirimi yeniden açıldı</string>
     <string name="skipped_updates_unskip_failure">Tercih güncellenemedi</string>
+    <string name="hidden_repositories_title">Gizli depolar</string>
+    <string name="hidden_repositories_entry_description">Ana ekran ve Arama\'da gizlediğin depoları yönet.</string>
+    <string name="hidden_repositories_count">%1$d gizli</string>
+    <string name="hidden_repositories_empty_title">Gizli depo yok</string>
+    <string name="hidden_repositories_empty_description">Ana ekran veya Arama\'da bir depo kartına basılı tutarak keşiften gizleyin.</string>
+    <string name="hidden_repositories_unhide_action">Göster</string>
+    <string name="hidden_repositories_unhide_all">Tümünü göster</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s yeniden görünür</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">Tüm depolar yeniden görünür</string>
+    <string name="hidden_repositories_unhide_failure">Gösterilemedi. Tekrar dene.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -642,6 +642,9 @@
     <string name="seen_history_cleared">Görüntüleme geçmişi temizlendi</string>
     <string name="seen_badge">Görüntülendi</string>
     <string name="self_owned_badge">Bu deponun sahibisin</string>
+    <string name="hide_repository">Depoyu gizle</string>
+    <string name="repository_hidden">Depo gizlendi</string>
+    <string name="undo_hide">Geri al</string>
     <string name="privacy_section">Gizlilik</string>
     <string name="telemetry_title">Aramayı iyileştirmeye yardım et</string>
     <string name="telemetry_description">Sıfırlanabilir bir analiz kimliğiyle ilişkilendirilmiş kullanım verilerini (aramalar, yüklemeler, etkileşimler) paylaş. Hesap ayrıntıları paylaşılmaz.</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1147,4 +1147,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s yeniden görünür</string>
     <string name="hidden_repositories_unhidden_all_snackbar">Tüm depolar yeniden görünür</string>
     <string name="hidden_repositories_unhide_failure">Gösterilemedi. Tekrar dene.</string>
+    <string name="open_on_github">GitHub\'da aç</string>
+    <string name="mark_as_viewed">Görüldü olarak işaretle</string>
+    <string name="mark_as_unviewed">Görülmedi olarak işaretle</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1107,4 +1107,7 @@
     <string name="hidden_repositories_unhidden_snackbar">%1$s 已重新显示</string>
     <string name="hidden_repositories_unhidden_all_snackbar">所有仓库已重新显示</string>
     <string name="hidden_repositories_unhide_failure">无法取消隐藏。请重试。</string>
+    <string name="open_on_github">在 GitHub 打开</string>
+    <string name="mark_as_viewed">标记为已查看</string>
+    <string name="mark_as_unviewed">取消已查看标记</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1097,4 +1097,14 @@
     <string name="skipped_updates_unskip_action">不要跳过</string>
     <string name="skipped_updates_unskipped_snackbar">已为 %1$s 重新启用更新提示</string>
     <string name="skipped_updates_unskip_failure">无法更新偏好设置</string>
+    <string name="hidden_repositories_title">已隐藏的仓库</string>
+    <string name="hidden_repositories_entry_description">管理从首页和搜索中隐藏的仓库。</string>
+    <string name="hidden_repositories_count">已隐藏 %1$d 个</string>
+    <string name="hidden_repositories_empty_title">没有隐藏的仓库</string>
+    <string name="hidden_repositories_empty_description">在首页或搜索中长按仓库卡片即可从发现中隐藏。</string>
+    <string name="hidden_repositories_unhide_action">取消隐藏</string>
+    <string name="hidden_repositories_unhide_all">全部取消隐藏</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s 已重新显示</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">所有仓库已重新显示</string>
+    <string name="hidden_repositories_unhide_failure">无法取消隐藏。请重试。</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -608,6 +608,9 @@
     <string name="seen_history_cleared">浏览记录已清除</string>
     <string name="seen_badge">已浏览</string>
     <string name="self_owned_badge">你拥有此仓库</string>
+    <string name="hide_repository">隐藏仓库</string>
+    <string name="repository_hidden">仓库已隐藏</string>
+    <string name="undo_hide">撤销</string>
     <string name="privacy_section">隐私</string>
     <string name="telemetry_title">帮助改进搜索</string>
     <string name="telemetry_description">分享与可重置分析 ID 关联的使用数据（搜索、安装、交互）。不分享账户详情。</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -771,6 +771,9 @@
     <string name="seen_history_cleared">Seen history cleared</string>
     <string name="seen_badge">Viewed</string>
     <string name="self_owned_badge">You own this repo</string>
+    <string name="hide_repository">Hide repository</string>
+    <string name="repository_hidden">Repository hidden</string>
+    <string name="undo_hide">Undo</string>
 
     <!-- Privacy / telemetry -->
     <string name="privacy_section">Privacy</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -772,6 +772,9 @@
     <string name="seen_badge">Viewed</string>
     <string name="self_owned_badge">You own this repo</string>
     <string name="hide_repository">Hide repository</string>
+    <string name="open_on_github">Open on GitHub</string>
+    <string name="mark_as_viewed">Mark as viewed</string>
+    <string name="mark_as_unviewed">Mark as unviewed</string>
     <string name="repository_hidden">Repository hidden</string>
     <string name="undo_hide">Undo</string>
     <string name="hidden_repositories_title">Hidden repositories</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -774,6 +774,16 @@
     <string name="hide_repository">Hide repository</string>
     <string name="repository_hidden">Repository hidden</string>
     <string name="undo_hide">Undo</string>
+    <string name="hidden_repositories_title">Hidden repositories</string>
+    <string name="hidden_repositories_entry_description">Manage repositories you hid from Home and Search.</string>
+    <string name="hidden_repositories_count">%1$d hidden</string>
+    <string name="hidden_repositories_empty_title">No hidden repositories</string>
+    <string name="hidden_repositories_empty_description">Long-press a repository card on Home or Search to hide it from discovery.</string>
+    <string name="hidden_repositories_unhide_action">Unhide</string>
+    <string name="hidden_repositories_unhide_all">Unhide all</string>
+    <string name="hidden_repositories_unhidden_snackbar">%1$s unhidden</string>
+    <string name="hidden_repositories_unhidden_all_snackbar">All repositories unhidden</string>
+    <string name="hidden_repositories_unhide_failure">Could not unhide. Try again.</string>
 
     <!-- Privacy / telemetry -->
     <string name="privacy_section">Privacy</string>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
@@ -9,7 +9,10 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+
+private val EXPRESSIVE_CARD_SHAPE = RoundedCornerShape(32.dp)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -28,13 +31,15 @@ fun ExpressiveCard(
     when {
         onClick != null && onLongClick != null -> {
             // ElevatedCard's built-in `onClick` doesn't expose long-press;
-            // route both gestures through `combinedClickable` on the modifier
-            // instead so callers can attach a hide-menu without sacrificing
-            // the tap ripple.
+            // route both gestures through `combinedClickable`. Clip the
+            // modifier chain to the card shape FIRST so the ripple
+            // respects the 32.dp rounded corners — without the clip the
+            // ripple draws as a square overlapping the card edges.
             ElevatedCard(
                 modifier =
                     modifier
                         .fillMaxWidth()
+                        .clip(EXPRESSIVE_CARD_SHAPE)
                         .combinedClickable(
                             onClick = onClick,
                             onLongClick = onLongClick,
@@ -43,7 +48,7 @@ fun ExpressiveCard(
                     CardDefaults.elevatedCardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     ),
-                shape = RoundedCornerShape(32.dp),
+                shape = EXPRESSIVE_CARD_SHAPE,
                 content = { content() },
             )
         }
@@ -56,7 +61,7 @@ fun ExpressiveCard(
                         containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     ),
                 onClick = onClick,
-                shape = RoundedCornerShape(32.dp),
+                shape = EXPRESSIVE_CARD_SHAPE,
                 content = { content() },
             )
         }
@@ -68,7 +73,7 @@ fun ExpressiveCard(
                     CardDefaults.elevatedCardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainer,
                     ),
-                shape = RoundedCornerShape(32.dp),
+                shape = EXPRESSIVE_CARD_SHAPE,
                 content = { content() },
             )
         }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
@@ -1,5 +1,7 @@
 package zed.rainxch.core.presentation.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
@@ -9,32 +11,60 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ExpressiveCard(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
-    if (onClick != null) {
-        ElevatedCard(
-            modifier = modifier.fillMaxWidth(),
-            colors =
-                CardDefaults.elevatedCardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                ),
-            onClick = onClick,
-            shape = RoundedCornerShape(32.dp),
-            content = { content() },
-        )
-    } else {
-        ElevatedCard(
-            modifier = modifier.fillMaxWidth(),
-            colors =
-                CardDefaults.elevatedCardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                ),
-            shape = RoundedCornerShape(32.dp),
-            content = { content() },
-        )
+    when {
+        onClick != null && onLongClick != null -> {
+            // ElevatedCard's built-in `onClick` doesn't expose long-press;
+            // route both gestures through `combinedClickable` on the modifier
+            // instead so callers can attach a hide-menu without sacrificing
+            // the tap ripple.
+            ElevatedCard(
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = onClick,
+                            onLongClick = onLongClick,
+                        ),
+                colors =
+                    CardDefaults.elevatedCardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    ),
+                shape = RoundedCornerShape(32.dp),
+                content = { content() },
+            )
+        }
+
+        onClick != null -> {
+            ElevatedCard(
+                modifier = modifier.fillMaxWidth(),
+                colors =
+                    CardDefaults.elevatedCardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    ),
+                onClick = onClick,
+                shape = RoundedCornerShape(32.dp),
+                content = { content() },
+            )
+        }
+
+        else -> {
+            ElevatedCard(
+                modifier = modifier.fillMaxWidth(),
+                colors =
+                    CardDefaults.elevatedCardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    ),
+                shape = RoundedCornerShape(32.dp),
+                content = { content() },
+            )
+        }
     }
 }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/ExpressiveCard.kt
@@ -19,6 +19,12 @@ fun ExpressiveCard(
     onLongClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
+    // Long-press without tap leaves the gesture orphaned: the card looks
+    // tappable but only responds to a hold. Fail loud so the API contract
+    // is obvious at the call site.
+    check(onLongClick == null || onClick != null) {
+        "ExpressiveCard: onLongClick requires onClick"
+    }
     when {
         onClick != null && onLongClick != null -> {
             // ElevatedCard's built-in `onClick` doesn't expose long-press;

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.material.icons.outlined.Code
@@ -31,6 +32,7 @@ import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -70,6 +72,9 @@ import zed.rainxch.core.presentation.utils.toIcons
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.forked_repository
 import zed.rainxch.githubstore.core.presentation.res.hide_repository
+import zed.rainxch.githubstore.core.presentation.res.mark_as_unviewed
+import zed.rainxch.githubstore.core.presentation.res.mark_as_viewed
+import zed.rainxch.githubstore.core.presentation.res.open_on_github
 import zed.rainxch.githubstore.core.presentation.res.home_view_details
 import zed.rainxch.githubstore.core.presentation.res.installed
 import zed.rainxch.githubstore.core.presentation.res.open_in_browser
@@ -91,6 +96,7 @@ fun RepositoryCard(
     onDeveloperClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     onHideClick: (() -> Unit)? = null,
+    onToggleSeen: (() -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -100,11 +106,16 @@ fun RepositoryCard(
         label = "seen_content_alpha",
     )
 
-    var showHideSheet by remember { mutableStateOf(false) }
+    var showActionsSheet by remember { mutableStateOf(false) }
+    val sheetEnabled = onHideClick != null
 
     ExpressiveCard(
         onClick = onClick,
-        onLongClick = onHideClick?.let { { showHideSheet = true } },
+        onLongClick = if (sheetEnabled) {
+            { showActionsSheet = true }
+        } else {
+            null
+        },
         modifier = modifier,
     ) {
         Box(modifier = Modifier.alpha(contentAlpha)) {
@@ -357,13 +368,30 @@ fun RepositoryCard(
         }
     }
 
-    if (onHideClick != null && showHideSheet) {
-        HideRepositoryBottomSheet(
-            repoName = discoveryRepositoryUi.repository.fullName,
-            onDismiss = { showHideSheet = false },
-            onConfirmHide = {
-                showHideSheet = false
-                onHideClick()
+    if (sheetEnabled && showActionsSheet) {
+        RepositoryActionsBottomSheet(
+            repository = discoveryRepositoryUi.repository,
+            isSeen = discoveryRepositoryUi.isSeen,
+            onDismiss = { showActionsSheet = false },
+            onShare = {
+                showActionsSheet = false
+                onShareClick()
+            },
+            onOpenOnGithub = {
+                showActionsSheet = false
+                uriHandler.openUri(discoveryRepositoryUi.repository.htmlUrl)
+            },
+            onToggleSeen = onToggleSeen?.let {
+                {
+                    showActionsSheet = false
+                    it()
+                }
+            },
+            onHide = onHideClick?.let {
+                {
+                    showActionsSheet = false
+                    it()
+                }
             },
         )
     }
@@ -371,10 +399,14 @@ fun RepositoryCard(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun HideRepositoryBottomSheet(
-    repoName: String,
+private fun RepositoryActionsBottomSheet(
+    repository: GithubRepoSummaryUi,
+    isSeen: Boolean,
     onDismiss: () -> Unit,
-    onConfirmHide: () -> Unit,
+    onShare: () -> Unit,
+    onOpenOnGithub: () -> Unit,
+    onToggleSeen: (() -> Unit)?,
+    onHide: (() -> Unit)?,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
@@ -382,41 +414,108 @@ private fun HideRepositoryBottomSheet(
         sheetState = sheetState,
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 12.dp),
-        ) {
-            Text(
-                text = repoName,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
+        Column(modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp)) {
+            // Context header so the user can verify which repo they're
+            // acting on without the card behind the sheet.
+            Row(
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 24.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                GitHubStoreImage(
+                    imageModel = { repository.owner.avatarUrl },
+                    modifier =
+                        Modifier
+                            .size(36.dp)
+                            .clip(CircleShape),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = repository.fullName,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    repository.description?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.outlineVariant,
+                modifier = Modifier.padding(horizontal = 16.dp),
             )
 
-            ListItem(
-                headlineContent = {
-                    Text(stringResource(Res.string.hide_repository))
-                },
-                leadingContent = {
-                    Icon(
-                        imageVector = Icons.Default.VisibilityOff,
-                        contentDescription = null,
-                    )
-                },
-                colors =
-                    ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                    ),
-                modifier = Modifier.clickable(onClick = onConfirmHide),
+            SheetActionRow(
+                label = stringResource(Res.string.share_repository),
+                icon = Icons.Default.Share,
+                onClick = onShare,
             )
+            SheetActionRow(
+                label = stringResource(Res.string.open_on_github),
+                icon = Icons.Default.OpenInBrowser,
+                onClick = onOpenOnGithub,
+            )
+            if (onToggleSeen != null) {
+                SheetActionRow(
+                    label =
+                        if (isSeen) {
+                            stringResource(Res.string.mark_as_unviewed)
+                        } else {
+                            stringResource(Res.string.mark_as_viewed)
+                        },
+                    icon = Icons.Outlined.Visibility,
+                    onClick = onToggleSeen,
+                )
+            }
+            if (onHide != null) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                SheetActionRow(
+                    label = stringResource(Res.string.hide_repository),
+                    icon = Icons.Default.VisibilityOff,
+                    onClick = onHide,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun SheetActionRow(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onClick: () -> Unit,
+    tint: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+) {
+    ListItem(
+        headlineContent = {
+            Text(text = label, color = tint)
+        },
+        leadingContent = {
+            Icon(imageVector = icon, contentDescription = null, tint = tint)
+        },
+        colors =
+            ListItemDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+        modifier = Modifier.clickable(onClick = onClick),
+    )
 }
 
 @Composable

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -29,10 +29,13 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.icons.outlined.Visibility
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -75,7 +78,11 @@ import zed.rainxch.githubstore.core.presentation.res.self_owned_badge
 import zed.rainxch.githubstore.core.presentation.res.share_repository
 import zed.rainxch.githubstore.core.presentation.res.update_available
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+@OptIn(
+    ExperimentalMaterial3ExpressiveApi::class,
+    ExperimentalLayoutApi::class,
+    ExperimentalMaterial3Api::class,
+)
 @Composable
 fun RepositoryCard(
     discoveryRepositoryUi: DiscoveryRepositoryUi,
@@ -93,18 +100,13 @@ fun RepositoryCard(
         label = "seen_content_alpha",
     )
 
-    var hideMenuExpanded by remember { mutableStateOf(false) }
+    var showHideSheet by remember { mutableStateOf(false) }
 
     ExpressiveCard(
         onClick = onClick,
-        onLongClick = onHideClick?.let { { hideMenuExpanded = true } },
+        onLongClick = onHideClick?.let { { showHideSheet = true } },
         modifier = modifier,
     ) {
-        // Outer Box (no alpha) hosts both the dimmed visual content and the
-        // DropdownMenu. Putting the menu inside the alpha Box made the
-        // popup inherit `contentAlpha = 0.55f` whenever the repo was
-        // already seen, dimming the menu surface.
-        Box {
         Box(modifier = Modifier.alpha(contentAlpha)) {
             if (discoveryRepositoryUi.isFavourite) {
                 Icon(
@@ -353,27 +355,66 @@ fun RepositoryCard(
                 }
             }
         }
+    }
 
-        if (onHideClick != null) {
-            DropdownMenu(
-                expanded = hideMenuExpanded,
-                onDismissRequest = { hideMenuExpanded = false },
-            ) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.hide_repository)) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Default.VisibilityOff,
-                            contentDescription = null,
-                        )
-                    },
-                    onClick = {
-                        hideMenuExpanded = false
-                        onHideClick()
-                    },
-                )
-            }
-        }
+    if (onHideClick != null && showHideSheet) {
+        HideRepositoryBottomSheet(
+            repoName = discoveryRepositoryUi.repository.fullName,
+            onDismiss = { showHideSheet = false },
+            onConfirmHide = {
+                showHideSheet = false
+                onHideClick()
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HideRepositoryBottomSheet(
+    repoName: String,
+    onDismiss: () -> Unit,
+    onConfirmHide: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp),
+        ) {
+            Text(
+                text = repoName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+
+            ListItem(
+                headlineContent = {
+                    Text(stringResource(Res.string.hide_repository))
+                },
+                leadingContent = {
+                    Icon(
+                        imageVector = Icons.Default.VisibilityOff,
+                        contentDescription = null,
+                    )
+                },
+                colors =
+                    ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    ),
+                modifier = Modifier.clickable(onClick = onConfirmHide),
+            )
         }
     }
 }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -100,6 +100,11 @@ fun RepositoryCard(
         onLongClick = onHideClick?.let { { hideMenuExpanded = true } },
         modifier = modifier,
     ) {
+        // Outer Box (no alpha) hosts both the dimmed visual content and the
+        // DropdownMenu. Putting the menu inside the alpha Box made the
+        // popup inherit `contentAlpha = 0.55f` whenever the repo was
+        // already seen, dimming the menu surface.
+        Box {
         Box(modifier = Modifier.alpha(contentAlpha)) {
             if (discoveryRepositoryUi.isFavourite) {
                 Icon(
@@ -347,27 +352,28 @@ fun RepositoryCard(
                     }
                 }
             }
+        }
 
-            if (onHideClick != null) {
-                DropdownMenu(
-                    expanded = hideMenuExpanded,
-                    onDismissRequest = { hideMenuExpanded = false },
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(Res.string.hide_repository)) },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.VisibilityOff,
-                                contentDescription = null,
-                            )
-                        },
-                        onClick = {
-                            hideMenuExpanded = false
-                            onHideClick()
-                        },
-                    )
-                }
+        if (onHideClick != null) {
+            DropdownMenu(
+                expanded = hideMenuExpanded,
+                onDismissRequest = { hideMenuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(Res.string.hide_repository)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.VisibilityOff,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        hideMenuExpanded = false
+                        onHideClick()
+                    },
+                )
             }
+        }
         }
     }
 }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.material.icons.outlined.Code
@@ -28,6 +29,8 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,6 +42,9 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -60,6 +66,7 @@ import zed.rainxch.core.presentation.utils.hasWeekNotPassed
 import zed.rainxch.core.presentation.utils.toIcons
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.forked_repository
+import zed.rainxch.githubstore.core.presentation.res.hide_repository
 import zed.rainxch.githubstore.core.presentation.res.home_view_details
 import zed.rainxch.githubstore.core.presentation.res.installed
 import zed.rainxch.githubstore.core.presentation.res.open_in_browser
@@ -76,6 +83,7 @@ fun RepositoryCard(
     onShareClick: () -> Unit,
     onDeveloperClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onHideClick: (() -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -85,8 +93,11 @@ fun RepositoryCard(
         label = "seen_content_alpha",
     )
 
+    var hideMenuExpanded by remember { mutableStateOf(false) }
+
     ExpressiveCard(
         onClick = onClick,
+        onLongClick = onHideClick?.let { { hideMenuExpanded = true } },
         modifier = modifier,
     ) {
         Box(modifier = Modifier.alpha(contentAlpha)) {
@@ -334,6 +345,27 @@ fun RepositoryCard(
                             contentDescription = stringResource(Res.string.open_in_browser),
                         )
                     }
+                }
+            }
+
+            if (onHideClick != null) {
+                DropdownMenu(
+                    expanded = hideMenuExpanded,
+                    onDismissRequest = { hideMenuExpanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.hide_repository)) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.VisibilityOff,
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = {
+                            hideMenuExpanded = false
+                            onHideClick()
+                        },
+                    )
                 }
             }
         }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
@@ -45,4 +45,12 @@ sealed interface HomeAction {
     data class OnRepositoryDeveloperClick(
         val username: String,
     ) : HomeAction
+
+    data class OnHideRepository(
+        val repo: GithubRepoSummaryUi,
+    ) : HomeAction
+
+    data class OnUndoHideRepository(
+        val repoId: Long,
+    ) : HomeAction
 }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
@@ -53,4 +53,12 @@ sealed interface HomeAction {
     data class OnUndoHideRepository(
         val repoId: Long,
     ) : HomeAction
+
+    data class OnMarkAsSeen(
+        val repo: GithubRepoSummaryUi,
+    ) : HomeAction
+
+    data class OnMarkAsUnseen(
+        val repoId: Long,
+    ) : HomeAction
 }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -444,6 +444,9 @@ private fun MainState(
                     onShareClick = {
                         onAction(HomeAction.OnShareClick(discoveryRepository.repository))
                     },
+                    onHideClick = {
+                        onAction(HomeAction.OnHideRepository(discoveryRepository.repository))
+                    },
                     modifier = Modifier.animateItem(),
                 )
             }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -457,6 +457,13 @@ private fun MainState(
                     onHideClick = {
                         onAction(HomeAction.OnHideRepository(discoveryRepository.repository))
                     },
+                    onToggleSeen = {
+                        if (discoveryRepository.isSeen) {
+                            onAction(HomeAction.OnMarkAsUnseen(discoveryRepository.repository.id))
+                        } else {
+                            onAction(HomeAction.OnMarkAsSeen(discoveryRepository.repository))
+                        }
+                    },
                     modifier = Modifier.animateItem(),
                 )
             }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -397,12 +397,22 @@ private fun MainState(
     onAction: (HomeAction) -> Unit,
 ) {
     val bottomNavHeight = LocalBottomNavigationHeight.current
-    val visibleRepos by remember(state.repos, state.isHideSeenEnabled, state.seenRepoIds) {
+    val visibleRepos by remember(
+        state.repos,
+        state.isHideSeenEnabled,
+        state.seenRepoIds,
+        state.hiddenRepoIds,
+    ) {
         derivedStateOf {
-            if (state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()) {
-                state.repos.filter { it.repository.id !in state.seenRepoIds }
-            } else {
+            val hidden = state.hiddenRepoIds
+            val needsHideSeen = state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()
+            if (hidden.isEmpty() && !needsHideSeen) {
                 state.repos
+            } else {
+                state.repos.filter { repo ->
+                    repo.repository.id !in hidden &&
+                        (!needsHideSeen || repo.repository.id !in state.seenRepoIds)
+                }
             }
         }
     }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeState.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeState.kt
@@ -29,4 +29,5 @@ data class HomeState(
     val isPlatformPopupVisible: Boolean = false,
     val isHideSeenEnabled: Boolean = false,
     val seenRepoIds: Set<Long> = emptySet(),
+    val hiddenRepoIds: Set<Long> = emptySet(),
 )

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -553,6 +553,39 @@ class HomeViewModel(
                 }
             }
 
+            is HomeAction.OnMarkAsSeen -> {
+                val repo = action.repo
+                viewModelScope.launch {
+                    try {
+                        seenReposRepository.markAsSeen(
+                            repoId = repo.id,
+                            repoName = repo.name,
+                            repoOwner = repo.owner.login,
+                            repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                            repoDescription = repo.description,
+                            primaryLanguage = repo.language,
+                            repoUrl = repo.htmlUrl,
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Mark as seen failed for ${repo.id}: ${e.message}")
+                    }
+                }
+            }
+
+            is HomeAction.OnMarkAsUnseen -> {
+                viewModelScope.launch {
+                    try {
+                        seenReposRepository.removeFromHistory(action.repoId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Mark as unseen failed for ${action.repoId}: ${e.message}")
+                    }
+                }
+            }
+
             HomeAction.OnSearchClick -> {
                 // Handled in composable
             }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -526,18 +526,30 @@ class HomeViewModel(
             is HomeAction.OnHideRepository -> {
                 val repo = action.repo
                 viewModelScope.launch {
-                    hiddenReposRepository.hide(
-                        repoId = repo.id,
-                        repoName = repo.name,
-                        repoOwner = repo.owner.login,
-                        repoOwnerAvatarUrl = repo.owner.avatarUrl,
-                    )
+                    try {
+                        hiddenReposRepository.hide(
+                            repoId = repo.id,
+                            repoName = repo.name,
+                            repoOwner = repo.owner.login,
+                            repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Hide repository failed for ${repo.id}: ${e.message}")
+                    }
                 }
             }
 
             is HomeAction.OnUndoHideRepository -> {
                 viewModelScope.launch {
-                    hiddenReposRepository.unhide(action.repoId)
+                    try {
+                        hiddenReposRepository.unhide(action.repoId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Unhide repository failed for ${action.repoId}: ${e.message}")
+                    }
                 }
             }
 

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -26,6 +26,7 @@ import zed.rainxch.core.domain.model.Platform
 import zed.rainxch.core.domain.model.hasActualUpdate
 import zed.rainxch.core.domain.model.isReallyInstalled
 import zed.rainxch.core.domain.repository.FavouritesRepository
+import zed.rainxch.core.domain.repository.HiddenReposRepository
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
 import zed.rainxch.core.domain.repository.SeenReposRepository
 import zed.rainxch.core.domain.repository.StarredRepository
@@ -52,6 +53,7 @@ class HomeViewModel(
     private val shareManager: ShareManager,
     private val tweaksRepository: TweaksRepository,
     private val seenReposRepository: SeenReposRepository,
+    private val hiddenReposRepository: HiddenReposRepository,
     private val profileRepository: ProfileRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
@@ -79,6 +81,7 @@ class HomeViewModel(
                     observeFavourites()
                     observeStarredRepos()
                     observeSeenRepos()
+                    observeHiddenRepos()
                     observeDiscoveryPlatforms()
                     observeHideSeenEnabled()
 
@@ -374,9 +377,10 @@ class HomeViewModel(
                 .associateBy { it.repoId }
 
         val seenIds = _state.value.seenRepoIds
+        val hiddenIds = _state.value.hiddenRepoIds
         val currentLogin = currentUserLogin
 
-        return repos.map { repo ->
+        return repos.filter { it.id !in hiddenIds }.map { repo ->
             val apps = installedAppsMap[repo.id].orEmpty()
             val favourite = favoritesMap[repo.id]
             val starred = starredReposMap[repo.id]
@@ -520,6 +524,24 @@ class HomeViewModel(
                 // Handled in composable
             }
 
+            is HomeAction.OnHideRepository -> {
+                val repo = action.repo
+                viewModelScope.launch {
+                    hiddenReposRepository.hide(
+                        repoId = repo.id,
+                        repoName = repo.name,
+                        repoOwner = repo.owner.login,
+                        repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                    )
+                }
+            }
+
+            is HomeAction.OnUndoHideRepository -> {
+                viewModelScope.launch {
+                    hiddenReposRepository.unhide(action.repoId)
+                }
+            }
+
             HomeAction.OnSearchClick -> {
                 // Handled in composable
             }
@@ -576,6 +598,25 @@ class HomeViewModel(
                                 .map { repo ->
                                     repo.copy(isSeen = repo.repository.id in ids)
                                 }.toImmutableList(),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun observeHiddenRepos() {
+        viewModelScope.launch {
+            hiddenReposRepository.getAllHiddenRepoIds().collect { ids ->
+                _state.update { current ->
+                    current.copy(
+                        hiddenRepoIds = ids,
+                        // Drop already-loaded repos that are now hidden so
+                        // the grid reacts immediately to a hide action
+                        // without waiting for the next pagination tick.
+                        repos =
+                            current.repos
+                                .filter { it.repository.id !in ids }
+                                .toImmutableList(),
                     )
                 }
             }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -377,10 +377,9 @@ class HomeViewModel(
                 .associateBy { it.repoId }
 
         val seenIds = _state.value.seenRepoIds
-        val hiddenIds = _state.value.hiddenRepoIds
         val currentLogin = currentUserLogin
 
-        return repos.filter { it.id !in hiddenIds }.map { repo ->
+        return repos.map { repo ->
             val apps = installedAppsMap[repo.id].orEmpty()
             val favourite = favoritesMap[repo.id]
             val starred = starredReposMap[repo.id]
@@ -607,18 +606,11 @@ class HomeViewModel(
     private fun observeHiddenRepos() {
         viewModelScope.launch {
             hiddenReposRepository.getAllHiddenRepoIds().collect { ids ->
-                _state.update { current ->
-                    current.copy(
-                        hiddenRepoIds = ids,
-                        // Drop already-loaded repos that are now hidden so
-                        // the grid reacts immediately to a hide action
-                        // without waiting for the next pagination tick.
-                        repos =
-                            current.repos
-                                .filter { it.repository.id !in ids }
-                                .toImmutableList(),
-                    )
-                }
+                // Track IDs only — mirror the `seenRepoIds` pattern so
+                // unhiding restores the repo to the visible list without
+                // a refresh. `HomeRoot.visibleRepos` filters at render
+                // time using these IDs.
+                _state.update { it.copy(hiddenRepoIds = ids) }
             }
         }
     }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
@@ -75,4 +75,12 @@ sealed interface SearchAction {
     data object ExploreFromGithub : SearchAction
 
     data object OnDisableHideSeenForResults : SearchAction
+
+    data class OnHideRepository(
+        val repo: GithubRepoSummaryUi,
+    ) : SearchAction
+
+    data class OnUndoHideRepository(
+        val repoId: Long,
+    ) : SearchAction
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchAction.kt
@@ -83,4 +83,12 @@ sealed interface SearchAction {
     data class OnUndoHideRepository(
         val repoId: Long,
     ) : SearchAction
+
+    data class OnMarkAsSeen(
+        val repo: GithubRepoSummaryUi,
+    ) : SearchAction
+
+    data class OnMarkAsUnseen(
+        val repoId: Long,
+    ) : SearchAction
 }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -692,6 +692,9 @@ fun SearchScreen(
                                     onShareClick = {
                                         onAction(SearchAction.OnShareClick(discoveryRepository.repository))
                                     },
+                                    onHideClick = {
+                                        onAction(SearchAction.OnHideRepository(discoveryRepository.repository))
+                                    },
                                     modifier = Modifier.animateItem(),
                                 )
                             }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchRoot.kt
@@ -695,6 +695,13 @@ fun SearchScreen(
                                     onHideClick = {
                                         onAction(SearchAction.OnHideRepository(discoveryRepository.repository))
                                     },
+                                    onToggleSeen = {
+                                        if (discoveryRepository.isSeen) {
+                                            onAction(SearchAction.OnMarkAsUnseen(discoveryRepository.repository.id))
+                                        } else {
+                                            onAction(SearchAction.OnMarkAsSeen(discoveryRepository.repository))
+                                        }
+                                    },
                                     modifier = Modifier.animateItem(),
                                 )
                             }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchState.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchState.kt
@@ -20,6 +20,7 @@ data class SearchState(
     val isLoading: Boolean = false,
     val isHideSeenEnabled: Boolean = false,
     val seenRepoIds: Set<Long> = emptySet(),
+    val hiddenRepoIds: Set<Long> = emptySet(),
     val isLoadingMore: Boolean = false,
     val errorMessage: String? = null,
     val hasMorePages: Boolean = true,

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -24,6 +24,7 @@ import zed.rainxch.core.domain.model.RateLimitException
 import zed.rainxch.core.domain.model.hasActualUpdate
 import zed.rainxch.core.domain.model.isReallyInstalled
 import zed.rainxch.core.domain.repository.FavouritesRepository
+import zed.rainxch.core.domain.repository.HiddenReposRepository
 import zed.rainxch.core.domain.repository.InstalledAppsRepository
 import zed.rainxch.core.domain.repository.SearchHistoryRepository
 import zed.rainxch.core.domain.repository.SeenReposRepository
@@ -65,6 +66,7 @@ class SearchViewModel(
     private val searchHistoryRepository: SearchHistoryRepository,
     private val telemetryRepository: TelemetryRepository,
     private val profileRepository: ProfileRepository,
+    private val hiddenReposRepository: HiddenReposRepository,
 ) : ViewModel() {
     private var hasLoadedInitialData = false
     private var currentSearchJob: Job? = null
@@ -100,6 +102,7 @@ class SearchViewModel(
                     observeFavouriteApps()
                     observeStarredRepos()
                     observeSeenRepos()
+                    observeHiddenRepos()
                     observeHideSeenEnabled()
                     observeClipboardSetting()
                     observeSearchHistory()
@@ -115,12 +118,17 @@ class SearchViewModel(
                 initialValue = SearchState(),
             )
 
-    private fun computeVisibleRepos(state: SearchState): ImmutableList<DiscoveryRepositoryUi> =
-        if (state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()) {
-            state.repositories.filter { it.repository.id !in state.seenRepoIds }.toImmutableList()
-        } else {
-            state.repositories
-        }
+    private fun computeVisibleRepos(state: SearchState): ImmutableList<DiscoveryRepositoryUi> {
+        val hidden = state.hiddenRepoIds
+        val needsHideSeenFilter = state.isHideSeenEnabled && state.seenRepoIds.isNotEmpty()
+        if (hidden.isEmpty() && !needsHideSeenFilter) return state.repositories
+        return state.repositories
+            .filter { repo ->
+                repo.repository.id !in hidden &&
+                    (!needsHideSeenFilter || repo.repository.id !in state.seenRepoIds)
+            }
+            .toImmutableList()
+    }
 
     private fun observeSeenRepos() {
         viewModelScope.launch {
@@ -143,6 +151,24 @@ class SearchViewModel(
         viewModelScope.launch {
             tweaksRepository.getHideSeenEnabled().collect { enabled ->
                 _state.update { it.copy(isHideSeenEnabled = enabled) }
+            }
+        }
+    }
+
+    private fun observeHiddenRepos() {
+        viewModelScope.launch {
+            hiddenReposRepository.getAllHiddenRepoIds().collect { ids ->
+                _state.update { current ->
+                    current.copy(
+                        hiddenRepoIds = ids,
+                        // Drop already-loaded repos that are now hidden so
+                        // the grid reacts immediately to a hide action.
+                        repositories =
+                            current.repositories
+                                .filter { it.repository.id !in ids }
+                                .toImmutableList(),
+                    )
+                }
             }
         }
     }
@@ -721,6 +747,24 @@ class SearchViewModel(
             SearchAction.OnDisableHideSeenForResults -> {
                 viewModelScope.launch {
                     tweaksRepository.setHideSeenEnabled(false)
+                }
+            }
+
+            is SearchAction.OnHideRepository -> {
+                val repo = action.repo
+                viewModelScope.launch {
+                    hiddenReposRepository.hide(
+                        repoId = repo.id,
+                        repoName = repo.name,
+                        repoOwner = repo.owner.login,
+                        repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                    )
+                }
+            }
+
+            is SearchAction.OnUndoHideRepository -> {
+                viewModelScope.launch {
+                    hiddenReposRepository.unhide(action.repoId)
                 }
             }
         }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -747,18 +747,30 @@ class SearchViewModel(
             is SearchAction.OnHideRepository -> {
                 val repo = action.repo
                 viewModelScope.launch {
-                    hiddenReposRepository.hide(
-                        repoId = repo.id,
-                        repoName = repo.name,
-                        repoOwner = repo.owner.login,
-                        repoOwnerAvatarUrl = repo.owner.avatarUrl,
-                    )
+                    try {
+                        hiddenReposRepository.hide(
+                            repoId = repo.id,
+                            repoName = repo.name,
+                            repoOwner = repo.owner.login,
+                            repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Hide repository failed for ${repo.id}: ${e.message}")
+                    }
                 }
             }
 
             is SearchAction.OnUndoHideRepository -> {
                 viewModelScope.launch {
-                    hiddenReposRepository.unhide(action.repoId)
+                    try {
+                        hiddenReposRepository.unhide(action.repoId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Unhide repository failed for ${action.repoId}: ${e.message}")
+                    }
                 }
             }
         }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -773,6 +773,39 @@ class SearchViewModel(
                     }
                 }
             }
+
+            is SearchAction.OnMarkAsSeen -> {
+                val repo = action.repo
+                viewModelScope.launch {
+                    try {
+                        seenReposRepository.markAsSeen(
+                            repoId = repo.id,
+                            repoName = repo.name,
+                            repoOwner = repo.owner.login,
+                            repoOwnerAvatarUrl = repo.owner.avatarUrl,
+                            repoDescription = repo.description,
+                            primaryLanguage = repo.language,
+                            repoUrl = repo.htmlUrl,
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Mark as seen failed for ${repo.id}: ${e.message}")
+                    }
+                }
+            }
+
+            is SearchAction.OnMarkAsUnseen -> {
+                viewModelScope.launch {
+                    try {
+                        seenReposRepository.removeFromHistory(action.repoId)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Mark as unseen failed for ${action.repoId}: ${e.message}")
+                    }
+                }
+            }
         }
     }
 

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -158,17 +158,11 @@ class SearchViewModel(
     private fun observeHiddenRepos() {
         viewModelScope.launch {
             hiddenReposRepository.getAllHiddenRepoIds().collect { ids ->
-                _state.update { current ->
-                    current.copy(
-                        hiddenRepoIds = ids,
-                        // Drop already-loaded repos that are now hidden so
-                        // the grid reacts immediately to a hide action.
-                        repositories =
-                            current.repositories
-                                .filter { it.repository.id !in ids }
-                                .toImmutableList(),
-                    )
-                }
+                // Track IDs only — `computeVisibleRepos` already filters
+                // hidden at render time. Removing from `repositories`
+                // would break `OnUndoHideRepository`: once the entity is
+                // gone there's nothing to bring back without re-fetching.
+                _state.update { it.copy(hiddenRepoIds = ids) }
             }
         }
     }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
@@ -131,6 +131,8 @@ sealed interface TweaksAction {
 
     data object OnSkippedUpdatesClick : TweaksAction
 
+    data object OnHiddenRepositoriesClick : TweaksAction
+
     data class OnTelemetryToggled(
         val enabled: Boolean,
     ) : TweaksAction

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -46,6 +46,7 @@ import zed.rainxch.tweaks.presentation.feedback.model.FeedbackChannel
 fun TweaksRoot(
     onNavigateToMirrorPicker: () -> Unit,
     onNavigateToSkippedUpdates: () -> Unit,
+    onNavigateToHiddenRepositories: () -> Unit,
     viewModel: TweaksViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -155,6 +156,8 @@ fun TweaksRoot(
             when (action) {
                 TweaksAction.OnMirrorPickerClick -> onNavigateToMirrorPicker()
                 TweaksAction.OnSkippedUpdatesClick -> onNavigateToSkippedUpdates()
+
+                TweaksAction.OnHiddenRepositoriesClick -> onNavigateToHiddenRepositories()
                 else -> viewModel.onAction(action)
             }
         },

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -523,6 +523,10 @@ class TweaksViewModel(
                 // Handled in composable (navigates to the skipped-updates screen).
             }
 
+            TweaksAction.OnHiddenRepositoriesClick -> {
+                // Handled in composable (navigates to the hidden-repositories screen).
+            }
+
             is TweaksAction.OnThemeColorSelected -> {
                 viewModelScope.launch {
                     tweaksRepository.setThemeColor(action.themeColor)

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Installation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Installation.kt
@@ -348,6 +348,50 @@ fun LazyListScope.updatesSection(
         SkippedUpdatesEntryCard(
             onClick = { onAction(TweaksAction.OnSkippedUpdatesClick) },
         )
+
+        Spacer(Modifier.height(12.dp))
+
+        HiddenRepositoriesEntryCard(
+            onClick = { onAction(TweaksAction.OnHiddenRepositoriesClick) },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun HiddenRepositoriesEntryCard(
+    onClick: () -> Unit,
+) {
+    OutlinedCard(
+        onClick = onClick,
+        colors =
+            CardDefaults.outlinedCardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+            ),
+        shape = RoundedCornerShape(32.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(Res.string.hidden_repositories_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = stringResource(Res.string.hidden_repositories_entry_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+            )
+        }
     }
 }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesAction.kt
@@ -1,0 +1,7 @@
+package zed.rainxch.tweaks.presentation.hidden
+
+sealed interface HiddenRepositoriesAction {
+    data class OnUnhide(val repoId: Long) : HiddenRepositoriesAction
+
+    data object OnUnhideAll : HiddenRepositoriesAction
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesEvent.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesEvent.kt
@@ -1,0 +1,9 @@
+package zed.rainxch.tweaks.presentation.hidden
+
+sealed interface HiddenRepositoriesEvent {
+    data class Unhidden(val repoFullName: String) : HiddenRepositoriesEvent
+
+    data object UnhiddenAll : HiddenRepositoriesEvent
+
+    data class Failure(val message: String) : HiddenRepositoriesEvent
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesRoot.kt
@@ -1,0 +1,238 @@
+package zed.rainxch.tweaks.presentation.hidden
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import zed.rainxch.core.presentation.components.GitHubStoreImage
+import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_count
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_empty_description
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_empty_title
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_title
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_unhide_action
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_unhide_all
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_unhide_failure
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_unhidden_all_snackbar
+import zed.rainxch.githubstore.core.presentation.res.hidden_repositories_unhidden_snackbar
+import zed.rainxch.githubstore.core.presentation.res.navigate_back
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HiddenRepositoriesRoot(
+    onNavigateBack: () -> Unit,
+    viewModel: HiddenRepositoriesViewModel = koinViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    ObserveAsEvents(viewModel.events) { event ->
+        when (event) {
+            is HiddenRepositoriesEvent.Unhidden ->
+                scope.launch {
+                    snackbarState.showSnackbar(
+                        getString(Res.string.hidden_repositories_unhidden_snackbar, event.repoFullName),
+                    )
+                }
+            HiddenRepositoriesEvent.UnhiddenAll ->
+                scope.launch {
+                    snackbarState.showSnackbar(
+                        getString(Res.string.hidden_repositories_unhidden_all_snackbar),
+                    )
+                }
+            is HiddenRepositoriesEvent.Failure ->
+                scope.launch {
+                    snackbarState.showSnackbar(
+                        getString(Res.string.hidden_repositories_unhide_failure),
+                    )
+                }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            text = stringResource(Res.string.hidden_repositories_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (state.items.isNotEmpty()) {
+                            Text(
+                                text = stringResource(Res.string.hidden_repositories_count, state.items.size),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.navigate_back),
+                        )
+                    }
+                },
+                actions = {
+                    if (state.items.isNotEmpty()) {
+                        TextButton(
+                            onClick = {
+                                viewModel.onAction(HiddenRepositoriesAction.OnUnhideAll)
+                            },
+                        ) {
+                            Text(stringResource(Res.string.hidden_repositories_unhide_all))
+                        }
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarState) },
+    ) { padding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+        ) {
+            when {
+                state.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                state.items.isEmpty() -> {
+                    Column(
+                        modifier =
+                            Modifier
+                                .align(Alignment.Center)
+                                .padding(horizontal = 32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.hidden_repositories_empty_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.size(8.dp))
+                        Text(
+                            text = stringResource(Res.string.hidden_repositories_empty_description),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.items, key = { it.repoId }) { item ->
+                            HiddenRepoRow(
+                                item = item,
+                                onUnhide = {
+                                    viewModel.onAction(HiddenRepositoriesAction.OnUnhide(item.repoId))
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HiddenRepoRow(
+    item: HiddenRepoUi,
+    onUnhide: () -> Unit,
+) {
+    OutlinedCard(
+        colors =
+            CardDefaults.outlinedCardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+            ),
+        shape = RoundedCornerShape(24.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            GitHubStoreImage(
+                imageModel = { item.repoOwnerAvatarUrl },
+                modifier =
+                    Modifier
+                        .size(36.dp)
+                        .clip(CircleShape),
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.repoName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = item.repoOwner,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            TextButton(onClick = onUnhide) {
+                Text(stringResource(Res.string.hidden_repositories_unhide_action))
+            }
+        }
+    }
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesState.kt
@@ -1,0 +1,18 @@
+package zed.rainxch.tweaks.presentation.hidden
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class HiddenRepositoriesState(
+    val isLoading: Boolean = true,
+    val items: ImmutableList<HiddenRepoUi> = persistentListOf(),
+)
+
+data class HiddenRepoUi(
+    val repoId: Long,
+    val repoName: String,
+    val repoOwner: String,
+    val repoOwnerAvatarUrl: String,
+) {
+    val fullName: String get() = "$repoOwner/$repoName"
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesViewModel.kt
@@ -1,0 +1,82 @@
+package zed.rainxch.tweaks.presentation.hidden
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import zed.rainxch.core.domain.repository.HiddenReposRepository
+
+class HiddenRepositoriesViewModel(
+    private val hiddenReposRepository: HiddenReposRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(HiddenRepositoriesState())
+    val state = _state.asStateFlow()
+
+    private val _events = Channel<HiddenRepositoriesEvent>()
+    val events = _events.receiveAsFlow()
+
+    init {
+        hiddenReposRepository
+            .getAllHiddenRepos()
+            .onEach { repos ->
+                _state.value =
+                    HiddenRepositoriesState(
+                        isLoading = false,
+                        items =
+                            repos.map { repo ->
+                                HiddenRepoUi(
+                                    repoId = repo.repoId,
+                                    repoName = repo.repoName,
+                                    repoOwner = repo.repoOwner,
+                                    repoOwnerAvatarUrl = repo.repoOwnerAvatarUrl,
+                                )
+                            }.toImmutableList(),
+                    )
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onAction(action: HiddenRepositoriesAction) {
+        when (action) {
+            is HiddenRepositoriesAction.OnUnhide -> unhide(action.repoId)
+            HiddenRepositoriesAction.OnUnhideAll -> unhideAll()
+        }
+    }
+
+    private fun unhide(repoId: Long) {
+        // Snapshot the row name BEFORE the flow re-emits without it, so the
+        // success snackbar can name what the user just acted on.
+        val fullName =
+            _state.value.items.firstOrNull { it.repoId == repoId }?.fullName.orEmpty()
+        viewModelScope.launch {
+            try {
+                hiddenReposRepository.unhide(repoId)
+                _events.send(HiddenRepositoriesEvent.Unhidden(fullName))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                _events.send(HiddenRepositoriesEvent.Failure(e.message.orEmpty()))
+            }
+        }
+    }
+
+    private fun unhideAll() {
+        viewModelScope.launch {
+            try {
+                hiddenReposRepository.clearAll()
+                _events.send(HiddenRepositoriesEvent.UnhiddenAll)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                _events.send(HiddenRepositoriesEvent.Failure(e.message.orEmpty()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sprint 2 task E11. Survey #4 — "Hide seen" is too strict; users want manual hide.

What landed:
- `hidden_repos` Room table (v17 migration) + DAO + `HiddenReposRepository` in core/domain + impl in core/data.
- Long-press on `RepositoryCard` opens a `DropdownMenu` with "Hide repository" (`VisibilityOff` icon). `ExpressiveCard` extended with optional `onLongClick` so the existing tap ripple stays intact via `combinedClickable`.
- HomeViewModel + SearchViewModel inject `HiddenReposRepository`, observe hidden IDs, drop already-loaded repos that get hidden so the grid reacts immediately. `mapReposToUi` / `computeVisibleRepos` filter forward on subsequent page loads.
- `OnHideRepository` / `OnUndoHideRepository` actions on both VMs persist via repo. Library/Apps screen unaffected — install state still authoritative.
- 13-locale strings + 1.8.2 what's-new bullet.

Deferred to follow-up:
- Swipe-to-hide gesture (long-press covers AC #1).
- Snackbar with Undo on hide — needs SnackbarHostState wiring on Home + Search roots.
- Tweaks → Storage → Hidden repositories management screen (per brief AC). Hidden repos currently only un-hideable via DB or pending UI.

Compile-verified: `:composeApp:compileDebugKotlinAndroid` BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-press a repo card on Home or Search to hide it; undo via Snackbar.

* **Management**
  * New "Hidden repositories" screen to view, unhide single repos or unhide all.

* **Persistence**
  * Hidden repos are stored locally and preserved across app updates.

* **Presentation**
  * Repository cards open a hide confirmation sheet on long-press.

* **Localization**
  * Added hide/hidden/undo and hidden-repos UI strings for AR, BN, ES, FR, HI, IT, JA, KO, PL, RU, TR, ZH.

* **Documentation**
  * Updated in-app "What's New" for release 17.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/587)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->