### PR TITLE
Add Homebrew Cask for macOS install

### DIFF
--- a/.github/workflows/homebrew-tap-publish.yml
+++ b/.github/workflows/homebrew-tap-publish.yml
@@ -1,0 +1,102 @@
+name: Publish to Homebrew Tap
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.8.3)'
+        required: true
+
+jobs:
+  update-cask:
+    name: Update Homebrew Cask
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG version=$VERSION"
+
+      - name: Download macOS DMGs
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          curl -fSL -o arm64.dmg "$BASE/GitHub-Store-$VERSION-arm64.dmg"
+          curl -fSL -o x64.dmg   "$BASE/GitHub-Store-$VERSION-x64.dmg"
+          ls -la *.dmg
+
+      - name: Compute SHA256
+        id: hash
+        run: |
+          SHA_ARM=$(sha256sum arm64.dmg | awk '{print $1}')
+          SHA_X64=$(sha256sum x64.dmg | awk '{print $1}')
+          echo "arm=$SHA_ARM"   >> "$GITHUB_OUTPUT"
+          echo "intel=$SHA_X64" >> "$GITHUB_OUTPUT"
+          echo "arm64=$SHA_ARM"
+          echo "x64=$SHA_X64"
+
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+        with:
+          repository: OpenHub-Store/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Patch cask
+        working-directory: homebrew-tap
+        env:
+          NEW_VERSION: ${{ steps.tag.outputs.version }}
+          NEW_SHA_ARM: ${{ steps.hash.outputs.arm }}
+          NEW_SHA_INTEL: ${{ steps.hash.outputs.intel }}
+        run: |
+          python3 - <<'EOF'
+          import os, re, sys
+          path = "Casks/github-store.rb"
+          version = os.environ["NEW_VERSION"]
+          sha_arm = os.environ["NEW_SHA_ARM"]
+          sha_intel = os.environ["NEW_SHA_INTEL"]
+          text = open(path).read()
+
+          new_text, n_v = re.subn(r'version\s+"[^"]+"', f'version "{version}"', text, count=1)
+          if n_v != 1:
+              sys.exit("Failed to patch version stanza")
+
+          pattern = re.compile(
+              r'sha256 arm:\s+"[0-9a-f]+",\s*\n\s*intel:\s+"[0-9a-f]+"'
+          )
+          replacement = (
+              f'sha256 arm:   "{sha_arm}",\n'
+              f'         intel: "{sha_intel}"'
+          )
+          new_text, n_s = pattern.subn(replacement, new_text, count=1)
+          if n_s != 1:
+              sys.exit("Failed to patch sha256 stanza")
+
+          open(path, "w").write(new_text)
+          print("Patched cask:")
+          print(new_text)
+          EOF
+
+      - name: Commit + push
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/github-store.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date"
+            exit 0
+          fi
+          git commit -m "Bump github-store to ${{ steps.tag.outputs.version }}"
+          git push

--- a/.github/workflows/homebrew-tap-publish.yml
+++ b/.github/workflows/homebrew-tap-publish.yml
@@ -16,11 +16,19 @@ jobs:
     steps:
       - name: Resolve release tag
         id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "No tag resolved from event inputs" >&2
+            exit 1
           fi
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -28,17 +36,21 @@ jobs:
           echo "Resolved tag=$TAG version=$VERSION"
 
       - name: Download macOS DMGs
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          BASE="https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}"
-          VERSION="${{ steps.tag.outputs.version }}"
-          curl -fSL -o arm64.dmg "$BASE/GitHub-Store-$VERSION-arm64.dmg"
-          curl -fSL -o x64.dmg   "$BASE/GitHub-Store-$VERSION-x64.dmg"
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+          curl -fSL -o arm64.dmg "${BASE}/GitHub-Store-${VERSION}-arm64.dmg"
+          curl -fSL -o x64.dmg   "${BASE}/GitHub-Store-${VERSION}-x64.dmg"
           ls -la *.dmg
 
       - name: Compute SHA256
         id: hash
         run: |
+          set -euo pipefail
           SHA_ARM=$(sha256sum arm64.dmg | awk '{print $1}')
           SHA_X64=$(sha256sum x64.dmg | awk '{print $1}')
           echo "arm=$SHA_ARM"   >> "$GITHUB_OUTPUT"
@@ -70,7 +82,8 @@ jobs:
 
           new_text, n_v = re.subn(r'version\s+"[^"]+"', f'version "{version}"', text, count=1)
           if n_v != 1:
