### PR TITLE
feat(apps): Keep Android Open in-app banner

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -330,6 +330,17 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getKaoBannerDismissed(): Flow<Boolean> =
+        preferences.data.map { prefs ->
+            prefs[KAO_BANNER_DISMISSED_KEY] ?: false
+        }
+
+    override suspend fun setKaoBannerDismissed(dismissed: Boolean) {
+        preferences.edit { prefs ->
+            prefs[KAO_BANNER_DISMISSED_KEY] = dismissed
+        }
+    }
+
     override fun getApkInspectCoachmarkShown(): Flow<Boolean> =
         preferences.data.map { prefs ->
             prefs[APK_INSPECT_COACHMARK_SHOWN_KEY] ?: false
@@ -466,6 +477,7 @@ class TweaksRepositoryImpl(
         private val EXTERNAL_IMPORT_ENABLED_KEY = booleanPreferencesKey("external_import_enabled")
         private val EXTERNAL_MATCH_SEARCH_ENABLED_KEY = booleanPreferencesKey("external_match_search_enabled")
         private val EXTERNAL_IMPORT_BANNER_DISMISSED_AT_KEY = intPreferencesKey("external_import_banner_dismissed_at")
+        private val KAO_BANNER_DISMISSED_KEY = booleanPreferencesKey("kao_banner_dismissed")
         private val APK_INSPECT_COACHMARK_SHOWN_KEY = booleanPreferencesKey("apk_inspect_coachmark_shown")
         private val CHANNEL_CHIP_COACHMARK_SHOWN_KEY = booleanPreferencesKey("channel_chip_coachmark_shown")
         private val SHOW_ALL_PLATFORMS_KEY = booleanPreferencesKey("show_all_platforms")

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -105,6 +105,15 @@ interface TweaksRepository {
     suspend fun setExternalImportBannerDismissedAtCount(count: Int)
 
     /**
+     * Permanent dismissal flag for the Keep Android Open campaign banner on
+     * Apps. False until user taps the close button; flips to true forever
+     * once dismissed.
+     */
+    fun getKaoBannerDismissed(): Flow<Boolean>
+
+    suspend fun setKaoBannerDismissed(dismissed: Boolean)
+
+    /**
      * One-shot flag for the APK Inspect coachmark next to the install
      * button on the details screen. `false` until the user has seen the
      * coachmark at least once; flips permanently to `true` thereafter.

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "macOS install via Homebrew — `brew install --cask github-store` from our new tap.",
-        "Added fastly.jsdelivr.net as a community mirror. Useful when GitHub is throttled."
+        "Added fastly.jsdelivr.net as a community mirror. Useful when GitHub is throttled.",
+        "Joined the Keep Android Open coalition — in-app banner on Apps explains why."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ar/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "التثبيت على macOS عبر Homebrew — `brew install --cask github-store` من المستودع الجديد.",
-        "تمت إضافة fastly.jsdelivr.net كمرآة مجتمعية. مفيدة عند تقييد GitHub."
+        "تمت إضافة fastly.jsdelivr.net كمرآة مجتمعية. مفيدة عند تقييد GitHub.",
+        "انضممنا إلى تحالف Keep Android Open — لافتة في Apps توضح السبب."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/bn/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Homebrew দিয়ে macOS-এ ইনস্টল করুন — আমাদের নতুন tap থেকে `brew install --cask github-store`।",
-        "কমিউনিটি মিরর হিসেবে fastly.jsdelivr.net যোগ করা হয়েছে। GitHub সীমাবদ্ধ থাকলে কাজে আসে।"
+        "কমিউনিটি মিরর হিসেবে fastly.jsdelivr.net যোগ করা হয়েছে। GitHub সীমাবদ্ধ থাকলে কাজে আসে।",
+        "Keep Android Open কোয়ালিশনে যোগ দিয়েছি — Apps-এ ব্যানার ব্যাখ্যা করে।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/es/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Instalación en macOS con Homebrew — `brew install --cask github-store` desde nuestro nuevo tap.",
-        "Añadido fastly.jsdelivr.net como mirror comunitario. Útil cuando GitHub está limitado."
+        "Añadido fastly.jsdelivr.net como mirror comunitario. Útil cuando GitHub está limitado.",
+        "Nos unimos a la coalición Keep Android Open — un banner en Apps lo explica."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/fr/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Installation macOS via Homebrew — `brew install --cask github-store` depuis notre nouveau tap.",
-        "fastly.jsdelivr.net ajouté comme mirror communautaire. Utile quand GitHub est limité."
+        "fastly.jsdelivr.net ajouté comme mirror communautaire. Utile quand GitHub est limité.",
+        "Rejoint la coalition Keep Android Open — une bannière in-app sur Apps l'explique."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/hi/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "macOS पर Homebrew से इंस्टॉल — हमारे नए tap से `brew install --cask github-store`।",
-        "कम्युनिटी मिरर के रूप में fastly.jsdelivr.net जोड़ा गया। GitHub सीमित होने पर उपयोगी।"
+        "कम्युनिटी मिरर के रूप में fastly.jsdelivr.net जोड़ा गया। GitHub सीमित होने पर उपयोगी।",
+        "Keep Android Open गठबंधन में शामिल — Apps पर बैनर वजह बताता है।"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/it/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Installazione macOS con Homebrew — `brew install --cask github-store` dal nostro nuovo tap.",
-        "Aggiunto fastly.jsdelivr.net come mirror della community. Utile quando GitHub è limitato."
+        "Aggiunto fastly.jsdelivr.net come mirror della community. Utile quando GitHub è limitato.",
+        "Aderito alla coalizione Keep Android Open — un banner in-app su Apps lo spiega."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ja/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Homebrew で macOS にインストール — 新しい tap から `brew install --cask github-store`。",
-        "コミュニティミラーに fastly.jsdelivr.net を追加。GitHub が制限されたときに便利。"
+        "コミュニティミラーに fastly.jsdelivr.net を追加。GitHub が制限されたときに便利。",
+        "Keep Android Open 連合に参加 — Apps のバナーで理由を説明。"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ko/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Homebrew로 macOS에 설치 — 새 tap에서 `brew install --cask github-store`.",
-        "커뮤니티 미러로 fastly.jsdelivr.net 추가. GitHub가 제한될 때 유용."
+        "커뮤니티 미러로 fastly.jsdelivr.net 추가. GitHub가 제한될 때 유용.",
+        "Keep Android Open 연합 합류 — Apps의 배너로 이유 설명."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/pl/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Instalacja na macOS przez Homebrew — `brew install --cask github-store` z naszego nowego tap.",
-        "Dodano fastly.jsdelivr.net jako mirror społeczności. Przydatne, gdy GitHub jest ograniczony."
+        "Dodano fastly.jsdelivr.net jako mirror społeczności. Przydatne, gdy GitHub jest ograniczony.",
+        "Dołączyliśmy do koalicji Keep Android Open — baner w Apps wyjaśnia dlaczego."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/ru/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "Установка на macOS через Homebrew — `brew install --cask github-store` из нашего нового tap.",
-        "Добавлено зеркало сообщества fastly.jsdelivr.net. Полезно, когда GitHub ограничен."
+        "Добавлено зеркало сообщества fastly.jsdelivr.net. Полезно, когда GitHub ограничен.",
+        "Присоединились к коалиции Keep Android Open — баннер на Apps объясняет."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/tr/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "macOS'ta Homebrew ile kurulum — yeni tap'imizden `brew install --cask github-store`.",
-        "Topluluk yansısı olarak fastly.jsdelivr.net eklendi. GitHub kısıtlandığında işe yarar."
+        "Topluluk yansısı olarak fastly.jsdelivr.net eklendi. GitHub kısıtlandığında işe yarar.",
+        "Keep Android Open koalisyonuna katıldık — Apps'teki banner nedenini açıklıyor."
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/zh-CN/18.json
@@ -8,7 +8,8 @@
       "type": "NEW",
       "bullets": [
         "通过 Homebrew 在 macOS 上安装 — 从我们的新 tap 运行 `brew install --cask github-store`。",
-        "新增社区镜像 fastly.jsdelivr.net。GitHub 受限时很有用。"
+        "新增社区镜像 fastly.jsdelivr.net。GitHub 受限时很有用。",
+        "加入 Keep Android Open 联盟 — Apps 上的横幅说明原因。"
       ]
     },
     {

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1173,4 +1173,8 @@
     <string name="saved_for_transfer_hint">منصة أخرى — يفتح في المتصفح للحفظ والنقل</string>
     <string name="section_chip_your_device">جهازك</string>
     <string name="section_chip_for_transfer">للنقل</string>
+    <string name="kao_banner_title">أبقِ أندرويد مفتوحًا</string>
+    <string name="kao_banner_body">سياسة التحقق من المطورين من Google تهدد التوزيع المفتوح لأندرويد. GitHub Store يدعم التحالف.</string>
+    <string name="kao_banner_cta">اعرف المزيد</string>
+    <string name="kao_banner_dismiss_cd">إغلاق البانر</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1149,4 +1149,8 @@
     <string name="saved_for_transfer_hint">অন্য প্ল্যাটফর্ম — ট্রান্সফারের জন্য সংরক্ষণে ব্রাউজারে খুলবে</string>
     <string name="section_chip_your_device">আপনার ডিভাইস</string>
     <string name="section_chip_for_transfer">ট্রান্সফারের জন্য</string>
+    <string name="kao_banner_title">Android-কে উন্মুক্ত রাখুন</string>
+    <string name="kao_banner_body">Google-এর ডেভেলপার-যাচাইকরণ নীতি উন্মুক্ত Android বিতরণকে হুমকির মুখে ফেলেছে। GitHub Store কোয়ালিশনের পাশে।</string>
+    <string name="kao_banner_cta">আরও জানুন</string>
+    <string name="kao_banner_dismiss_cd">ব্যানার বন্ধ করুন</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1121,4 +1121,8 @@
     <string name="saved_for_transfer_hint">Otra plataforma — se abre en el navegador para guardar y transferir</string>
     <string name="section_chip_your_device">Tu dispositivo</string>
     <string name="section_chip_for_transfer">Para transferir</string>
+    <string name="kao_banner_title">Mantén Android abierto</string>
+    <string name="kao_banner_body">La política de verificación de desarrolladores de Google amenaza la distribución abierta de Android. GitHub Store apoya a la coalición.</string>
+    <string name="kao_banner_cta">Saber más</string>
+    <string name="kao_banner_dismiss_cd">Cerrar banner</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1122,4 +1122,8 @@
     <string name="saved_for_transfer_hint">Autre plateforme — s'ouvre dans le navigateur pour enregistrement et transfert</string>
     <string name="section_chip_your_device">Votre appareil</string>
     <string name="section_chip_for_transfer">Pour transfert</string>
+    <string name="kao_banner_title">Gardez Android ouvert</string>
+    <string name="kao_banner_body">La politique de vérification des développeurs de Google menace la distribution ouverte d'Android. GitHub Store soutient la coalition.</string>
+    <string name="kao_banner_cta">En savoir plus</string>
+    <string name="kao_banner_dismiss_cd">Fermer la bannière</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1160,4 +1160,8 @@
     <string name="saved_for_transfer_hint">अन्य प्लेटफ़ॉर्म — ट्रांसफ़र के लिए सहेजने हेतु ब्राउज़र में खुलता है</string>
     <string name="section_chip_your_device">आपका डिवाइस</string>
     <string name="section_chip_for_transfer">ट्रांसफ़र के लिए</string>
+    <string name="kao_banner_title">Android को खुला रखें</string>
+    <string name="kao_banner_body">Google की डेवलपर-सत्यापन नीति खुले Android वितरण को खतरे में डालती है। GitHub Store गठबंधन के साथ है।</string>
+    <string name="kao_banner_cta">और जानें</string>
+    <string name="kao_banner_dismiss_cd">बैनर बंद करें</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1161,4 +1161,8 @@
     <string name="saved_for_transfer_hint">Altra piattaforma — si apre nel browser per salvare e trasferire</string>
     <string name="section_chip_your_device">Il tuo dispositivo</string>
     <string name="section_chip_for_transfer">Da trasferire</string>
+    <string name="kao_banner_title">Mantieni Android aperto</string>
+    <string name="kao_banner_body">La policy di verifica degli sviluppatori di Google minaccia la distribuzione aperta di Android. GitHub Store sostiene la coalizione.</string>
+    <string name="kao_banner_cta">Scopri di più</string>
+    <string name="kao_banner_dismiss_cd">Chiudi banner</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1116,4 +1116,8 @@
     <string name="saved_for_transfer_hint">他のプラットフォーム — ブラウザで開き、転送用に保存します</string>
     <string name="section_chip_your_device">このデバイス</string>
     <string name="section_chip_for_transfer">転送用</string>
+    <string name="kao_banner_title">Android をオープンに</string>
+    <string name="kao_banner_body">Google の開発者検証ポリシーが Android のオープンな配布を脅かしています。GitHub Store は連合を支持します。</string>
+    <string name="kao_banner_cta">詳しく見る</string>
+    <string name="kao_banner_dismiss_cd">バナーを閉じる</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1151,4 +1151,8 @@
     <string name="saved_for_transfer_hint">다른 플랫폼 — 전송용 저장을 위해 브라우저에서 열립니다</string>
     <string name="section_chip_your_device">내 기기</string>
     <string name="section_chip_for_transfer">전송용</string>
+    <string name="kao_banner_title">Android를 열린 상태로</string>
+    <string name="kao_banner_body">Google의 개발자 인증 정책이 Android의 개방적인 배포를 위협합니다. GitHub Store는 연합을 지지합니다.</string>
+    <string name="kao_banner_cta">자세히 보기</string>
+    <string name="kao_banner_dismiss_cd">배너 닫기</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1142,4 +1142,8 @@
     <string name="saved_for_transfer_hint">Inna platforma — otwiera się w przeglądarce, aby zapisać do transferu</string>
     <string name="section_chip_your_device">Twoje urządzenie</string>
     <string name="section_chip_for_transfer">Do transferu</string>
+    <string name="kao_banner_title">Niech Android pozostanie otwarty</string>
+    <string name="kao_banner_body">Polityka weryfikacji deweloperów Google zagraża otwartej dystrybucji Androida. GitHub Store popiera koalicję.</string>
+    <string name="kao_banner_cta">Dowiedz się więcej</string>
+    <string name="kao_banner_dismiss_cd">Zamknij baner</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1142,4 +1142,8 @@
     <string name="saved_for_transfer_hint">Другая платформа — открывается в браузере для сохранения и переноса</string>
     <string name="section_chip_your_device">Это устройство</string>
     <string name="section_chip_for_transfer">Для переноса</string>
+    <string name="kao_banner_title">Сохраним Android открытым</string>
+    <string name="kao_banner_body">Политика верификации разработчиков Google угрожает открытому распространению Android. GitHub Store поддерживает коалицию.</string>
+    <string name="kao_banner_cta">Подробнее</string>
+    <string name="kao_banner_dismiss_cd">Закрыть баннер</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1158,4 +1158,8 @@
     <string name="saved_for_transfer_hint">Diğer platform — aktarma için kaydetmek üzere tarayıcıda açılır</string>
     <string name="section_chip_your_device">Cihazınız</string>
     <string name="section_chip_for_transfer">Aktarım için</string>
+    <string name="kao_banner_title">Android'i Açık Tutun</string>
+    <string name="kao_banner_body">Google'ın geliştirici doğrulama politikası açık Android dağıtımını tehdit ediyor. GitHub Store koalisyonu destekliyor.</string>
+    <string name="kao_banner_cta">Daha fazla bilgi</string>
+    <string name="kao_banner_dismiss_cd">Banner'ı kapat</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1118,4 +1118,8 @@
     <string name="saved_for_transfer_hint">其他平台 — 在浏览器中打开以保存并转移</string>
     <string name="section_chip_your_device">你的设备</string>
     <string name="section_chip_for_transfer">用于转移</string>
+    <string name="kao_banner_title">保持 Android 开放</string>
+    <string name="kao_banner_body">Google 的开发者验证政策威胁 Android 的开放分发。GitHub Store 与联盟同行。</string>
+    <string name="kao_banner_cta">了解更多</string>
+    <string name="kao_banner_dismiss_cd">关闭横幅</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1184,4 +1184,8 @@
     <string name="skipped_updates_unskip_action">Don't skip</string>
     <string name="skipped_updates_unskipped_snackbar">Update prompt enabled for %1$s</string>
     <string name="skipped_updates_unskip_failure">Couldn't update skip preference</string>
+    <string name="kao_banner_title">Keep Android Open</string>
+    <string name="kao_banner_body">Google's developer-verification policy threatens open Android distribution. GitHub Store stands with the coalition.</string>
+    <string name="kao_banner_cta">Learn more</string>
+    <string name="kao_banner_dismiss_cd">Dismiss banner</string>
 </resources>

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsAction.kt
@@ -118,6 +118,9 @@ sealed interface AppsAction {
     data object OnImportApps : AppsAction
     data object OnDismissImportSummary : AppsAction
 
+    data object OnDismissKaoBanner : AppsAction
+    data object OnKaoLearnMore : AppsAction
+
     /**
      * User tapped the "Install" affordance on a row whose download
      * was previously deferred (the user navigated away from Details

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsRoot.kt
@@ -98,6 +98,7 @@ import zed.rainxch.apps.presentation.components.CompactAppRow
 import zed.rainxch.apps.presentation.components.InstalledAppIcon
 import zed.rainxch.apps.presentation.components.LinkAppBottomSheet
 import zed.rainxch.apps.presentation.components.VariantPickerDialog
+import zed.rainxch.apps.presentation.components.KaoBanner
 import zed.rainxch.apps.presentation.import.components.ImportProposalBanner
 import zed.rainxch.apps.presentation.model.AppItem
 import zed.rainxch.apps.presentation.model.AppSortRule
@@ -672,6 +673,17 @@ fun AppsScreen(
                                                 pendingCount = state.pendingExternalImportCount,
                                                 onReview = { onAction(AppsAction.OnImportProposalReview) },
                                                 onDismiss = { onAction(AppsAction.OnImportProposalDismiss) },
+                                            )
+                                        }
+                                    }
+                                }
+
+                                if (state.showKaoBanner) {
+                                    item(key = "kao-banner") {
+                                        Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                                            KaoBanner(
+                                                onLearnMore = { onAction(AppsAction.OnKaoLearnMore) },
+                                                onDismiss = { onAction(AppsAction.OnDismissKaoBanner) },
                                             )
                                         }
                                     }

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsState.kt
@@ -88,6 +88,8 @@ data class AppsState(
     val pendingExternalImportCount: Int = 0,
     val showImportProposalBanner: Boolean = false,
     val isExternalImportInFlight: Boolean = false,
+    // Keep Android Open campaign banner
+    val showKaoBanner: Boolean = false,
 ) {
     val filteredDeviceApps: ImmutableList<DeviceAppUi>
         get() =

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import zed.rainxch.core.domain.util.AssetFilter
 import zed.rainxch.core.domain.util.AssetVariant
+import zed.rainxch.core.domain.utils.BrowserHelper
 import zed.rainxch.core.domain.utils.ShareManager
 import zed.rainxch.githubstore.core.presentation.res.*
 import java.io.File
@@ -63,10 +64,12 @@ class AppsViewModel(
     private val downloadOrchestrator: DownloadOrchestrator,
     private val externalImportRepository: ExternalImportRepository,
     private val systemInstallSerializer: SystemInstallSerializer,
+    private val browserHelper: BrowserHelper,
 ) : ViewModel() {
     companion object {
         private const val BANNER_THRESHOLD = 1
         private const val UPDATE_CHECK_COOLDOWN_MS = 30 * 60 * 1000L
+        private const val KAO_OPEN_LETTER_URL = "https://keepandroidopen.org/open-letter/"
     }
 
     private var hasLoadedInitialData = false
@@ -92,6 +95,7 @@ class AppsViewModel(
                 if (!hasLoadedInitialData) {
                     loadApps()
                     observePendingExternalImports()
+                    observeKaoBannerDismissed()
                     hasLoadedInitialData = true
                 }
             }.stateIn(
@@ -99,6 +103,14 @@ class AppsViewModel(
                 started = SharingStarted.WhileSubscribed(5_000L),
                 initialValue = AppsState(),
             )
+
+    private fun observeKaoBannerDismissed() {
+        viewModelScope.launch {
+            tweaksRepository.getKaoBannerDismissed().collect { dismissed ->
+                _state.update { it.copy(showKaoBanner = !dismissed) }
+            }
+        }
+    }
 
     private fun observePendingExternalImports() {
         viewModelScope.launch {
@@ -511,6 +523,18 @@ class AppsViewModel(
 
             AppsAction.OnDismissImportSummary -> {
                 _state.update { it.copy(importSummary = null) }
+            }
+
+            AppsAction.OnDismissKaoBanner -> {
+                viewModelScope.launch {
+                    tweaksRepository.setKaoBannerDismissed(true)
+                }
+            }
+
+            AppsAction.OnKaoLearnMore -> {
+                browserHelper.openUrl(KAO_OPEN_LETTER_URL) { error ->
+                    logger.warn("Failed to open KAO open letter: $error")
+                }
             }
 
             is AppsAction.OnUninstallConfirmed -> {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/KaoBanner.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/components/KaoBanner.kt
@@ -1,0 +1,96 @@
+package zed.rainxch.apps.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.kao_banner_body
+import zed.rainxch.githubstore.core.presentation.res.kao_banner_cta
+import zed.rainxch.githubstore.core.presentation.res.kao_banner_dismiss_cd
+import zed.rainxch.githubstore.core.presentation.res.kao_banner_title
+
+@Composable
+fun KaoBanner(
+    onLearnMore: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 12.dp, top = 4.dp, end = 4.dp, bottom = 8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Shield,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.size(24.dp).padding(top = 10.dp),
+                )
+
+                Spacer(Modifier.width(12.dp))
+
+                Column(
+                    modifier = Modifier.weight(1f).padding(top = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.kao_banner_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                    Text(
+                        text = stringResource(Res.string.kao_banner_body),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(Res.string.kao_banner_dismiss_cd),
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(end = 8.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onLearnMore) {
+                    Text(text = stringResource(Res.string.kao_banner_cta))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sprint 3 Task 6. Dismissable banner on Apps screen linking to keepandroidopen.org. Localised across 13 locales.

Wiring
- `TweaksRepository.getKaoBannerDismissed` / `setKaoBannerDismissed` (DataStore).
- `KaoBanner` composable, `OnDismissKaoBanner` + `OnKaoLearnMore` actions.
- `BrowserHelper` injected into `AppsViewModel` for CTA.

Test plan
- [x] Android + JVM compile clean
- [x] 13 locale strings + whatsnew
- [ ] Real-device: banner appears on Apps, CTA opens letter, dismiss persists

Source: Wave-2 survey #12 + KAO signatory status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Keep Android Open" banner to the Apps section
  * Banner includes a dismiss button and "Learn more" link
  * Banner dismissal state persists across app sessions

* **Documentation**
  * Updated release notes in multiple languages to highlight the new feature

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/601)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->