### PR TITLE
feat(e15): multi-OS release picker — download installers for other platforms

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -352,6 +352,17 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getShowAllPlatforms(): Flow<Boolean> =
+        preferences.data.map { prefs ->
+            prefs[SHOW_ALL_PLATFORMS_KEY] ?: false
+        }
+
+    override suspend fun setShowAllPlatforms(enabled: Boolean) {
+        preferences.edit { prefs ->
+            prefs[SHOW_ALL_PLATFORMS_KEY] = enabled
+        }
+    }
+
     override fun getBatteryOptimizationPromptDismissed(): Flow<Boolean> =
         preferences.data.map { prefs ->
             prefs[BATTERY_OPT_PROMPT_DISMISSED_KEY] ?: false
@@ -457,6 +468,7 @@ class TweaksRepositoryImpl(
         private val EXTERNAL_IMPORT_BANNER_DISMISSED_AT_KEY = intPreferencesKey("external_import_banner_dismissed_at")
         private val APK_INSPECT_COACHMARK_SHOWN_KEY = booleanPreferencesKey("apk_inspect_coachmark_shown")
         private val CHANNEL_CHIP_COACHMARK_SHOWN_KEY = booleanPreferencesKey("channel_chip_coachmark_shown")
+        private val SHOW_ALL_PLATFORMS_KEY = booleanPreferencesKey("show_all_platforms")
         private val BATTERY_OPT_PROMPT_DISMISSED_KEY = booleanPreferencesKey("battery_opt_prompt_dismissed")
         private val LAST_SEEN_WHATS_NEW_VERSION_CODE_KEY = intPreferencesKey("last_seen_whats_new_version_code")
         private val ANNOUNCEMENTS_DISMISSED_IDS_KEY = stringSetPreferencesKey("announcements_dismissed_ids")

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -124,6 +124,15 @@ interface TweaksRepository {
     suspend fun setChannelChipCoachmarkShown(shown: Boolean)
 
     /**
+     * When true, the release-assets picker on Details shows installers
+     * for every OS (grouped by platform section). When false (default),
+     * only assets installable on the current platform are listed.
+     */
+    fun getShowAllPlatforms(): Flow<Boolean>
+
+    suspend fun setShowAllPlatforms(enabled: Boolean)
+
+    /**
      * One-shot watermark for the battery-optimization prompt on
      * aggressive-OEM ROMs (Oppo / OnePlus / Realme / Xiaomi / vivo /
      * Honor). `false` until the user has either granted the exemption

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetPlatform.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetPlatform.kt
@@ -1,0 +1,26 @@
+package zed.rainxch.core.domain.util
+
+import zed.rainxch.core.domain.model.DiscoveryPlatform
+
+/**
+ * Maps a release asset filename to the OS platform it targets, by
+ * extension. Returns `null` for files we can't classify (zip bundles,
+ * sources, sig/sha files, etc.) — callers should drop those from the
+ * cross-platform picker so the list isn't polluted by non-installable
+ * sidecars.
+ */
+fun assetPlatformOf(assetName: String): DiscoveryPlatform? {
+    val lower = assetName.lowercase()
+    return when {
+        lower.endsWith(".apk") -> DiscoveryPlatform.Android
+        lower.endsWith(".exe") || lower.endsWith(".msi") -> DiscoveryPlatform.Windows
+        lower.endsWith(".dmg") || lower.endsWith(".pkg") -> DiscoveryPlatform.Macos
+        lower.endsWith(".deb") ||
+            lower.endsWith(".rpm") ||
+            lower.endsWith(".appimage") ||
+            lower.endsWith(".pkg.tar.zst") ||
+            lower.endsWith(".snap") ||
+            lower.endsWith(".flatpakref") -> DiscoveryPlatform.Linux
+        else -> null
+    }
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -12,7 +12,8 @@
         "Silent install via root — Magisk, KernelSU, and APatch users can now install without Shizuku or Dhizuku.",
         "Search in Starred and Favourites — quickly filter long lists by repo name, owner, description, or language.",
         "Self-owned ✓ badge — when you're signed in, repos you own get a verified checkmark on Home and Search cards.",
-        "Hide repository — long-press any repo card on Home or Search to hide it from discovery. The repo stays in your library if you have it installed."
+        "Hide repository — long-press any repo card on Home or Search to hide it from discovery. The repo stays in your library if you have it installed.",
+        "Multi-OS release picker — toggle 'Show all platforms' on the asset picker to grab Android APKs from desktop or Linux .debs from your phone. Other-platform downloads open in your browser to save for transfer."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1171,4 +1171,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">منصة أخرى — يفتح في المتصفح للحفظ والنقل</string>
+    <string name="section_chip_your_device">جهازك</string>
+    <string name="section_chip_for_transfer">للنقل</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1165,4 +1165,10 @@
     <string name="open_on_github">فتح في GitHub</string>
     <string name="mark_as_viewed">وضع علامة مشاهد</string>
     <string name="mark_as_unviewed">إلغاء علامة مشاهد</string>
+    <string name="show_all_platforms_label">إظهار جميع المنصات</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">منصة أخرى — يفتح في المتصفح للحفظ والنقل</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1147,4 +1147,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">অন্য প্ল্যাটফর্ম — ট্রান্সফারের জন্য সংরক্ষণে ব্রাউজারে খুলবে</string>
+    <string name="section_chip_your_device">আপনার ডিভাইস</string>
+    <string name="section_chip_for_transfer">ট্রান্সফারের জন্য</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1141,4 +1141,10 @@
     <string name="open_on_github">GitHub-এ খুলুন</string>
     <string name="mark_as_viewed">দেখা হিসেবে চিহ্নিত করুন</string>
     <string name="mark_as_unviewed">অদেখা হিসেবে চিহ্নিত করুন</string>
+    <string name="show_all_platforms_label">সব প্ল্যাটফর্ম দেখান</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">অন্য প্ল্যাটফর্ম — ট্রান্সফারের জন্য সংরক্ষণে ব্রাউজারে খুলবে</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1119,4 +1119,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Otra plataforma — se abre en el navegador para guardar y transferir</string>
+    <string name="section_chip_your_device">Tu dispositivo</string>
+    <string name="section_chip_for_transfer">Para transferir</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1113,4 +1113,10 @@
     <string name="open_on_github">Abrir en GitHub</string>
     <string name="mark_as_viewed">Marcar como visto</string>
     <string name="mark_as_unviewed">Marcar como no visto</string>
+    <string name="show_all_platforms_label">Mostrar todas las plataformas</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Otra plataforma — se abre en el navegador para guardar y transferir</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1120,4 +1120,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Autre plateforme — s\'ouvre dans le navigateur pour enregistrement et transfert</string>
+    <string name="section_chip_your_device">Votre appareil</string>
+    <string name="section_chip_for_transfer">Pour transfert</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1114,4 +1114,10 @@
     <string name="open_on_github">Ouvrir sur GitHub</string>
     <string name="mark_as_viewed">Marquer comme vu</string>
     <string name="mark_as_unviewed">Marquer comme non vu</string>
+    <string name="show_all_platforms_label">Afficher toutes les plateformes</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Autre plateforme — s\'ouvre dans le navigateur pour enregistrement et transfert</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1158,4 +1158,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">अन्य प्लेटफ़ॉर्म — ट्रांसफ़र के लिए सहेजने हेतु ब्राउज़र में खुलता है</string>
+    <string name="section_chip_your_device">आपका डिवाइस</string>
+    <string name="section_chip_for_transfer">ट्रांसफ़र के लिए</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1152,4 +1152,10 @@
     <string name="open_on_github">GitHub पर खोलें</string>
     <string name="mark_as_viewed">देखा हुआ चिह्नित करें</string>
     <string name="mark_as_unviewed">अनदेखा चिह्नित करें</string>
+    <string name="show_all_platforms_label">सभी प्लेटफ़ॉर्म दिखाएं</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">अन्य प्लेटफ़ॉर्म — ट्रांसफ़र के लिए सहेजने हेतु ब्राउज़र में खुलता है</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1159,4 +1159,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Altra piattaforma — si apre nel browser per salvare e trasferire</string>
+    <string name="section_chip_your_device">Il tuo dispositivo</string>
+    <string name="section_chip_for_transfer">Da trasferire</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1153,4 +1153,10 @@
     <string name="open_on_github">Apri su GitHub</string>
     <string name="mark_as_viewed">Segna come visto</string>
     <string name="mark_as_unviewed">Segna come non visto</string>
+    <string name="show_all_platforms_label">Mostra tutte le piattaforme</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Altra piattaforma — si apre nel browser per salvare e trasferire</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1114,4 +1114,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">他のプラットフォーム — ブラウザで開き、転送用に保存します</string>
+    <string name="section_chip_your_device">このデバイス</string>
+    <string name="section_chip_for_transfer">転送用</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1108,4 +1108,10 @@
     <string name="open_on_github">GitHub で開く</string>
     <string name="mark_as_viewed">既読にする</string>
     <string name="mark_as_unviewed">未読にする</string>
+    <string name="show_all_platforms_label">すべてのプラットフォームを表示</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">他のプラットフォーム — ブラウザで開き、転送用に保存します</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1149,4 +1149,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">다른 플랫폼 — 전송용 저장을 위해 브라우저에서 열립니다</string>
+    <string name="section_chip_your_device">내 기기</string>
+    <string name="section_chip_for_transfer">전송용</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1143,4 +1143,10 @@
     <string name="open_on_github">GitHub에서 열기</string>
     <string name="mark_as_viewed">본 항목으로 표시</string>
     <string name="mark_as_unviewed">본 항목 해제</string>
+    <string name="show_all_platforms_label">모든 플랫폼 표시</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">다른 플랫폼 — 전송용 저장을 위해 브라우저에서 열립니다</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1140,4 +1140,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Inna platforma — otwiera się w przeglądarce, aby zapisać do transferu</string>
+    <string name="section_chip_your_device">Twoje urządzenie</string>
+    <string name="section_chip_for_transfer">Do transferu</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1134,4 +1134,10 @@
     <string name="open_on_github">Otwórz w GitHub</string>
     <string name="mark_as_viewed">Oznacz jako obejrzane</string>
     <string name="mark_as_unviewed">Oznacz jako nieobejrzane</string>
+    <string name="show_all_platforms_label">Pokaż wszystkie platformy</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Inna platforma — otwiera się w przeglądarce, aby zapisać do transferu</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1140,4 +1140,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Другая платформа — открывается в браузере для сохранения и переноса</string>
+    <string name="section_chip_your_device">Это устройство</string>
+    <string name="section_chip_for_transfer">Для переноса</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1134,4 +1134,10 @@
     <string name="open_on_github">Открыть на GitHub</string>
     <string name="mark_as_viewed">Отметить как просмотренный</string>
     <string name="mark_as_unviewed">Снять отметку</string>
+    <string name="show_all_platforms_label">Показать все платформы</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Другая платформа — открывается в браузере для сохранения и переноса</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1156,4 +1156,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Diğer platform — aktarma için kaydetmek üzere tarayıcıda açılır</string>
+    <string name="section_chip_your_device">Cihazınız</string>
+    <string name="section_chip_for_transfer">Aktarım için</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1150,4 +1150,10 @@
     <string name="open_on_github">GitHub\'da aç</string>
     <string name="mark_as_viewed">Görüldü olarak işaretle</string>
     <string name="mark_as_unviewed">Görülmedi olarak işaretle</string>
+    <string name="show_all_platforms_label">Tüm platformları göster</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Diğer platform — aktarma için kaydetmek üzere tarayıcıda açılır</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1116,4 +1116,6 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">其他平台 — 在浏览器中打开以保存并转移</string>
+    <string name="section_chip_your_device">你的设备</string>
+    <string name="section_chip_for_transfer">用于转移</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1110,4 +1110,10 @@
     <string name="open_on_github">在 GitHub 打开</string>
     <string name="mark_as_viewed">标记为已查看</string>
     <string name="mark_as_unviewed">取消已查看标记</string>
+    <string name="show_all_platforms_label">显示所有平台</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">其他平台 — 在浏览器中打开以保存并转移</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -781,6 +781,8 @@
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
     <string name="saved_for_transfer_hint">Other platform — opens in browser to save for transfer</string>
+    <string name="section_chip_your_device">Your device</string>
+    <string name="section_chip_for_transfer">For transfer</string>
     <string name="repository_hidden">Repository hidden</string>
     <string name="undo_hide">Undo</string>
     <string name="hidden_repositories_title">Hidden repositories</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -775,6 +775,12 @@
     <string name="open_on_github">Open on GitHub</string>
     <string name="mark_as_viewed">Mark as viewed</string>
     <string name="mark_as_unviewed">Mark as unviewed</string>
+    <string name="show_all_platforms_label">Show all platforms</string>
+    <string name="platform_section_android">Android</string>
+    <string name="platform_section_windows">Windows</string>
+    <string name="platform_section_macos">macOS</string>
+    <string name="platform_section_linux">Linux</string>
+    <string name="saved_for_transfer_hint">Other platform — opens in browser to save for transfer</string>
     <string name="repository_hidden">Repository hidden</string>
     <string name="undo_hide">Undo</string>
     <string name="hidden_repositories_title">Hidden repositories</string>

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
@@ -160,8 +160,12 @@ sealed interface DetailsAction {
      */
     data object OnAcknowledgeChannelChipCoachmark : DetailsAction
 
-    /** Flip the "Show all platforms" picker setting (persisted globally). */
-    data object OnToggleShowAllPlatforms : DetailsAction
+    /**
+     * Flip the "Show all platforms" picker setting (persisted globally).
+     * Carries the explicit target value so rapid back-and-forth toggles
+     * don't race against a stale read of the in-memory state.
+     */
+    data class OnToggleShowAllPlatforms(val enabled: Boolean) : DetailsAction
 
     /**
      * Download a non-current-platform asset for transfer to another
@@ -170,6 +174,5 @@ sealed interface DetailsAction {
      */
     data class OnDownloadForTransfer(
         val assetUrl: String,
-        val assetName: String,
     ) : DetailsAction
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsAction.kt
@@ -159,4 +159,17 @@ sealed interface DetailsAction {
      * Persists so the coachmark only ever shows once.
      */
     data object OnAcknowledgeChannelChipCoachmark : DetailsAction
+
+    /** Flip the "Show all platforms" picker setting (persisted globally). */
+    data object OnToggleShowAllPlatforms : DetailsAction
+
+    /**
+     * Download a non-current-platform asset for transfer to another
+     * device. Routes to the user's browser so the file lands in their
+     * normal Downloads folder.
+     */
+    data class OnDownloadForTransfer(
+        val assetUrl: String,
+        val assetName: String,
+    ) : DetailsAction
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsState.kt
@@ -134,6 +134,13 @@ data class DetailsState(
      * `ChannelChip` so users discover the per-app channel toggle.
      */
     val isChannelChipCoachmarkPending: Boolean = false,
+    /**
+     * Mirrors `TweaksRepository.getShowAllPlatforms()`. When true the
+     * release-assets picker lists installers for every OS (grouped by
+     * section); the install button still operates on the current
+     * platform's primary asset.
+     */
+    val showAllPlatforms: Boolean = false,
 ) {
     val filteredReleases: List<GithubRelease>
         get() =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -494,11 +494,10 @@ class DetailsViewModel(
                 acknowledgeChannelChipCoachmark()
             }
 
-            DetailsAction.OnToggleShowAllPlatforms -> {
-                val next = !_state.value.showAllPlatforms
+            is DetailsAction.OnToggleShowAllPlatforms -> {
                 viewModelScope.launch {
                     try {
-                        tweaksRepository.setShowAllPlatforms(next)
+                        tweaksRepository.setShowAllPlatforms(action.enabled)
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Throwable) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -147,6 +147,7 @@ class DetailsViewModel(
                     observeApkInspectCoachmark()
                     observeChannelChipCoachmark()
                     observeCurrentUserForBadge()
+                    observeShowAllPlatforms()
 
                     hasLoadedInitialData = true
                 }
@@ -491,6 +492,30 @@ class DetailsViewModel(
 
             DetailsAction.OnAcknowledgeChannelChipCoachmark -> {
                 acknowledgeChannelChipCoachmark()
+            }
+
+            DetailsAction.OnToggleShowAllPlatforms -> {
+                val next = !_state.value.showAllPlatforms
+                viewModelScope.launch {
+                    try {
+                        tweaksRepository.setShowAllPlatforms(next)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warn("Toggle show-all-platforms failed: ${e.message}")
+                    }
+                }
+            }
+
+            is DetailsAction.OnDownloadForTransfer -> {
+                // Cross-platform assets land here when the user picks an
+                // installer for a different OS. Browser handles the
+                // actual save-to-Downloads — keeps install plumbing
+                // unchanged and matches existing "open external link"
+                // flows on Details.
+                helper.openUrl(action.assetUrl) { err ->
+                    logger.warn("Open transfer download failed: $err")
+                }
             }
         }
     }
@@ -870,6 +895,14 @@ class DetailsViewModel(
                 firstStable.installedApp?.isReallyInstalled() == true
             if (!installedAtOpen) return@launch
             _state.update { it.copy(isApkInspectCoachmarkPending = true) }
+        }
+    }
+
+    private fun observeShowAllPlatforms() {
+        viewModelScope.launch {
+            tweaksRepository.getShowAllPlatforms().collect { enabled ->
+                _state.update { it.copy(showAllPlatforms = enabled) }
+            }
         }
     }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
@@ -76,9 +76,13 @@ fun ReleaseAssetsPicker(
     showAllPlatforms: Boolean = false,
     crossPlatformAssets: List<GithubAsset> = emptyList(),
 ) {
-    val isPickerEnabled by remember(assetsList, crossPlatformAssets, showAllPlatforms) {
+    // Decouple from `showAllPlatforms`: the toggle lives INSIDE the sheet,
+    // so disabling the open-card whenever the current branch is empty
+    // would lock the user out of flipping the setting back. Picker stays
+    // openable whenever either source has anything to show.
+    val isPickerEnabled by remember(assetsList, crossPlatformAssets) {
         derivedStateOf {
-            if (showAllPlatforms) crossPlatformAssets.isNotEmpty() else assetsList.isNotEmpty()
+            assetsList.isNotEmpty() || crossPlatformAssets.isNotEmpty()
         }
     }
 
@@ -92,9 +96,11 @@ fun ReleaseAssetsPicker(
         onDismiss = { onAction(DetailsAction.ToggleReleaseAssetsPicker) },
         onSelect = { onAction(DetailsAction.SelectDownloadAsset(it)) },
         onUnpin = { onAction(DetailsAction.UnpinPreferredVariant) },
-        onToggleShowAllPlatforms = { onAction(DetailsAction.OnToggleShowAllPlatforms) },
+        onToggleShowAllPlatforms = { enabled ->
+            onAction(DetailsAction.OnToggleShowAllPlatforms(enabled))
+        },
         onDownloadForTransfer = { asset ->
-            onAction(DetailsAction.OnDownloadForTransfer(asset.downloadUrl, asset.name))
+            onAction(DetailsAction.OnDownloadForTransfer(asset.downloadUrl))
         },
     )
 
@@ -152,7 +158,7 @@ private fun ReleaseAssetsItemsPicker(
     onDismiss: () -> Unit,
     onSelect: (GithubAsset) -> Unit,
     onUnpin: () -> Unit,
-    onToggleShowAllPlatforms: () -> Unit,
+    onToggleShowAllPlatforms: (Boolean) -> Unit,
     onDownloadForTransfer: (GithubAsset) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -231,7 +237,7 @@ private fun ReleaseAssetsItemsPicker(
                 Row(
                     modifier =
                         Modifier
-                            .clickable(onClick = onToggleShowAllPlatforms)
+                            .clickable(onClick = { onToggleShowAllPlatforms(!showAllPlatforms) })
                             .padding(horizontal = 16.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -249,30 +255,31 @@ private fun ReleaseAssetsItemsPicker(
                     )
                     androidx.compose.material3.Switch(
                         checked = showAllPlatforms,
-                        onCheckedChange = { onToggleShowAllPlatforms() },
+                        onCheckedChange = onToggleShowAllPlatforms,
                     )
                 }
             }
 
+            // Hoisted out of the LazyListScope below: `LazyColumn { … }`
+                // body is not a @Composable context, so `remember` calls have
+                // to live in the enclosing Column instead.
+            val groups = remember(crossPlatformAssets) {
+                crossPlatformAssets
+                    .groupBy {
+                        zed.rainxch.core.domain.util.assetPlatformOf(it.name)
+                    }
+                    .filterKeys { it != null }
+                    .mapKeys { it.key!! }
+            }
+            val installableIds = remember(assetsList) {
+                assetsList.map { it.id }.toSet()
+            }
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 if (showAllPlatforms) {
-                    // Group all known-platform assets by detected OS,
-                    // render one collapsible-feeling Card per platform
-                    // with a single header chip telling the user whether
-                    // the section installs locally or saves for transfer.
-                    // One hint per section >> one hint per asset row
-                    // (which scaled badly: 10 assets = 10 redundant lines).
-                    val groups: Map<zed.rainxch.core.domain.model.DiscoveryPlatform, List<GithubAsset>> =
-                        crossPlatformAssets
-                            .groupBy {
-                                zed.rainxch.core.domain.util.assetPlatformOf(it.name)
-                            }
-                            .filterKeys { it != null }
-                            .mapKeys { it.key!! }
                     if (groups.isEmpty()) {
                         item {
                             Text(
@@ -286,7 +293,6 @@ private fun ReleaseAssetsItemsPicker(
                     } else {
                         // Order: current-platform section first (it's the
                         // primary install target), then the others.
-                        val installableIds = assetsList.map { it.id }.toSet()
                         val sectionOrder =
                             listOf(
                                 zed.rainxch.core.domain.model.DiscoveryPlatform.Android to Res.string.platform_section_android,
@@ -305,8 +311,10 @@ private fun ReleaseAssetsItemsPicker(
                                 PlatformSectionCard(
                                     platformLabel = stringResource(labelRes),
                                     isCurrentDevice = isCurrentDevice,
+                                    installableIds = installableIds,
                                     assets = assets,
                                     selectedAsset = selectedAsset,
+                                    pinnedVariant = pinnedVariant,
                                     onAssetClick = { asset ->
                                         if (asset.id in installableIds) {
                                             onSelect(asset)
@@ -485,8 +493,10 @@ private fun ReleaseAssetsPickerItemPreview() {
 private fun PlatformSectionCard(
     platformLabel: String,
     isCurrentDevice: Boolean,
+    installableIds: Set<Long>,
     assets: List<GithubAsset>,
     selectedAsset: GithubAsset?,
+    pinnedVariant: String?,
     onAssetClick: (GithubAsset) -> Unit,
 ) {
     OutlinedCard(
@@ -534,12 +544,16 @@ private fun PlatformSectionCard(
         )
 
         assets.forEachIndexed { index, asset ->
+            val isInstallableHere = asset.id in installableIds
+            val variantTag = AssetVariant.extract(asset.name)
+            val isPinned =
+                isInstallableHere &&
+                    !pinnedVariant.isNullOrBlank() &&
+                    variantTag?.equals(pinnedVariant, ignoreCase = true) == true
             ReleaseAssetItem(
                 asset = asset,
-                isSelected =
-                    isCurrentDevice &&
-                        asset.id == selectedAsset?.id,
-                isPinned = false,
+                isSelected = isInstallableHere && asset.id == selectedAsset?.id,
+                isPinned = isPinned,
                 onClick = { onAssetClick(asset) },
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
@@ -18,7 +18,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.outlined.Devices
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -217,37 +220,52 @@ private fun ReleaseAssetsItemsPicker(
             // changes every Details screen's picker behaviour for this
             // user. Off = current-OS assets only; On = grouped sections
             // for Android / Windows / macOS / Linux.
-            Row(
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = stringResource(Res.string.show_all_platforms_label),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f),
-                )
-                androidx.compose.material3.Switch(
-                    checked = showAllPlatforms,
-                    onCheckedChange = { onToggleShowAllPlatforms() },
-                )
+                Row(
+                    modifier =
+                        Modifier
+                            .clickable(onClick = onToggleShowAllPlatforms)
+                            .padding(horizontal = 16.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Devices,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(Modifier.size(12.dp))
+                    Text(
+                        text = stringResource(Res.string.show_all_platforms_label),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    androidx.compose.material3.Switch(
+                        checked = showAllPlatforms,
+                        onCheckedChange = { onToggleShowAllPlatforms() },
+                    )
+                }
             }
-
-            HorizontalDivider()
 
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(vertical = 8.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 if (showAllPlatforms) {
                     // Group all known-platform assets by detected OS,
-                    // emit a labelled section per group. Installable
-                    // assets keep their normal select-to-install flow;
-                    // other-platform assets route to a browser download
-                    // for transfer to another device.
+                    // render one collapsible-feeling Card per platform
+                    // with a single header chip telling the user whether
+                    // the section installs locally or saves for transfer.
+                    // One hint per section >> one hint per asset row
+                    // (which scaled badly: 10 assets = 10 redundant lines).
                     val groups: Map<zed.rainxch.core.domain.model.DiscoveryPlatform, List<GithubAsset>> =
                         crossPlatformAssets
                             .groupBy {
@@ -266,54 +284,37 @@ private fun ReleaseAssetsItemsPicker(
                             )
                         }
                     } else {
-                        val ordered =
+                        // Order: current-platform section first (it's the
+                        // primary install target), then the others.
+                        val installableIds = assetsList.map { it.id }.toSet()
+                        val sectionOrder =
                             listOf(
                                 zed.rainxch.core.domain.model.DiscoveryPlatform.Android to Res.string.platform_section_android,
                                 zed.rainxch.core.domain.model.DiscoveryPlatform.Windows to Res.string.platform_section_windows,
                                 zed.rainxch.core.domain.model.DiscoveryPlatform.Macos to Res.string.platform_section_macos,
                                 zed.rainxch.core.domain.model.DiscoveryPlatform.Linux to Res.string.platform_section_linux,
-                            )
-                        ordered.forEach { (platform, labelRes) ->
+                            ).sortedByDescending { (platform, _) ->
+                                groups[platform]?.any { it.id in installableIds } == true
+                            }
+                        sectionOrder.forEach { (platform, labelRes) ->
                             val assets = groups[platform].orEmpty()
                             if (assets.isEmpty()) return@forEach
+                            val isCurrentDevice =
+                                assets.any { it.id in installableIds }
                             item(key = "section-${platform.name}") {
-                                Text(
-                                    text = stringResource(labelRes),
-                                    style = MaterialTheme.typography.labelLargeEmphasized,
-                                    color = MaterialTheme.colorScheme.tertiary,
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                                )
-                            }
-                            items(items = assets, key = { it.id }) { asset ->
-                                val isInstallableHere =
-                                    assetsList.any { it.id == asset.id }
-                                ReleaseAssetItem(
-                                    asset = asset,
-                                    isSelected = asset.id == selectedAsset?.id && isInstallableHere,
-                                    isPinned = false,
-                                    onClick = {
-                                        if (isInstallableHere) {
+                                PlatformSectionCard(
+                                    platformLabel = stringResource(labelRes),
+                                    isCurrentDevice = isCurrentDevice,
+                                    assets = assets,
+                                    selectedAsset = selectedAsset,
+                                    onAssetClick = { asset ->
+                                        if (asset.id in installableIds) {
                                             onSelect(asset)
                                         } else {
                                             onDownloadForTransfer(asset)
                                         }
                                     },
-                                    modifier = Modifier.fillMaxWidth(),
                                 )
-                                if (!isInstallableHere) {
-                                    Text(
-                                        text = stringResource(Res.string.saved_for_transfer_hint),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .padding(horizontal = 24.dp, vertical = 2.dp),
-                                    )
-                                }
                             }
                         }
                     }
@@ -477,4 +478,108 @@ private fun ReleaseAssetsPickerItemPreview() {
         onClick = {},
         isSelected = false,
     )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun PlatformSectionCard(
+    platformLabel: String,
+    isCurrentDevice: Boolean,
+    assets: List<GithubAsset>,
+    selectedAsset: GithubAsset?,
+    onAssetClick: (GithubAsset) -> Unit,
+) {
+    OutlinedCard(
+        colors =
+            CardDefaults.outlinedCardColors(
+                containerColor =
+                    if (isCurrentDevice) {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLowest
+                    },
+            ),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = platformLabel,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            SectionChip(
+                label =
+                    if (isCurrentDevice) {
+                        stringResource(Res.string.section_chip_your_device)
+                    } else {
+                        stringResource(Res.string.section_chip_for_transfer)
+                    },
+                isPrimary = isCurrentDevice,
+            )
+        }
+
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+
+        assets.forEachIndexed { index, asset ->
+            ReleaseAssetItem(
+                asset = asset,
+                isSelected =
+                    isCurrentDevice &&
+                        asset.id == selectedAsset?.id,
+                isPinned = false,
+                onClick = { onAssetClick(asset) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (index < assets.lastIndex) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionChip(
+    label: String,
+    isPrimary: Boolean,
+) {
+    val container =
+        if (isPrimary) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.tertiaryContainer
+        }
+    val content =
+        if (isPrimary) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onTertiaryContainer
+        }
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = container,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = content,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+        )
+    }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
@@ -70,19 +70,29 @@ fun ReleaseAssetsPicker(
     selectedAsset: GithubAsset? = null,
     isPickerVisible: Boolean = false,
     pinnedVariant: String? = null,
+    showAllPlatforms: Boolean = false,
+    crossPlatformAssets: List<GithubAsset> = emptyList(),
 ) {
-    val isPickerEnabled by remember(assetsList) {
-        derivedStateOf { assetsList.isNotEmpty() }
+    val isPickerEnabled by remember(assetsList, crossPlatformAssets, showAllPlatforms) {
+        derivedStateOf {
+            if (showAllPlatforms) crossPlatformAssets.isNotEmpty() else assetsList.isNotEmpty()
+        }
     }
 
     ReleaseAssetsItemsPicker(
         showPicker = isPickerVisible,
         assetsList = assetsList,
+        crossPlatformAssets = crossPlatformAssets,
+        showAllPlatforms = showAllPlatforms,
         selectedAsset = selectedAsset,
         pinnedVariant = pinnedVariant,
         onDismiss = { onAction(DetailsAction.ToggleReleaseAssetsPicker) },
         onSelect = { onAction(DetailsAction.SelectDownloadAsset(it)) },
         onUnpin = { onAction(DetailsAction.UnpinPreferredVariant) },
+        onToggleShowAllPlatforms = { onAction(DetailsAction.OnToggleShowAllPlatforms) },
+        onDownloadForTransfer = { asset ->
+            onAction(DetailsAction.OnDownloadForTransfer(asset.downloadUrl, asset.name))
+        },
     )
 
     Column(
@@ -127,16 +137,20 @@ fun ReleaseAssetsPicker(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ReleaseAssetsItemsPicker(
     assetsList: List<GithubAsset>,
+    crossPlatformAssets: List<GithubAsset>,
+    showAllPlatforms: Boolean,
     selectedAsset: GithubAsset?,
     pinnedVariant: String?,
     showPicker: Boolean,
     onDismiss: () -> Unit,
     onSelect: (GithubAsset) -> Unit,
     onUnpin: () -> Unit,
+    onToggleShowAllPlatforms: () -> Unit,
+    onDownloadForTransfer: (GithubAsset) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (!showPicker) return
@@ -199,13 +213,111 @@ private fun ReleaseAssetsItemsPicker(
                 }
             }
 
+            // Cross-platform toggle. Persisted globally — flipping here
+            // changes every Details screen's picker behaviour for this
+            // user. Off = current-OS assets only; On = grouped sections
+            // for Android / Windows / macOS / Linux.
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.show_all_platforms_label),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                androidx.compose.material3.Switch(
+                    checked = showAllPlatforms,
+                    onCheckedChange = { onToggleShowAllPlatforms() },
+                )
+            }
+
             HorizontalDivider()
 
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(vertical = 8.dp),
             ) {
-                if (assetsList.isNotEmpty()) {
+                if (showAllPlatforms) {
+                    // Group all known-platform assets by detected OS,
+                    // emit a labelled section per group. Installable
+                    // assets keep their normal select-to-install flow;
+                    // other-platform assets route to a browser download
+                    // for transfer to another device.
+                    val groups: Map<zed.rainxch.core.domain.model.DiscoveryPlatform, List<GithubAsset>> =
+                        crossPlatformAssets
+                            .groupBy {
+                                zed.rainxch.core.domain.util.assetPlatformOf(it.name)
+                            }
+                            .filterKeys { it != null }
+                            .mapKeys { it.key!! }
+                    if (groups.isEmpty()) {
+                        item {
+                            Text(
+                                text = stringResource(Res.string.no_assets_in_list),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            )
+                        }
+                    } else {
+                        val ordered =
+                            listOf(
+                                zed.rainxch.core.domain.model.DiscoveryPlatform.Android to Res.string.platform_section_android,
+                                zed.rainxch.core.domain.model.DiscoveryPlatform.Windows to Res.string.platform_section_windows,
+                                zed.rainxch.core.domain.model.DiscoveryPlatform.Macos to Res.string.platform_section_macos,
+                                zed.rainxch.core.domain.model.DiscoveryPlatform.Linux to Res.string.platform_section_linux,
+                            )
+                        ordered.forEach { (platform, labelRes) ->
+                            val assets = groups[platform].orEmpty()
+                            if (assets.isEmpty()) return@forEach
+                            item(key = "section-${platform.name}") {
+                                Text(
+                                    text = stringResource(labelRes),
+                                    style = MaterialTheme.typography.labelLargeEmphasized,
+                                    color = MaterialTheme.colorScheme.tertiary,
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                                )
+                            }
+                            items(items = assets, key = { it.id }) { asset ->
+                                val isInstallableHere =
+                                    assetsList.any { it.id == asset.id }
+                                ReleaseAssetItem(
+                                    asset = asset,
+                                    isSelected = asset.id == selectedAsset?.id && isInstallableHere,
+                                    isPinned = false,
+                                    onClick = {
+                                        if (isInstallableHere) {
+                                            onSelect(asset)
+                                        } else {
+                                            onDownloadForTransfer(asset)
+                                        }
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                if (!isInstallableHere) {
+                                    Text(
+                                        text = stringResource(Res.string.saved_for_transfer_hint),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 24.dp, vertical = 2.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                } else if (assetsList.isNotEmpty()) {
                     items(items = assetsList, key = { it.id }) { asset ->
                         val variantTag = AssetVariant.extract(asset.name)
                         val isPinned =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/ReleaseAssetsPicker.kt
@@ -279,51 +279,46 @@ private fun ReleaseAssetsItemsPicker(
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                if (showAllPlatforms) {
-                    if (groups.isEmpty()) {
-                        item {
-                            Text(
-                                text = stringResource(Res.string.no_assets_in_list),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                            )
+                // Grouped path only when the toggle is on AND the release
+                // has platform-classifiable assets. If toggle is on but
+                // `assetPlatformOf` rejected every asset (e.g. release
+                // ships only .zip bundles / extensionless binaries), we
+                // fall through to the OFF-mode `assetsList` render so
+                // the user still sees the current-platform installables
+                // instead of an empty sheet.
+                if (showAllPlatforms && groups.isNotEmpty()) {
+                    // Order: current-platform section first (it's the
+                    // primary install target), then the others.
+                    val sectionOrder =
+                        listOf(
+                            zed.rainxch.core.domain.model.DiscoveryPlatform.Android to Res.string.platform_section_android,
+                            zed.rainxch.core.domain.model.DiscoveryPlatform.Windows to Res.string.platform_section_windows,
+                            zed.rainxch.core.domain.model.DiscoveryPlatform.Macos to Res.string.platform_section_macos,
+                            zed.rainxch.core.domain.model.DiscoveryPlatform.Linux to Res.string.platform_section_linux,
+                        ).sortedByDescending { (platform, _) ->
+                            groups[platform]?.any { it.id in installableIds } == true
                         }
-                    } else {
-                        // Order: current-platform section first (it's the
-                        // primary install target), then the others.
-                        val sectionOrder =
-                            listOf(
-                                zed.rainxch.core.domain.model.DiscoveryPlatform.Android to Res.string.platform_section_android,
-                                zed.rainxch.core.domain.model.DiscoveryPlatform.Windows to Res.string.platform_section_windows,
-                                zed.rainxch.core.domain.model.DiscoveryPlatform.Macos to Res.string.platform_section_macos,
-                                zed.rainxch.core.domain.model.DiscoveryPlatform.Linux to Res.string.platform_section_linux,
-                            ).sortedByDescending { (platform, _) ->
-                                groups[platform]?.any { it.id in installableIds } == true
-                            }
-                        sectionOrder.forEach { (platform, labelRes) ->
-                            val assets = groups[platform].orEmpty()
-                            if (assets.isEmpty()) return@forEach
-                            val isCurrentDevice =
-                                assets.any { it.id in installableIds }
-                            item(key = "section-${platform.name}") {
-                                PlatformSectionCard(
-                                    platformLabel = stringResource(labelRes),
-                                    isCurrentDevice = isCurrentDevice,
-                                    installableIds = installableIds,
-                                    assets = assets,
-                                    selectedAsset = selectedAsset,
-                                    pinnedVariant = pinnedVariant,
-                                    onAssetClick = { asset ->
-                                        if (asset.id in installableIds) {
-                                            onSelect(asset)
-                                        } else {
-                                            onDownloadForTransfer(asset)
-                                        }
-                                    },
-                                )
-                            }
+                    sectionOrder.forEach { (platform, labelRes) ->
+                        val assets = groups[platform].orEmpty()
+                        if (assets.isEmpty()) return@forEach
+                        val isCurrentDevice =
+                            assets.any { it.id in installableIds }
+                        item(key = "section-${platform.name}") {
+                            PlatformSectionCard(
+                                platformLabel = stringResource(labelRes),
+                                isCurrentDevice = isCurrentDevice,
+                                installableIds = installableIds,
+                                assets = assets,
+                                selectedAsset = selectedAsset,
+                                pinnedVariant = pinnedVariant,
+                                onAssetClick = { asset ->
+                                    if (asset.id in installableIds) {
+                                        onSelect(asset)
+                                    } else {
+                                        onDownloadForTransfer(asset)
+                                    }
+                                },
+                            )
                         }
                     }
                 } else if (assetsList.isNotEmpty()) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -107,20 +107,26 @@ fun LazyListScope.header(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ReleaseAssetsPicker(
-                        assetsList = state.installableAssets,
-                        selectedAsset = state.primaryAsset,
-                        isPickerVisible = state.isReleaseSelectorVisible,
-                        pinnedVariant = state.installedApp?.preferredAssetVariant,
-                        showAllPlatforms = state.showAllPlatforms,
-                        crossPlatformAssets =
+                    // Memoize the platform-classifiable subset of release
+                    // assets so each Header recompose (scroll, animation,
+                    // unrelated state change) doesn't re-run the filter.
+                    val crossPlatformAssets =
+                        androidx.compose.runtime.remember(state.selectedRelease) {
                             state.selectedRelease
                                 ?.assets
                                 ?.filter {
                                     zed.rainxch.core.domain.util
                                         .assetPlatformOf(it.name) != null
                                 }
-                                .orEmpty(),
+                                .orEmpty()
+                        }
+                    ReleaseAssetsPicker(
+                        assetsList = state.installableAssets,
+                        selectedAsset = state.primaryAsset,
+                        isPickerVisible = state.isReleaseSelectorVisible,
+                        pinnedVariant = state.installedApp?.preferredAssetVariant,
+                        showAllPlatforms = state.showAllPlatforms,
+                        crossPlatformAssets = crossPlatformAssets,
                         onAction = onAction,
                         modifier = Modifier.weight(.65f),
                     )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Header.kt
@@ -112,6 +112,15 @@ fun LazyListScope.header(
                         selectedAsset = state.primaryAsset,
                         isPickerVisible = state.isReleaseSelectorVisible,
                         pinnedVariant = state.installedApp?.preferredAssetVariant,
+                        showAllPlatforms = state.showAllPlatforms,
+                        crossPlatformAssets =
+                            state.selectedRelease
+                                ?.assets
+                                ?.filter {
+                                    zed.rainxch.core.domain.util
+                                        .assetPlatformOf(it.name) != null
+                                }
+                                .orEmpty(),
                         onAction = onAction,
                         modifier = Modifier.weight(.65f),
                     )


### PR DESCRIPTION
Sprint 2 task E15. Survey #7 — users want to grab installers across OSes ("Android APKs from desktop, Linux .debs from phone").

What landed:
- `core/domain/util/AssetPlatform.kt` — filename → `DiscoveryPlatform` mapping (apk/exe/msi/dmg/pkg/deb/rpm/AppImage/snap/etc.).
- `TweaksRepository.getShowAllPlatforms()` / `setShowAllPlatforms()` — global persisted toggle, DataStore key `show_all_platforms`.
- `DetailsState.showAllPlatforms` observed from preference.
- `ReleaseAssetsItemsPicker` (the sheet): Switch at top wired to `OnToggleShowAllPlatforms`. When ON, the list groups assets by `DiscoveryPlatform` with section headers (Android / Windows / macOS / Linux). Non-installable-on-current-platform assets route to `OnDownloadForTransfer` which opens the asset's downloadUrl via `BrowserHelper.openUrl` — browser handles save-to-Downloads. Hint row "Other platform — opens in browser to save for transfer" under each non-current asset.
- Current-platform install flow unchanged. Selecting an installable asset still hits `SelectDownloadAsset` → install button picks it up.
- 13-locale strings + 1.8.2 what's-new bullet.

Compile-verified: `:composeApp:compileDebugKotlinAndroid` BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-platform release asset picker: toggle to show installers grouped by platform or current-platform only.
  * Download non-current-platform assets for transfer (opens in browser).
  * Persisted "Show all platforms" preference so your choice is remembered.
  * Long-press “hide repository” on Home/Search cards.

* **Localization**
  * Added translations for the platform-selection UI across multiple languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/588)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->