-              sys.exit("Failed to patch version stanza")
+              print("Failed to patch version stanza", file=sys.stderr)
+              sys.exit(1)
 
           pattern = re.compile(
               r'sha256 arm:\s+"[0-9a-f]+",\s*\n\s*intel:\s+"[0-9a-f]+"'
@@ -81,7 +94,8 @@ jobs:
           )
           new_text, n_s = pattern.subn(replacement, new_text, count=1)
           if n_s != 1:
-              sys.exit("Failed to patch sha256 stanza")
+              print("Failed to patch sha256 stanza", file=sys.stderr)
+              sys.exit(1)
 
           open(path, "w").write(new_text)
           print("Patched cask:")
@@ -90,7 +104,10 @@ jobs:
 
       - name: Commit + push
         working-directory: homebrew-tap
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Casks/github-store.rb
@@ -98,5 +115,5 @@ jobs:
             echo "Cask already up to date"
             exit 0
           fi
-          git commit -m "Bump github-store to ${{ steps.tag.outputs.version }}"
+          git commit -m "Bump github-store to ${VERSION}"
           git push

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ brew install --cask github-store
 xattr -dr com.apple.quarantine /Applications/GitHub-Store.app
 ```
 
-The final `xattr` command is required until the app is signed and notarized; without it, macOS Gatekeeper blocks the app with a "damaged" or "cannot be opened" error.
+The final `xattr` command is required until the app is signed and notarized; without it, macOS Gatekeeper blocks the app with a "damaged" or "cannot be opened" error. Adjust the path if you installed the Cask with a custom `--appdir` (the default is `/Applications`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ scoop install scoop-bucket/github-store
 winget install zed.rainxch.githubstore
 ```
 
