### PR TITLE
fix(markdown): run details normalization before HTML-to-newline passes

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -189,6 +189,49 @@ fun preprocessMarkdown(
         }
 
     // ========================================================================
+    // Phase 0.5: <details>/<summary> normalisation
+    // ========================================================================
+    // Must run BEFORE Phase 1 — once `<br>` → `\n` and `<div>` → `\n\n`
+    // pass over a table cell, the row gets split and our context check
+    // (`linePrefix.contains('|')`) below would no longer see the pipe.
+    // Inline / table-cell details flatten to one line; standalone block
+    // details emit a fenced `ghs-details` block for ExpandableDetails.
+    processed =
+        processed.replace(
+            Regex(
+                """<details\b[^>]*?>.*?<summary[^>]*?>(.*?)</summary>(.*?)</details>""",
+                setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+            ),
+        ) { match ->
+            val summary = match.groupValues[1].trim()
+            val body = match.groupValues[2].trim()
+            val isInline = !match.value.contains('\n')
+            val lineStart = processed.lastIndexOf('\n', match.range.first) + 1
+            val linePrefix = processed.substring(lineStart, match.range.first)
+            val isInTableCell = linePrefix.contains('|')
+            val mustFlatten = isInline || isInTableCell
+
+            if (mustFlatten) {
+                // Collapse any whitespace (incl. embedded HTML tags
+                // that would otherwise expand to newlines) to single
+                // spaces so the result stays on one source line.
+                val flatBody = body
+                    .replace(Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE), " ")
+                    .replace(Regex("""\s+"""), " ")
+                    .trim()
+                when {
+                    summary.isEmpty() && flatBody.isEmpty() -> ""
+                    flatBody.isEmpty() -> "**$summary**"
+                    summary.isEmpty() -> flatBody
+                    else -> "**$summary**: $flatBody"
+                }
+            } else {
+                val encodedSummary = encodeDetailsSummary(summary)
+                "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
+            }
+        }
+
+    // ========================================================================
     // Phase 1: HTML → Markdown conversions
     // ========================================================================
 
@@ -434,51 +477,6 @@ fun preprocessMarkdown(
             Regex("""</p>""", RegexOption.IGNORE_CASE),
             "\n",
         )
-    // <details>…<summary>X</summary>BODY</details> → fenced code block
-    // with `ghs-details` info string. Summary text is %-encoded after a
-    // `|` so it survives markdown whitespace + special chars. Custom
-    // codeFence slot recognises the lang prefix and renders an
-    // ExpandableDetails card.
-    //
-    // Gap between `<details>` and `<summary>` is permissive (`.*?`) —
-    // earlier passes have already stripped `<div>` / `<p>` into newlines
-    // but may have left trailing whitespace or stray text in between.
-    // Padding with blank lines around the fence is required so the
-    // intellij-markdown parser recognises it as a real fenced block
-    // rather than inline text.
-    processed =
-        processed.replace(
-            Regex(
-                """<details\b[^>]*?>.*?<summary[^>]*?>(.*?)</summary>(.*?)</details>""",
-                setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
-            ),
-        ) { match ->
-            val summary = match.groupValues[1].trim()
-            val body = match.groupValues[2].trim()
-            // Details inside a GFM table cell would break the table if
-            // emitted as a multi-line fenced block. Detect two ways:
-            //   1. Entire match on one line (typical inline case).
-            //   2. Start of <details> sits on a line that already has
-            //      a `|` before it (multi-line cells some authors write).
-            val isInline = !match.value.contains('\n')
-            val lineStart = processed.lastIndexOf('\n', match.range.first) + 1
-            val linePrefix = processed.substring(lineStart, match.range.first)
-            val isInTableCell = linePrefix.contains('|')
-            val mustFlatten = isInline || isInTableCell
-
-            if (mustFlatten) {
-                val flatBody = body.replace(Regex("""\s+"""), " ")
-                when {
-                    summary.isEmpty() && flatBody.isEmpty() -> ""
-                    flatBody.isEmpty() -> "**$summary**"
-                    summary.isEmpty() -> flatBody
-                    else -> "**$summary**: $flatBody"
-                }
-            } else {
-                val encodedSummary = encodeDetailsSummary(summary)
-                "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
-            }
-        }
     // Handle bare/stripped <details> without inner <summary> — keep
     // contents as plain markdown.
     processed =


### PR DESCRIPTION
PR #624 still missed librepods because the \`<br>\` → \`\n\` and \`<div>\` → \`\n\n\` passes ran BEFORE the details handler. They split table rows mid-cell, so by the time details ran, the line containing \`<details>\` no longer had a \`|\` before it → table-cell context check failed → multi-line fence emitted → table broken.

Fix: move the entire \`<details>\` detect-and-flatten step into a new Phase 0.5, right after reference-link resolution and before any HTML→newline conversion. Also strip embedded \`<br>\` from the body during flatten so they don't reintroduce newlines after collapse.

Test plan
- [x] Compile clean
- [ ] Device: librepods README — feature-availability table renders end-to-end (all rows), \"Renaming AirPods\" cell has bold inline \"Note for Android\" prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized markdown processing for collapsible content blocks to improve formatting consistency.
  * Enhanced handling of collapsible elements in inline contexts and table cells.
  * Improved whitespace normalization for nested content within collapsible blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->