### PR TITLE
fix(markdown): inline details inside table cells stay one-line

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -455,8 +455,22 @@ fun preprocessMarkdown(
         ) { match ->
             val summary = match.groupValues[1].trim()
             val body = match.groupValues[2].trim()
-            val encodedSummary = encodeDetailsSummary(summary)
-            "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
+            // Inline details (entire match on one line) usually sits
+            // inside a GFM table cell. A multi-line fenced block there
+            // would terminate the table mid-row. Fall back to a flat
+            // `**summary**: body` rendering that stays on one line.
+            val isInline = !match.value.contains('\n')
+            if (isInline) {
+                when {
+                    summary.isEmpty() && body.isEmpty() -> ""
+                    body.isEmpty() -> "**$summary**"
+                    summary.isEmpty() -> body
+                    else -> "**$summary**: $body"
+                }
+            } else {
+                val encodedSummary = encodeDetailsSummary(summary)
+                "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
+            }
         }
     // Handle bare/stripped <details> without inner <summary> — keep
     // contents as plain markdown.


### PR DESCRIPTION
\`<details>\` inside a GFM table cell (kavishdevar/librepods README pattern) was emitted as a multi-line fenced code block, which terminates the table mid-row. Result: cells from that row onward render as raw pipe-separated text.

Fix: detect inline match (entire \`<details>...</details>\` on one line) and emit \`**summary**: body\` instead — flat single-line replacement that keeps the table parser happy. Multi-line matches still go through the fenced \`ghs-details\` path for ExpandableDetails rendering.

Test plan
- [x] Compile clean
- [ ] Device: open kavishdevar/librepods README — feature-availability table renders end-to-end. \"Note for Android\" details cell shows as bold + body inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Content rendering now intelligently handles inline and multiline detail blocks differently—inline details display as clean, single-line formatted text instead of code blocks, improving readability and reducing visual clutter
  * Multiline detail blocks continue with existing rendering behavior to maintain consistent formatting and proper content structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->