### PR TITLE
chore(whatsnew): announce fastly.jsdelivr.net mirror

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "macOS install via Homebrew — `brew install --cask github-store` from our new tap."
+        "macOS install via Homebrew — `brew install --cask github-store` from our new tap.",
+        "Two new community mirrors — fastgit.cc and fastly.jsdelivr.net. Useful when GitHub is throttled."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "macOS install via Homebrew — `brew install --cask github-store` from our new tap.",
-        "Two new community mirrors — fastgit.cc and fastly.jsdelivr.net. Useful when GitHub is throttled."
+        "Added fastly.jsdelivr.net as a community mirror. Useful when GitHub is throttled."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد."
+        "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد.",
+        "مرآتان مجتمعيتان جديدتان — fastgit.cc و fastly.jsdelivr.net. مفيدة عند تقييد GitHub."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد.",
-        "مرآتان مجتمعيتان جديدتان — fastgit.cc و fastly.jsdelivr.net. مفيدة عند تقييد GitHub."
+        "تمت إضافة fastly.jsdelivr.net كمرآة مجتمعية. مفيدة عند تقييد GitHub."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।"
+        "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।",
+        "দুটি নতুন কমিউনিটি মিরর — fastgit.cc এবং fastly.jsdelivr.net। GitHub সীমাবদ্ধ থাকলে কাজে আসে।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।",
-        "দুটি নতুন কমিউনিটি মিরর — fastgit.cc এবং fastly.jsdelivr.net। GitHub সীমাবদ্ধ থাকলে কাজে আসে।"
+        "কমিউনিটি মিরর হিসেবে fastly.jsdelivr.net যোগ করা হয়েছে। GitHub সীমাবদ্ধ থাকলে কাজে আসে।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap."
+        "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap.",
+        "Dos nuevos mirrors comunitarios — fastgit.cc y fastly.jsdelivr.net. Útiles cuando GitHub está limitado."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap.",
-        "Dos nuevos mirrors comunitarios — fastgit.cc y fastly.jsdelivr.net. Útiles cuando GitHub está limitado."
+        "Añadido fastly.jsdelivr.net como mirror comunitario. Útil cuando GitHub está limitado."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap."
+        "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap.",
+        "Deux nouveaux mirrors communautaires — fastgit.cc et fastly.jsdelivr.net. Utiles quand GitHub est limité."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap.",
-        "Deux nouveaux mirrors communautaires — fastgit.cc et fastly.jsdelivr.net. Utiles quand GitHub est limité."
+        "fastly.jsdelivr.net ajouté comme mirror communautaire. Utile quand GitHub est limité."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।"
+        "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।",
+        "दो नए कम्युनिटी मिरर — fastgit.cc और fastly.jsdelivr.net। GitHub सीमित होने पर उपयोगी।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।",
-        "दो नए कम्युनिटी मिरर — fastgit.cc और fastly.jsdelivr.net। GitHub सीमित होने पर उपयोगी।"
+        "कम्युनिटी मिरर के रूप में fastly.jsdelivr.net जोड़ा गया। GitHub सीमित होने पर उपयोगी।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap."
+        "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap.",
+        "Due nuovi mirror della community — fastgit.cc e fastly.jsdelivr.net. Utili quando GitHub è limitato."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap.",
-        "Due nuovi mirror della community — fastgit.cc e fastly.jsdelivr.net. Utili quando GitHub è limitato."
+        "Aggiunto fastly.jsdelivr.net come mirror della community. Utile quando GitHub è limitato."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。"
+        "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。",
+        "コミュニティミラー 2 件追加 — fastgit.cc と fastly.jsdelivr.net。GitHub が制限されたときに便利。"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。",
-        "コミュニティミラー 2 件追加 — fastgit.cc と fastly.jsdelivr.net。GitHub が制限されたときに便利。"
+        "コミュニティミラーに fastly.jsdelivr.net を追加。GitHub が制限されたときに便利。"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`.",
-        "새 커뮤니티 미러 2 개 — fastgit.cc 와 fastly.jsdelivr.net. GitHub 가 제한될 때 유용."
+        "새 커뮤니티 미러 2개 — fastgit.cc와 fastly.jsdelivr.net. GitHub가 제한될 때 유용."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`."
+        "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`.",
+        "새 커뮤니티 미러 2 개 — fastgit.cc 와 fastly.jsdelivr.net. GitHub 가 제한될 때 유용."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`.",
-        "새 커뮤니티 미러 2개 — fastgit.cc와 fastly.jsdelivr.net. GitHub가 제한될 때 유용."
+        "커뮤니티 미러로 fastly.jsdelivr.net 추가. GitHub가 제한될 때 유용."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap."
+        "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap.",
+        "Dwa nowe mirrory społeczności — fastgit.cc i fastly.jsdelivr.net. Przydatne, gdy GitHub jest ograniczony."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap.",
-        "Dwa nowe mirrory społeczności — fastgit.cc i fastly.jsdelivr.net. Przydatne, gdy GitHub jest ograniczony."
+        "Dodano fastly.jsdelivr.net jako mirror społeczności. Przydatne, gdy GitHub jest ograniczony."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap."
+        "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap.",
+        "Два новых зеркала сообщества — fastgit.cc и fastly.jsdelivr.net. Полезны, когда GitHub ограничен."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap.",
-        "Два новых зеркала сообщества — fastgit.cc и fastly.jsdelivr.net. Полезны, когда GitHub ограничен."
+        "Добавлено зеркало сообщества fastly.jsdelivr.net. Полезно, когда GitHub ограничен."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`."
+        "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`.",
+        "İki yeni topluluk yansısı — fastgit.cc ve fastly.jsdelivr.net. GitHub kısıtlandığında işe yarar."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`.",
-        "İki yeni topluluk yansısı — fastgit.cc ve fastly.jsdelivr.net. GitHub kısıtlandığında işe yarar."
+        "Topluluk yansısı olarak fastly.jsdelivr.net eklendi. GitHub kısıtlandığında işe yarar."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -7,7 +7,8 @@
     {
       "type": "NEW",
       "bullets": [
-        "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。"
+        "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。",
+        "新增两个社区镜像 — fastgit.cc 和 fastly.jsdelivr.net。GitHub 受限时很有用。"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -8,7 +8,7 @@
       "type": "NEW",
       "bullets": [
         "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。",
-        "新增两个社区镜像 — fastgit.cc 和 fastly.jsdelivr.net。GitHub 受限时很有用。"
+        "新增社区镜像 fastly.jsdelivr.net。GitHub 受限时很有用。"
       ]
     },
     {


### PR DESCRIPTION
Sprint 3 Task 13 — announce backend's new community mirror in 1.8.3 changelog (13 locales).

Originally scoped 2 mirrors. Backend dropped fastgit.cc — no public artifact ties it to FastGitORG (their .org domain is officially shut down); treated as supply-chain risk. Only fastly.jsdelivr.net ships.

Test plan
- [x] 13 `18.json` valid

Source: vbidv email + backend agent verification.

Follow-up
- Separate PR for client-side `traffic_kinds` dispatch (REQUIRED before 1.8.3 release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "What's New" for version 1.8.3 across supported languages to add fastly.jsdelivr.net as a community mirror for use when GitHub is throttled or restricted; the existing macOS/Homebrew installation note remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->