### PR TITLE
chore: release 1.8.2 prep — version bump + whatsnew alignment

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/17.json
@@ -1,7 +1,7 @@
 {
   "versionCode": 17,
-  "versionName": "1.9.0",
-  "releaseDate": "2026-05-07",
+  "versionName": "1.8.2",
+  "releaseDate": "2026-05-13",
   "showAsSheet": true,
   "sections": [
     {

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewSheet.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/whatsnew/WhatsNewSheet.kt
@@ -67,14 +67,6 @@ fun WhatsNewSheet(
             }
 
             item {
-                Text(
-                    text = stringResource(Res.string.whats_new_translations_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            item {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,11 +51,11 @@ ktlint-gradle = "12.1.1"
 flatpak-gradle-generator = "1.7.0"
 
 projectApplicationId = "zed.rainxch.githubstore"
-projectVersionName = "1.8.1"
+projectVersionName = "1.8.2"
+projectVersionCode = "17"
 projectMinSdkVersion = "26"
 projectTargetSdkVersion = "36"
 projectCompileSdkVersion = "36"
-projectVersionCode = "16"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
Release-prep diff for the 1.8.2 polish drop.

- `projectVersionName` 1.8.1 → 1.8.2, `projectVersionCode` 16 → 17.
- 13-locale whatsnew/17.json files: stale `"versionName": "1.9.0"` → `"1.8.2"`, `releaseDate` → 2026-05-13.
- `WhatsNewSheet.kt`: drops the obsolete translations-note block (8 lines).

Compile-verified: `:composeApp:compileDebugKotlinAndroid` BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Version updated to 1.8.2
  - Release date and metadata updated across all language variants
  - Release information display updated

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/589)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->