### PR TITLE
fix(markdown): release-notes details + bust stale readme cache

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -378,10 +378,6 @@ class DetailsRepositoryImpl(
         defaultBranch: String,
     ): String? =
         body
-            ?.replace("<details>", "")
-            ?.replace("</details>", "")
-            ?.replace("<summary>", "")
-            ?.replace("</summary>", "")
             ?.replace("\r\n", "\n")
             ?.let { rawMarkdown ->
                 preprocessMarkdown(
@@ -395,7 +391,11 @@ class DetailsRepositoryImpl(
         repo: String,
         defaultBranch: String,
     ): Triple<String, String?, String>? {
-        val cacheKey = "details:readme:$owner/$repo"
+        // v2 — bumped after markdown preprocessor overhaul (alerts,
+        // emoji, details, image-row). Forces re-fetch so users get a
+        // properly-processed readme instead of waiting for the stale
+        // v1 entry to expire.
+        val cacheKey = "details:readme:v2:$owner/$repo"
 
         cacheManager.get<CachedReadme>(cacheKey)?.let { cached ->
             logger.debug("Cache hit for readme $owner/$repo")


### PR DESCRIPTION
Two follow-ups to the markdown preprocessor PRs:

1. \`processReleaseBody\` was stripping \`<details>\`, \`</details>\`, \`<summary>\`, \`</summary>\` to bare text BEFORE calling \`preprocessMarkdown\` — pre-empting my new details handler. Release-notes (WhatsNew section) couldn't render collapsibles or detect them inside table cells. Strip removed; let preprocessMarkdown own the conversion.

2. README cache key bumped \`details:readme:\` → \`details:readme:v2:\`. Users running pre-#625 builds have cached READMEs with stale broken-table output. Bumping the key forces a re-fetch on next view so the new preprocessor output replaces the cached one without waiting for natural TTL.

Test plan
- [x] Compile clean
- [ ] Device: open librepods README (cached) — table renders end-to-end after cache busts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved README and release note rendering with enhanced markdown processing and consistent line break handling.
  * Updated cache strategy to refresh previously cached README content for all users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->