### PR TITLE
fix(markdown): details body with nested code fences

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -395,7 +395,7 @@ class DetailsRepositoryImpl(
         // emoji, details, image-row). Forces re-fetch so users get a
         // properly-processed readme instead of waiting for the stale
         // v1 entry to expire.
-        val cacheKey = "details:readme:v3:$owner/$repo"
+        val cacheKey = "details:readme:v4:$owner/$repo"
 
         cacheManager.get<CachedReadme>(cacheKey)?.let { cached ->
             logger.debug("Cache hit for readme $owner/$repo")

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -395,7 +395,7 @@ class DetailsRepositoryImpl(
         // emoji, details, image-row). Forces re-fetch so users get a
         // properly-processed readme instead of waiting for the stale
         // v1 entry to expire.
-        val cacheKey = "details:readme:v2:$owner/$repo"
+        val cacheKey = "details:readme:v3:$owner/$repo"
 
         cacheManager.get<CachedReadme>(cacheKey)?.let { cached ->
             logger.debug("Cache hit for readme $owner/$repo")

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -227,7 +227,13 @@ fun preprocessMarkdown(
                 }
             } else {
                 val encodedSummary = encodeDetailsSummary(summary)
-                "\n\n```ghs-details|$encodedSummary\n$body\n```\n\n"
+                // Body may contain its own ```fenced``` code blocks. Pick a
+                // fence delimiter at least one backtick longer than the
+                // longest run inside the body so nested fences don't
+                // terminate our wrapper early.
+                val longestRun = longestBacktickRun(body)
+                val fence = "`".repeat(maxOf(4, longestRun + 1))
+                "\n\n${fence}ghs-details|$encodedSummary\n$body\n$fence\n\n"
             }
         }
 
@@ -581,6 +587,20 @@ fun preprocessMarkdown(
     processed = joinAdjacentImageLines(processed)
 
     return processed.trim()
+}
+
+private fun longestBacktickRun(text: String): Int {
+    var max = 0
+    var current = 0
+    for (c in text) {
+        if (c == '`') {
+            current++
+            if (current > max) max = current
+        } else {
+            current = 0
+        }
+    }
+    return max
 }
 
 private fun encodeDetailsSummary(text: String): String {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/ExpandableDetails.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/ExpandableDetails.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.isSystemInDarkTheme
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.model.ImageTransformer
@@ -85,6 +86,7 @@ fun ExpandableDetails(
                 )
             }
             AnimatedVisibility(visible = expanded) {
+                val isDark = isSystemInDarkTheme()
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -96,6 +98,7 @@ fun ExpandableDetails(
                         typography = rememberMarkdownTypography(),
                         flavour = GFMFlavourDescriptor(),
                         imageTransformer = imageTransformer,
+                        components = githubStoreMarkdownComponents(imageTransformer, isDark),
                         modifier = Modifier.fillMaxWidth(),
                     )
                     Spacer(Modifier.width(0.dp))
@@ -126,20 +129,16 @@ private fun decodeDetailsSummary(encoded: String): String {
 }
 
 private fun extractFenceBody(model: MarkdownComponentModel): String {
+    // Slice the original source between the first and last
+    // CODE_FENCE_CONTENT child. Iterating child-by-child and
+    // re-inserting newlines double-counts (prepend on content + EOL
+    // token), producing a blank line between every body line — which
+    // breaks GFM tables, lists, and any block that needs contiguous
+    // source lines.
     val content = model.content
-    val body = StringBuilder()
-    var sawContent = false
-    model.node.children.forEach { child ->
-        when (child.type) {
-            MarkdownTokenTypes.CODE_FENCE_CONTENT -> {
-                if (sawContent) body.append('\n')
-                body.append(content.substring(child.startOffset, child.endOffset))
-                sawContent = true
-            }
-
-            MarkdownTokenTypes.EOL -> if (sawContent) body.append('\n')
-            else -> Unit
-        }
-    }
-    return body.toString().trim()
+    val contentNodes = model.node.children.filter { it.type == MarkdownTokenTypes.CODE_FENCE_CONTENT }
+    if (contentNodes.isEmpty()) return ""
+    val start = contentNodes.first().startOffset
+    val end = contentNodes.last().endOffset
+    return content.substring(start, end).trim()
 }


### PR DESCRIPTION
## Summary
GHS README's "Show full setup guide" `<details>` contained a ```properties code fence. The inner ``` terminated our 3-backtick `ghs-details` wrapper early, so body content leaked outside the collapsible and remainder of README rendered monospace.

Fix: size the wrapper fence to `max(4, longestRun + 1)` of backticks in body. Nested fences no longer close it. Bumps readme cache key v2→v3 to invalidate stale entries.

## Test plan
- [ ] Open GHS repo Details → README → collapsed details shows nothing else below; expand → renders OAuth setup steps + table + code block correctly.
- [ ] Content after `</details>` (Wiki & Resources section) renders as normal markdown, not monospace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme-aware Markdown rendering for expandable details (respects dark/light theme)

* **Bug Fixes**
  * README content is now refreshed to display the latest information
  * Improved handling and rendering of collapsible Markdown sections that contain fenced code blocks to prevent premature termination and preserve formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->