### PR TITLE
fix(updates): sibling-app detection — Layer 5 stem filter (#591)

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -243,6 +243,7 @@ class InstalledAppsRepositoryImpl(
         pickedIndex: Int?,
         pickedSiblingCount: Int?,
         trackedPackageName: String,
+        installedAssetName: String?,
     ): ResolvedRelease? {
         if (releases.isEmpty()) return null
 
@@ -307,8 +308,36 @@ class InstalledAppsRepositoryImpl(
             // tracked `.fdroid` package keeps fdroid-named assets.
             // Pinned variants are unaffected — fingerprintMatch /
             // positionMatch run against the full installable set above.
+            // Stem filter (issue #591): when the tracked app has a known
+            // prior asset name, restrict the auto-pick pool to release
+            // assets that share its base-name stem. Stops sibling apps
+            // shipped from the same repo (`AppA-1.10.apk` vs
+            // `AppB-2.20.apk`) from cross-pollinating: without this,
+            // `choosePrimaryAsset` would pick the highest numeric
+            // version regardless of the filename prefix.
+            val installedStem =
+                installedAssetName
+                    ?.let { AssetVariant.extractBaseStem(it) }
+                    ?.takeIf { it.isNotEmpty() }
             val autoPickPool =
-                AssetVariant.filterByPackageFlavor(installableForApp, trackedPackageName)
+                AssetVariant
+                    .filterByPackageFlavor(installableForApp, trackedPackageName)
+                    .let { pool ->
+                        if (installedStem == null) {
+                            pool
+                        } else {
+                            val matching =
+                                pool.filter {
+                                    AssetVariant.extractBaseStem(it.name) == installedStem
+                                }
+                            // Only honour the stem filter when it
+                            // actually keeps something; otherwise fall
+                            // back to the broader pool. A maintainer
+                            // legitimately renaming the binary should
+                            // not strand the update check.
+                            if (matching.isNotEmpty()) matching else pool
+                        }
+                    }
             val primary = fingerprintMatch
                 ?: positionMatch
                 ?: installer.choosePrimaryAsset(autoPickPool)
@@ -374,6 +403,7 @@ class InstalledAppsRepositoryImpl(
                     pickedIndex = app.pickedAssetIndex,
                     pickedSiblingCount = app.pickedAssetSiblingCount,
                     trackedPackageName = app.packageName,
+                    installedAssetName = app.installedAssetName,
                 )
 
             if (resolved == null) {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetVariant.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetVariant.kt
@@ -278,14 +278,41 @@ object AssetVariant {
     fun extractBaseStem(assetName: String): String {
         val tokens = tokenize(assetName)
         if (tokens.isEmpty()) return ""
-        return tokens
-            .filterNot { token ->
-                token in VOCABULARY ||
-                    token in ARCH_TOKENS ||
-                    token in FLAVOR_TOKENS ||
-                    isVersionLikeToken(token)
+
+        // Mirror `extractTokens`' n-gram consumption pass so the
+        // fragments of compound vocab entries (e.g. `arm64-v8a` →
+        // tokens `["arm64","v8a"]`) are both stripped, not just the
+        // canonical-form half. Without this, `v8a` / `v7a` would
+        // survive the filter and `app-arm64-v8a-1.10.apk` would yield
+        // a different stem than `app-x86_64-1.10.apk`, defeating the
+        // sibling-app detection for arch-variant releases.
+        val consumed = BooleanArray(tokens.size)
+
+        for (i in 0 until tokens.size - 2) {
+            if (consumed[i] || consumed[i + 1] || consumed[i + 2]) continue
+            val candidate = "${tokens[i]}-${tokens[i + 1]}-${tokens[i + 2]}"
+            if (candidate in VOCABULARY) {
+                consumed[i] = true; consumed[i + 1] = true; consumed[i + 2] = true
             }
-            .joinToString("")
+        }
+        for (i in 0 until tokens.size - 1) {
+            if (consumed[i] || consumed[i + 1]) continue
+            val dashed = "${tokens[i]}-${tokens[i + 1]}"
+            val underscored = "${tokens[i]}_${tokens[i + 1]}"
+            if (dashed in VOCABULARY || underscored in VOCABULARY) {
+                consumed[i] = true; consumed[i + 1] = true
+            }
+        }
+
+        val out = StringBuilder()
+        for (i in tokens.indices) {
+            if (consumed[i]) continue
+            val t = tokens[i]
+            if (t in VOCABULARY) continue
+            if (isVersionLikeToken(t)) continue
+            out.append(t)
+        }
+        return out.toString()
     }
 
     /**

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetVariant.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/AssetVariant.kt
@@ -257,6 +257,51 @@ object AssetVariant {
      * the glob would just equal the filename and provides no rescue
      * value beyond exact-match.
      */
+    /**
+     * Extracts the **base-name stem** of an asset — the lowercased,
+     * separator-stripped concatenation of every token that isn't a
+     * version-like number, an arch token, or a flavor token. Used to
+     * detect "sibling app in the same repo" cases where two releases
+     * ship `AppA-1.10.apk` and `AppB-2.20.apk` and the auto-picker
+     * would otherwise swap one for the other based on numeric version
+     * alone (issue #591).
+     *
+     * `AppA-1.10.apk` → `"appa"`
+     * `AppB-2.20.apk` → `"appb"`
+     * `app-arm64-v8a-1.10.apk` and `app-x86_64-1.10.apk` → both `"app"`
+     * `app-1.0.apk` and `app-fdroid-1.0.apk` → both `"app"`
+     *
+     * Returns an empty string when stripping leaves nothing behind
+     * (release ships only a versioned filename like `2.0.apk`). Callers
+     * treat empty as "no stem signal — don't filter".
+     */
+    fun extractBaseStem(assetName: String): String {
+        val tokens = tokenize(assetName)
+        if (tokens.isEmpty()) return ""
+        return tokens
+            .filterNot { token ->
+                token in VOCABULARY ||
+                    token in ARCH_TOKENS ||
+                    token in FLAVOR_TOKENS ||
+                    isVersionLikeToken(token)
+            }
+            .joinToString("")
+    }
+
+    /**
+     * `1`, `10`, `1.0.0`, `v2.0.1`, `2024.04.10`, `1.0-rc1`, `beta3` —
+     * common patterns used in release filenames to encode the version.
+     * Conservative on purpose: false positives here just lose a stem
+     * character; false negatives would let a numeric variant leak into
+     * the stem and break the sibling-app detection.
+     */
+    private fun isVersionLikeToken(token: String): Boolean {
+        if (token.isEmpty()) return false
+        if (token.all { it.isDigit() }) return true
+        if (token.startsWith("v") && token.drop(1).all { it.isDigit() }) return true
+        return false
+    }
+
     fun deriveGlob(assetName: String): String? {
         val lower = assetName.lowercase()
         // Match either:

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/17.json
@@ -23,7 +23,8 @@
         "Better version detection — releases that share a numeric version but ship distinct build artifacts are no longer falsely flagged as 'already installed'.",
         "Updating multiple apps in a row now works reliably — installs serialize so each one shows the correct APK in the system dialog. Apps screen versions also stay in sync after every install.",
         "Auto-update picks the right APK when a release ships both a regular and an F-Droid variant — no more accidentally installing a sibling app with a different package id.",
-        "Search no longer shows a result count over an empty list — when 'Hide seen' filters out every hit, the screen now explains why and offers a one-tap reset."
+        "Search no longer shows a result count over an empty list — when 'Hide seen' filters out every hit, the screen now explains why and offers a one-tap reset.",
+        "Sibling-app detection — auto-update no longer mistakes a different app shipped from the same repo (e.g. APP A → APP B) for a higher version of the tracked one."
       ]
     },
     {


### PR DESCRIPTION
Issue #591 — auto-update flagged `APP B-2.20.apk` as a higher version of an `APP A-1.10.apk` installed from the same repo, because Layer 5 (`installer.choosePrimaryAsset`) picks the highest-version asset from the auto-pick pool without checking that the candidate is actually the *same* app the user installed.

What landed:
- `AssetVariant.extractBaseStem(name)` — lowercased, separator-stripped concatenation of every token that isn't a version-like number, arch token, or flavor token. `APP A-1.10.apk → "appa"`, `APP B-2.20.apk → "appb"`, `app-arm64-v8a-1.10.apk and app-x86_64-1.10.apk → both "app"`. Empty stem (e.g. `2.0.apk`) means "no signal — don't filter".
- `resolveTrackedRelease` Layer 5 now receives `installedAssetName` (already on `InstalledAppEntity`). When the stem of the installed asset is non-empty, the auto-pick pool is filtered to assets with matching stem before `choosePrimaryAsset` runs.
- Graceful fallback: if the stem filter would empty the pool (maintainer legitimately renamed the binary), we fall back to the broader `filterByPackageFlavor` pool so updates still flow.
- 1.8.2 what's-new bullet under FIXED.

**Not compile-verified locally** — `~/.gradle` SSD unmounted in this session. Visual review only. Please compile-check before merge: `:core:domain`, `:core:data`, `:composeApp:compileDebugKotlinAndroid`.

Closes #591.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-update misidentifying a different sibling app from the same repository when selecting updates.
  * Improved update selection to prefer the currently installed asset’s base name, reducing incorrect update picks for similar assets.
  * Updated "What's New" to note the fix and preserve behavior for empty “Hide seen” results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/592)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->