### PR TITLE
fix(home): one-tap disable for hide-seen empty state

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "macOS install via Homebrew — `brew install --cask github-store` from our new tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Disable 'Hide seen' from Home — one-tap reset when the filter empties the grid."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "تعطيل 'Hide seen' من الرئيسية — نقرة واحدة لإعادة الضبط عند إفراغ الفلتر للشبكة."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।"
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Home থেকে 'Hide seen' বন্ধ করুন — ফিল্টার গ্রিড খালি করলে এক ট্যাপে রিসেট।"
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Desactiva 'Hide seen' desde Home — un toque para restablecer cuando el filtro vacía la cuadrícula."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Désactiver 'Hide seen' depuis Home — un tap pour réinitialiser quand le filtre vide la grille."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।"
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Home से 'Hide seen' बंद करें — फ़िल्टर ग्रिड खाली होने पर एक टैप में रीसेट।"
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Disattiva 'Hide seen' da Home — un tap per ripristinare quando il filtro svuota la griglia."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。"
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Home から 'Hide seen' を無効化 — フィルタがグリッドを空にしたとき、ワンタップでリセット。"
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Home에서 'Hide seen' 비활성화 — 필터가 그리드를 비울 때 한 번 탭으로 재설정."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Wyłącz 'Hide seen' z Home — jeden tap, by zresetować, gdy filtr opróżnia siatkę."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Отключить 'Hide seen' с Home — один тап для сброса, когда фильтр опустошает сетку."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`."
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "Home'dan 'Hide seen' kapat — filtre ızgarayı boşalttığında tek dokunuşla sıfırla."
+      ]
     }
   ]
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -9,6 +9,12 @@
       "bullets": [
         "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。"
       ]
+    },
+    {
+      "type": "FIXED",
+      "bullets": [
+        "从 Home 关闭 'Hide seen' — 过滤器清空网格时,一键重置。"
+      ]
     }
   ]
 }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeAction.kt
@@ -61,4 +61,6 @@ sealed interface HomeAction {
     data class OnMarkAsUnseen(
         val repoId: Long,
     ) : HomeAction
+
+    data object OnDisableHideSeenForResults : HomeAction
 }

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeRoot.kt
@@ -417,6 +417,28 @@ private fun MainState(
         }
     }
 
+    val isHideSeenFilteringAll =
+        state.repos.isNotEmpty() &&
+            visibleRepos.isEmpty() &&
+            state.isHideSeenEnabled
+
+    LaunchedEffect(
+        state.repos.size,
+        visibleRepos.size,
+        state.isHideSeenEnabled,
+        state.hasMorePages,
+        state.isLoadingMore,
+        state.isLoading,
+    ) {
+        if (isHideSeenFilteringAll &&
+            state.hasMorePages &&
+            !state.isLoadingMore &&
+            !state.isLoading
+        ) {
+            onAction(HomeAction.LoadMore)
+        }
+    }
+
     if (visibleRepos.isNotEmpty()) {
         val isScrollbarEnabled = LocalScrollbarEnabled.current
         ScrollbarContainer(
@@ -513,6 +535,47 @@ private fun MainState(
             }
         }
         } // ScrollbarContainer
+    } else if (isHideSeenFilteringAll && state.hasMorePages) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                CircularProgressIndicator()
+
+                Spacer(Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(Res.string.searching_for_unseen_repos),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
+    } else if (isHideSeenFilteringAll && !state.hasMorePages) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.search_results_hidden_by_seen_filter),
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                GithubStoreButton(
+                    text = stringResource(Res.string.show_all_results),
+                    onClick = {
+                        onAction(HomeAction.OnDisableHideSeenForResults)
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -597,6 +597,12 @@ class HomeViewModel(
             HomeAction.OnAppsClick -> {
                 // Handled in composable
             }
+
+            HomeAction.OnDisableHideSeenForResults -> {
+                viewModelScope.launch {
+                    tweaksRepository.setHideSeenEnabled(false)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Sprint 3 Task 11. Mirrors Search empty-state pattern. When `repos.isNotEmpty() && visibleRepos.isEmpty() && isHideSeenEnabled`: auto-paginate while `hasMorePages`; else show banner + "Disable 'Hide seen' filter" button → flips global toggle off.

Test plan
- [x] Android + JVM compile clean
- [x] 13 `18.json` valid
- [ ] Real-device smoke: mark all Home repos seen → banner → tap → grid restored

Source: 九幽 email, v1.8.1 zh-CN.