### PR TITLE
fix(markdown): widen details regex + pad fence with blank lines

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -434,24 +434,29 @@ fun preprocessMarkdown(
             Regex("""</p>""", RegexOption.IGNORE_CASE),
             "\n",
         )
-    // <details><summary>X</summary>BODY</details> → fenced code block
-    // with `ghs-details` info string. Summary text is base64-encoded
-    // after a `|` so it survives markdown whitespace + special chars.
-    // Custom codeFence slot recognises the lang prefix and renders an
-    // ExpandableSection. Falls through to default fence rendering when
-    // the lib's parser doesn't reach our custom slot for any reason
-    // (degraded but never broken).
+    // <details>…<summary>X</summary>BODY</details> → fenced code block
+    // with `ghs-details` info string. Summary text is %-encoded after a
+    // `|` so it survives markdown whitespace + special chars. Custom
+    // codeFence slot recognises the lang prefix and renders an
+    // ExpandableDetails card.
+    //
+    // Gap between `<details>` and `<summary>` is permissive (`.*?`) —
+    // earlier passes have already stripped `<div>` / `<p>` into newlines
+    // but may have left trailing whitespace or stray text in between.
+    // Padding with blank lines around the fence is required so the
+    // intellij-markdown parser recognises it as a real fenced block
+    // rather than inline text.
     processed =
         processed.replace(
             Regex(
-                """<details[^>]*?>\s*<summary[^>]*?>(.*?)</summary>(.*?)</details>""",
+                """<details\b[^>]*?>.*?<summary[^>]*?>(.*?)</summary>(.*?)</details>""",
                 setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
             ),
         ) { match ->
             val summary = match.groupValues[1].trim()
             val body = match.groupValues[2].trim()
             val encodedSummary = encodeDetailsSummary(summary)
-            "\n```ghs-details|$encodedSummary\n$body\n```\n"
+            "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
         }
     // Handle bare/stripped <details> without inner <summary> — keep
     // contents as plain markdown.


### PR DESCRIPTION
Details collapsible from PR #621 only matched when \`<details>\` and \`<summary>\` had nothing but whitespace between them. Many READMEs (incl. gkd.li-style) put markup or text in between (newlines plus stripped \`<div>\` remnants from earlier passes), so the regex skipped them and the fallback \`<summary>\` → \`**bold**\` ran instead — summary turned into a bold heading and body rendered inline expanded.

Fix:
- Gap between tags widened from \`\s*\` to \`.*?\` with DOT_MATCHES_ALL so anything in between matches lazily.
- Output padded with \`\n\n\` before and after the fence so intellij-markdown's parser sees a proper block fence, not inline backticks.

Test plan
- [x] Compile clean
- [ ] Device: open gkd.li-style README — verify \`<details>\` renders as collapsed tap-to-expand card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of collapsible content blocks in markdown to ensure consistent and reliable rendering.

* **Refactor**
  * Enhanced pattern matching and output formatting for collapsible content elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->