+> [!TIP]
+> **macOS Users:** Install GitHub Store with Homebrew.
+
+**Homebrew**
+
+```bash
+brew tap OpenHub-Store/tap
+brew install --cask github-store
+xattr -dr com.apple.quarantine /Applications/GitHub-Store.app
+```
+
+The final `xattr` command is required until the app is signed and notarized; without it, macOS Gatekeeper blocks the app with a "damaged" or "cannot be opened" error.
+
 ---
 
 <div align="center">

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewLoaderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/whatsnew/WhatsNewLoaderImpl.kt
@@ -74,5 +74,5 @@ class WhatsNewLoaderImpl(
 }
 
 object KnownWhatsNewVersionCodes {
-    val ALL: List<Int> = listOf(17, 16, 15)
+    val ALL: List<Int> = listOf(18, 17, 16, 15)
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "macOS install via Homebrew — `brew install --cask github-store` from our new tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।"
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।"
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。"
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`."
+      ]
+    }
+  ]
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -1,6 +1,6 @@
 {
   "versionCode": 18,
-  "versionName": "1.9.0",
+  "versionName": "1.8.3",
   "releaseDate": "2026-05-14",
   "showAsSheet": true,
   "sections": [

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -1,0 +1,14 @@
+{
+  "versionCode": 18,
+  "versionName": "1.9.0",
+  "releaseDate": "2026-05-14",
+  "showAsSheet": true,
+  "sections": [
+    {
+      "type": "NEW",
+      "bullets": [
+        "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。"
+      ]
+    }
+  ]
+}

--- a/dist/homebrew/Casks/github-store.rb
+++ b/dist/homebrew/Casks/github-store.rb
@@ -16,9 +16,14 @@ cask "github-store" do
   end
 
   auto_updates false
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "GitHub-Store.app"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/GitHub-Store.app"]
+  end
 
   uninstall quit: "zed.rainxch.githubstore"
 

--- a/dist/homebrew/Casks/github-store.rb
+++ b/dist/homebrew/Casks/github-store.rb
@@ -20,11 +20,6 @@ cask "github-store" do
 
   app "GitHub-Store.app"
 
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/GitHub-Store.app"]
-  end
-
   uninstall quit: "zed.rainxch.githubstore"
 
   zap trash: [
@@ -34,4 +29,17 @@ cask "github-store" do
     "~/Library/Preferences/zed.rainxch.githubstore.plist",
     "~/Library/Saved Application State/zed.rainxch.githubstore.savedState",
   ]
+
+  caveats <<~EOS
+    GitHub Store is not yet signed with an Apple Developer ID.
+    macOS Gatekeeper will block it from launching with a "damaged" or
+    "cannot be opened" error.
+
+    To allow the app to launch, run:
+
+      xattr -dr com.apple.quarantine "#{appdir}/GitHub-Store.app"
+
+    This step is required after each install or upgrade until the app is
+    signed and notarized.
+  EOS
 end

--- a/dist/homebrew/Casks/github-store.rb
+++ b/dist/homebrew/Casks/github-store.rb
@@ -1,0 +1,32 @@
+cask "github-store" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.8.2"
+  sha256 arm:   "ad0c532873c0400736b7ea706a33604f7ef93b2479a4a6f32673a789b18ccd8e",
+         intel: "faf002283c301db2a97f7a32193778f678d42ed71551a623711cd170d6fde16a"
+
+  url "https://github.com/OpenHub-Store/GitHub-Store/releases/download/v#{version}/GitHub-Store-#{version}-#{arch}.dmg"
+  name "GitHub Store"
+  desc "Cross-platform app store for GitHub releases"
+  homepage "https://github.com/OpenHub-Store/GitHub-Store"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on macos: ">= :big_sur"
+
+  app "GitHub-Store.app"
+
+  uninstall quit: "zed.rainxch.githubstore"
+
+  zap trash: [
+    "~/Library/Application Support/GitHub-Store",
+    "~/Library/Caches/GitHub-Store",
+    "~/Library/Logs/GitHub-Store",
+    "~/Library/Preferences/zed.rainxch.githubstore.plist",
+    "~/Library/Saved Application State/zed.rainxch.githubstore.savedState",
+  ]
+end

--- a/dist/homebrew/README.md
+++ b/dist/homebrew/README.md
@@ -1,0 +1,32 @@
+# Homebrew Cask (reference copy)
+
+The Cask in this directory is a **reference/seed copy**. The live, user-facing
+Cask lives in [`OpenHub-Store/homebrew-tap`](https://github.com/OpenHub-Store/homebrew-tap)
+and is auto-updated on each release by
+[`.github/workflows/homebrew-tap-publish.yml`](../../.github/workflows/homebrew-tap-publish.yml).
+
+Users install with:
+
+```bash
+brew tap OpenHub-Store/tap
+brew install --cask github-store
+xattr -dr com.apple.quarantine /Applications/GitHub-Store.app
+```
+
+The final `xattr` is required until the app is signed and notarized.
+
+## Releasing
+
+No manual step needed. On each `release: types: [released]` event, the workflow:
+
+1. Downloads `GitHub-Store-<version>-arm64.dmg` + `GitHub-Store-<version>-x64.dmg`.
+2. Computes SHA256 of both.
+3. Patches `version` + `sha256` in the tap repo's `Casks/github-store.rb`.
+4. Commits + pushes to the tap repo.
+
+Requires the `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with
+`contents: write` permission on the tap repo.
+
+This reference copy is not auto-synced; treat the tap repo as canonical. If you
+edit Cask metadata (caveats, zap paths, etc.), update both this file and the
+tap repo until we drop one or the other.


### PR DESCRIPTION
## Summary
- New Cask `dist/homebrew/Casks/github-store.rb` (multi-arch, livecheck wired, audit clean).
- Published to `OpenHub-Store/homebrew-tap`. Users install via:
  ```bash
  brew tap OpenHub-Store/tap
  brew install --cask github-store
  xattr -dr com.apple.quarantine /Applications/GitHub-Store.app
  ```
- README updated with the install steps next to Scoop/Winget.
- `caveats` block surfaces the `xattr` step in `brew info`.
- 1.8.3 what's-new (`whatsnew/18.json`) seeded across 13 locales with Homebrew bullet; `KnownWhatsNewVersionCodes.ALL` updated.
- New workflow `.github/workflows/homebrew-tap-publish.yml` auto-publishes the Cask to the tap repo on every release (downloads DMGs, computes SHA256, patches `version` + `sha256`, commits + pushes).

## Required setup
Add repo secret `HOMEBREW_TAP_TOKEN` — fine-grained PAT with `contents: write` on `OpenHub-Store/homebrew-tap`.

## Notes
- App is adhoc-signed; Gatekeeper blocks until notarized. `postflight` auto-strip will be banned by Homebrew on Sept 1, 2026, so manual `xattr` is documented instead.
- `dist/homebrew/Casks/github-store.rb` is a seed/reference; tap repo is canonical (`dist/homebrew/README.md` documents this).

## Test plan
- [x] `brew style --cask` clean
- [x] `brew audit --cask --online` exit 0
- [x] `brew livecheck` reports 1.8.2
- [x] End-to-end install on arm64 Mac (`xattr` strips quarantine; app launches)
- [x] `:composeApp:compileKotlinMetadata` build successful
- [x] All 13 `18.json` files parse as valid JSON
- [x] Workflow patch script dry-run produces lint-clean Cask
- [ ] Live release event end-to-end (verify on next tag push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Homebrew installation support via a Homebrew cask.

* **Documentation**
  * Updated README with macOS installation steps and Gatekeeper/xattr guidance.

* **Chores**
  * Added workflow to publish/update the Homebrew tap automatically.
  * Added "What's New" release content for version 1.8.3 across multiple languages (shown as a release sheet).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/595)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->