### PR TITLE
fix(markdown): flatten multi-line details inside table cells

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -455,17 +455,24 @@ fun preprocessMarkdown(
         ) { match ->
             val summary = match.groupValues[1].trim()
             val body = match.groupValues[2].trim()
-            // Inline details (entire match on one line) usually sits
-            // inside a GFM table cell. A multi-line fenced block there
-            // would terminate the table mid-row. Fall back to a flat
-            // `**summary**: body` rendering that stays on one line.
+            // Details inside a GFM table cell would break the table if
+            // emitted as a multi-line fenced block. Detect two ways:
+            //   1. Entire match on one line (typical inline case).
+            //   2. Start of <details> sits on a line that already has
+            //      a `|` before it (multi-line cells some authors write).
             val isInline = !match.value.contains('\n')
-            if (isInline) {
+            val lineStart = processed.lastIndexOf('\n', match.range.first) + 1
+            val linePrefix = processed.substring(lineStart, match.range.first)
+            val isInTableCell = linePrefix.contains('|')
+            val mustFlatten = isInline || isInTableCell
+
+            if (mustFlatten) {
+                val flatBody = body.replace(Regex("""\s+"""), " ")
                 when {
-                    summary.isEmpty() && body.isEmpty() -> ""
-                    body.isEmpty() -> "**$summary**"
-                    summary.isEmpty() -> body
-                    else -> "**$summary**: $body"
+                    summary.isEmpty() && flatBody.isEmpty() -> ""
+                    flatBody.isEmpty() -> "**$summary**"
+                    summary.isEmpty() -> flatBody
+                    else -> "**$summary**: $flatBody"
                 }
             } else {
                 val encodedSummary = encodeDetailsSummary(summary)


### PR DESCRIPTION
PR #623's inline check (\`!match.value.contains('\n')\`) missed the common case where authors split \`<details>\` across source lines inside a table cell:

\`\`\`
| Renaming AirPods<details>
<summary>Note for Android</summary>
On Android, you need to re-pair...
</details> | ✅ | ✅ |
\`\`\`

Match contains newlines → old logic emitted multi-line fence → table still broke.

Fix: also detect by context — if the line containing the start of \`<details>\` has a \`|\` before it, we're inside a GFM table cell. Either condition (inline OR table-cell-context) triggers the flatten path: collapse body whitespace to single spaces, emit \`**summary**: body\` on one line.

Test plan
- [x] Compile clean
- [ ] Device: re-render kavishdevar/librepods README — feature-availability table parses end-to-end, all rows visible, Renaming AirPods cell shows bold \"Note for Android\" inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of details and summary elements in Markdown content. Details now render correctly in inline contexts and within table cells, with enhanced whitespace normalization for better consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->