### PR TITLE
fix(nav): Desktop crash on SearchScreen enum nav arg

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -114,6 +114,13 @@ fun AppNavigation(
 
                 composable<GithubStoreGraph.SearchScreen> { backStackEntry ->
                     val args = backStackEntry.toRoute<GithubStoreGraph.SearchScreen>()
+                    val initialPlatform =
+                        args.initialPlatform?.let { name ->
+                            runCatching {
+                                zed.rainxch.search.presentation.model.SearchPlatformUi
+                                    .valueOf(name)
+                            }.getOrNull()
+                        }
                     SearchRoot(
                         onNavigateBack = {
                             navController.navigateUp()
@@ -142,7 +149,7 @@ fun AppNavigation(
                         },
                         viewModel =
                             koinViewModel {
-                                parametersOf(args.initialPlatform)
+                                parametersOf(initialPlatform)
                             },
                     )
                 }
@@ -170,7 +177,7 @@ fun AppNavigation(
                         onNavigateToSearchByPlatform = { platform ->
                             navController.navigate(
                                 GithubStoreGraph.SearchScreen(
-                                    initialPlatform = platform.toSearchPlatformUi(),
+                                    initialPlatform = platform.toSearchPlatformUi().name,
                                 ),
                             )
                         },

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -1,7 +1,6 @@
 package zed.rainxch.githubstore.app.navigation
 
 import kotlinx.serialization.Serializable
-import zed.rainxch.search.presentation.model.SearchPlatformUi
 
 @Serializable
 sealed interface GithubStoreGraph {
@@ -10,7 +9,12 @@ sealed interface GithubStoreGraph {
 
     @Serializable
     data class SearchScreen(
-        val initialPlatform: SearchPlatformUi? = null,
+        // String over enum: Compose Navigation's Desktop (`nonAndroid.kt`)
+        // serializer needs an explicit NavType for non-primitive nav args,
+        // which enums don't have out of the box. Enum-as-name string keeps
+        // the contract type-safe at the caller / VM boundary while letting
+        // the route serialize on every target with no typeMap.
+        val initialPlatform: String? = null,
     ) : GithubStoreGraph
 
     @Serializable


### PR DESCRIPTION
Hotfix. Regression from #597 (Task 12 platform chips). `SearchScreen(val initialPlatform: SearchPlatformUi? = null)` works on Android but crashes Desktop:

\`\`\`
IllegalArgumentException: Route ...SearchScreen could not find any NavType
for argument initialPlatform of type SearchPlatformUi? - typeMap received was {}
  at RouteSerializerKt.forEachIndexedKType (RouteSerializer.kt:190)
  at NavDestinationBuilder.<init> (nonAndroid.kt:49)
\`\`\`

Compose Navigation's non-Android serializer has no built-in NavType for enums. Cheapest fix: switch nav arg to `String?` (enum name), convert at `composable<>` boundary via `SearchPlatformUi.valueOf(name)`.

Test plan
- [x] Android + JVM compile clean
- [ ] Real device: Desktop launches without crash; platform chip on Details still opens filtered Search

Source: user-reported crash on desktop launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and compatibility of the search screen's platform selection across different platforms by refining how platform information is passed through navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/606)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->