### PR TITLE
feat(auth): per-host PAT storage encrypted via KSafe

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -21,6 +21,7 @@ import zed.rainxch.starred.presentation.StarredReposViewModel
 import zed.rainxch.tweaks.presentation.TweaksViewModel
 import zed.rainxch.tweaks.presentation.feedback.FeedbackViewModel
 import zed.rainxch.tweaks.presentation.hidden.HiddenRepositoriesViewModel
+import zed.rainxch.tweaks.presentation.hosttokens.HostTokensViewModel
 import zed.rainxch.tweaks.presentation.mirror.AutoSuggestMirrorViewModel
 import zed.rainxch.tweaks.presentation.mirror.MirrorPickerViewModel
 import zed.rainxch.tweaks.presentation.skipped.SkippedUpdatesViewModel
@@ -98,6 +99,7 @@ val viewModelsModule =
         viewModelOf(::AutoSuggestMirrorViewModel)
         viewModelOf(::SkippedUpdatesViewModel)
         viewModelOf(::HiddenRepositoriesViewModel)
+        viewModelOf(::HostTokensViewModel)
         viewModelOf(::WhatsNewViewModel)
         viewModelOf(::AnnouncementsViewModel)
         viewModel {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -48,6 +48,7 @@ import zed.rainxch.search.presentation.mappers.toSearchPlatformUi
 import zed.rainxch.starred.presentation.StarredReposRoot
 import zed.rainxch.tweaks.presentation.TweaksRoot
 import zed.rainxch.tweaks.presentation.hidden.HiddenRepositoriesRoot
+import zed.rainxch.tweaks.presentation.hosttokens.HostTokensRoot
 import zed.rainxch.tweaks.presentation.mirror.AutoSuggestMirrorViewModel
 import zed.rainxch.tweaks.presentation.mirror.MirrorPickerRoot
 import zed.rainxch.tweaks.presentation.mirror.components.AutoSuggestMirrorSheet
@@ -408,6 +409,11 @@ fun AppNavigation(
                                 launchSingleTop = true
                             }
                         },
+                        onNavigateToHostTokens = {
+                            navController.navigate(GithubStoreGraph.HostTokensScreen) {
+                                launchSingleTop = true
+                            }
+                        },
                     )
                 }
 
@@ -419,6 +425,12 @@ fun AppNavigation(
 
                 composable<GithubStoreGraph.HiddenRepositoriesScreen> {
                     HiddenRepositoriesRoot(
+                        onNavigateBack = { navController.popBackStack() },
+                    )
+                }
+
+                composable<GithubStoreGraph.HostTokensScreen> {
+                    HostTokensRoot(
                         onNavigateBack = { navController.popBackStack() },
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -74,4 +74,7 @@ sealed interface GithubStoreGraph {
 
     @Serializable
     data object StarredPickerScreen : GithubStoreGraph
+
+    @Serializable
+    data object HostTokensScreen : GithubStoreGraph
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -402,6 +402,13 @@ val networkModule =
             RateLimitRepositoryImpl()
         }
 
+        single<zed.rainxch.core.domain.repository.HostTokenRepository> {
+            zed.rainxch.core.data.repository.HostTokenRepositoryImpl(
+                ksafe = get(qualifier = org.koin.core.qualifier.named("tokens")),
+                httpClient = get(qualifier = org.koin.core.qualifier.named("test")),
+            )
+        }
+
         single<HttpClient>(qualifier = named("test")) {
             createPlatformHttpClient(ProxyConfig.System).config {
                 install(HttpTimeout) {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
@@ -2,6 +2,7 @@ package zed.rainxch.core.data.download
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -14,6 +15,7 @@ import zed.rainxch.core.domain.model.TrafficKind
 import zed.rainxch.core.domain.network.Downloader
 import zed.rainxch.core.domain.system.MultiSourceDownloader
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MultiSourceDownloaderImpl(
     private val downloader: Downloader,
 ) : MultiSourceDownloader {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
@@ -16,7 +16,11 @@ val HostTokenInterceptor = createClientPlugin("HostTokenInterceptor", ::HostToke
     onRequest { request, _ ->
         val existing = request.headers[HttpHeaders.Authorization]
         if (!existing.isNullOrBlank()) return@onRequest
-        val host = HostNames.normalize(request.url.host)
+        // `api.github.com` requests must map back to the `github.com`
+        // storage key, otherwise the PAT is never attached. Forgejo /
+        // Codeberg / Gitea APIs share the host with storage, so the
+        // mapping is a no-op for them.
+        val host = HostNames.apiHostToTokenHost(request.url.host)
         if (host.isBlank()) return@onRequest
         val token = try {
             repo.get(host)?.token

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
@@ -1,0 +1,33 @@
+package zed.rainxch.core.data.network.interceptor
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.runBlocking
+import zed.rainxch.core.domain.model.HostNames
+import zed.rainxch.core.domain.repository.HostTokenRepository
+
+/**
+ * Attaches `Authorization: Bearer <token>` from [HostTokenRepository]
+ * to outgoing requests whose URL host has a stored token.
+ *
+ * Skips when an `Authorization` header already present (so other auth
+ * paths like OAuth's TokenStore still win for github.com).
+ */
+class HostTokenInterceptorConfig {
+    lateinit var repository: HostTokenRepository
+}
+
+val HostTokenInterceptor = createClientPlugin("HostTokenInterceptor", ::HostTokenInterceptorConfig) {
+    val repo = pluginConfig.repository
+    onRequest { request, _ ->
+        val existing = request.headers[HttpHeaders.Authorization]
+        if (!existing.isNullOrBlank()) return@onRequest
+        val host = HostNames.normalize(request.url.host)
+        if (host.isBlank()) return@onRequest
+        val token = runCatching { runBlocking { repo.get(host)?.token } }.getOrNull()
+        if (!token.isNullOrBlank()) {
+            request.header(HttpHeaders.Authorization, "Bearer $token")
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/interceptor/HostTokenInterceptor.kt
@@ -3,17 +3,10 @@ package zed.rainxch.core.data.network.interceptor
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
-import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.cancellation.CancellationException
 import zed.rainxch.core.domain.model.HostNames
 import zed.rainxch.core.domain.repository.HostTokenRepository
 
-/**
- * Attaches `Authorization: Bearer <token>` from [HostTokenRepository]
- * to outgoing requests whose URL host has a stored token.
- *
- * Skips when an `Authorization` header already present (so other auth
- * paths like OAuth's TokenStore still win for github.com).
- */
 class HostTokenInterceptorConfig {
     lateinit var repository: HostTokenRepository
 }
@@ -25,7 +18,13 @@ val HostTokenInterceptor = createClientPlugin("HostTokenInterceptor", ::HostToke
         if (!existing.isNullOrBlank()) return@onRequest
         val host = HostNames.normalize(request.url.host)
         if (host.isBlank()) return@onRequest
-        val token = runCatching { runBlocking { repo.get(host)?.token } }.getOrNull()
+        val token = try {
+            repo.get(host)?.token
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (_: Throwable) {
+            null
+        }
         if (!token.isNullOrBlank()) {
             request.header(HttpHeaders.Authorization, "Bearer $token")
         }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HostTokenRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HostTokenRepositoryImpl.kt
@@ -1,0 +1,147 @@
+package zed.rainxch.core.data.repository
+
+import eu.anifantakis.lib.ksafe.KSafe
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+import zed.rainxch.core.domain.model.HostNames
+import zed.rainxch.core.domain.model.HostToken
+import zed.rainxch.core.domain.repository.HostTokenRepository
+import zed.rainxch.core.domain.repository.TokenValidation
+
+class HostTokenRepositoryImpl(
+    private val ksafe: KSafe,
+    private val httpClient: HttpClient,
+) : HostTokenRepository {
+
+    private val rmwLock = Mutex()
+    private val cache = MutableStateFlow<List<HostToken>>(emptyList())
+    private val loadOnce = Mutex()
+
+    @Volatile private var loaded = false
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun observeAll(): Flow<List<HostToken>> = cache.asStateFlow()
+
+    override suspend fun get(host: String): HostToken? {
+        ensureLoaded()
+        val key = HostNames.normalize(host)
+        return cache.value.firstOrNull { it.host == key }
+    }
+
+    override suspend fun set(host: String, token: String, displayName: String?) {
+        val key = HostNames.normalize(host)
+        if (key.isBlank() || token.isBlank()) return
+        rmwLock.withLock {
+            ensureLoadedLocked()
+            val now = Clock.System.now().toEpochMilliseconds()
+            val updated = HostToken(
+                host = key,
+                token = token,
+                displayName = displayName?.trim()?.takeIf { it.isNotEmpty() },
+                createdAtEpochMillis = now,
+            )
+            val next = cache.value.filterNot { it.host == key } + updated
+            persist(next)
+        }
+    }
+
+    override suspend fun delete(host: String) {
+        val key = HostNames.normalize(host)
+        rmwLock.withLock {
+            ensureLoadedLocked()
+            val before = cache.value
+            val after = before.filterNot { it.host == key }
+            if (after.size == before.size) return@withLock
+            persist(after)
+        }
+    }
+
+    override suspend fun validate(host: String, token: String): Result<TokenValidation> {
+        val key = HostNames.normalize(host)
+        if (key.isBlank()) return Result.failure(IllegalArgumentException("blank host"))
+        return runCatching {
+            val response = httpClient.get(buildUserUrl(key)) {
+                accept(ContentType.Application.Json)
+                header(HttpHeaders.Authorization, "Bearer $token")
+                header(HttpHeaders.UserAgent, "GithubStore/1.0 (host-token-validate)")
+            }
+            mapValidation(response)
+        }.recoverCatching { t ->
+            if (t is CancellationException) throw t
+            throw t
+        }
+    }
+
+    private fun buildUserUrl(host: String): String =
+        when (host) {
+            HostNames.GITHUB -> "https://api.github.com/user"
+            else -> "https://$host/api/v1/user"
+        }
+
+    private suspend fun mapValidation(response: HttpResponse): TokenValidation {
+        val status = response.status
+        if (status.value !in 200..299) {
+            val body = runCatching { response.bodyAsText() }.getOrDefault("")
+            error("HTTP ${status.value} ${status.description}: ${body.take(200)}")
+        }
+        val login = runCatching {
+            val text = response.bodyAsText()
+            val pattern = Regex("\"login\"\\s*:\\s*\"([^\"]+)\"")
+            pattern.find(text)?.groupValues?.getOrNull(1)
+        }.getOrNull()
+        val scopesHeader = response.headers["X-OAuth-Scopes"].orEmpty()
+        val scopes = if (scopesHeader.isBlank()) emptyList() else
+            scopesHeader.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        val remaining = response.headers["X-RateLimit-Remaining"]?.toIntOrNull()
+        return TokenValidation(login = login, scopes = scopes, rateLimitRemaining = remaining)
+    }
+
+    private suspend fun ensureLoaded() {
+        if (loaded) return
+        loadOnce.withLock {
+            if (loaded) return
+            ensureLoadedLocked()
+        }
+    }
+
+    private suspend fun ensureLoadedLocked() {
+        if (loaded) return
+        val raw = runCatching { ksafe.get(KEY_TOKENS_JSON, "") }.getOrDefault("")
+        val list = if (raw.isBlank()) emptyList() else
+            runCatching { json.decodeFromString(ListSerializer(HostToken.serializer()), raw) }
+                .getOrDefault(emptyList())
+        cache.value = list
+        loaded = true
+    }
+
+    private suspend fun persist(list: List<HostToken>) {
+        cache.value = list
+        val encoded = json.encodeToString(ListSerializer(HostToken.serializer()), list)
+        runCatching { ksafe.put(KEY_TOKENS_JSON, encoded) }
+    }
+
+    private companion object {
+        const val KEY_TOKENS_JSON = "host_tokens_v1"
+        // String.serializer kept to silence unused-import warning if file lifts to plain key list.
+        @Suppress("unused")
+        private val stringSerializer = String.serializer()
+    }
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HostTokenRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/HostTokenRepositoryImpl.kt
@@ -9,15 +9,18 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 import zed.rainxch.core.domain.model.HostNames
@@ -30,6 +33,7 @@ class HostTokenRepositoryImpl(
     private val httpClient: HttpClient,
 ) : HostTokenRepository {
 
+    private val initScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val rmwLock = Mutex()
     private val cache = MutableStateFlow<List<HostToken>>(emptyList())
     private val loadOnce = Mutex()
@@ -38,7 +42,18 @@ class HostTokenRepositoryImpl(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    override fun observeAll(): Flow<List<HostToken>> = cache.asStateFlow()
+    init {
+        // Kick off the initial KSafe read so the first collector of
+        // `observeAll()` already sees the persisted list rather than an
+        // empty value emitted from a fresh `MutableStateFlow`.
+        initScope.launch { runCatching { ensureLoaded() } }
+    }
+
+    // `onStart` guarantees the load runs before the first emission, so
+    // collectors that subscribe before `init { … }` lands still get the
+    // persisted list as their initial value.
+    override fun observeAll(): Flow<List<HostToken>> =
+        cache.asStateFlow().onStart { ensureLoaded() }
 
     override suspend fun get(host: String): HostToken? {
         ensureLoaded()
@@ -59,7 +74,7 @@ class HostTokenRepositoryImpl(
                 createdAtEpochMillis = now,
             )
             val next = cache.value.filterNot { it.host == key } + updated
-            persist(next)
+            persistOrThrow(next)
         }
     }
 
@@ -70,23 +85,24 @@ class HostTokenRepositoryImpl(
             val before = cache.value
             val after = before.filterNot { it.host == key }
             if (after.size == before.size) return@withLock
-            persist(after)
+            persistOrThrow(after)
         }
     }
 
     override suspend fun validate(host: String, token: String): Result<TokenValidation> {
         val key = HostNames.normalize(host)
         if (key.isBlank()) return Result.failure(IllegalArgumentException("blank host"))
-        return runCatching {
+        return try {
             val response = httpClient.get(buildUserUrl(key)) {
                 accept(ContentType.Application.Json)
                 header(HttpHeaders.Authorization, "Bearer $token")
                 header(HttpHeaders.UserAgent, "GithubStore/1.0 (host-token-validate)")
             }
-            mapValidation(response)
-        }.recoverCatching { t ->
-            if (t is CancellationException) throw t
-            throw t
+            Result.success(mapValidation(response))
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            Result.failure(t)
         }
     }
 
@@ -132,16 +148,25 @@ class HostTokenRepositoryImpl(
         loaded = true
     }
 
-    private suspend fun persist(list: List<HostToken>) {
-        cache.value = list
+    // Persists then promotes the in-memory cache. If KSafe write fails,
+    // the in-memory value is rolled back and the exception is thrown so
+    // the caller can surface the failure to the UI instead of pretending
+    // the save succeeded.
+    private suspend fun persistOrThrow(list: List<HostToken>) {
+        val previous = cache.value
         val encoded = json.encodeToString(ListSerializer(HostToken.serializer()), list)
-        runCatching { ksafe.put(KEY_TOKENS_JSON, encoded) }
+        try {
+            ksafe.put(KEY_TOKENS_JSON, encoded)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            cache.value = previous
+            throw t
+        }
+        cache.value = list
     }
 
     private companion object {
         const val KEY_TOKENS_JSON = "host_tokens_v1"
-        // String.serializer kept to silence unused-import warning if file lifts to plain key list.
-        @Suppress("unused")
-        private val stringSerializer = String.serializer()
     }
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -429,8 +429,7 @@ class InstalledAppsRepositoryImpl(
             val installedCode = app.installedVersionCode
             val latestCode = app.latestVersionCode
             val codesAlreadyMatch =
-                installedCode != null &&
-                    installedCode > 0L &&
+                installedCode > 0L &&
                     latestCode != null &&
                     latestCode > 0L &&
                     installedCode == latestCode
@@ -492,7 +491,6 @@ class InstalledAppsRepositoryImpl(
             // self-update completed), pin the tag to the matched
             // release so subsequent checks don't keep re-flagging.
             if (codesAlreadyMatch &&
-                installedCode != null &&
                 app.installedVersion != matchedRelease.tagName
             ) {
                 installedAppsDao.updateInstalledVersion(

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
@@ -10,6 +10,33 @@ data class HostToken(
     val createdAtEpochMillis: Long,
 )
 
+enum class ForgeKind(
+    val tokenHost: String,
+    val displayName: String,
+    val tokenCreationUrl: String,
+    val tokenTermNoun: String,
+) {
+    GITHUB(
+        tokenHost = "github.com",
+        displayName = "GitHub",
+        tokenCreationUrl =
+            "https://github.com/settings/tokens/new" +
+                "?scopes=public_repo,read:user&description=GitHub%20Store",
+        tokenTermNoun = "Personal access token",
+    ),
+    CODEBERG(
+        tokenHost = "codeberg.org",
+        displayName = "Codeberg",
+        tokenCreationUrl = "https://codeberg.org/user/settings/applications",
+        tokenTermNoun = "Access token",
+    ),
+    ;
+
+    companion object {
+        fun fromHost(host: String): ForgeKind? = entries.firstOrNull { it.tokenHost == host }
+    }
+}
+
 object HostNames {
     const val GITHUB = "github.com"
     const val CODEBERG = "codeberg.org"
@@ -18,7 +45,8 @@ object HostNames {
         val trimmed = raw.trim().lowercase()
         val withoutScheme = trimmed.removePrefix("https://").removePrefix("http://")
         val hostOnly = withoutScheme.substringBefore('/')
-        return hostOnly.removeSuffix(".")
+        val noAuth = hostOnly.substringAfterLast('@')
+        return noAuth.removeSuffix(".").removePrefix("www.").removePrefix("api.")
     }
 
     /**
@@ -33,6 +61,25 @@ object HostNames {
      * `https://<host>/api/v1/...` (same host as the storage key), so
      * they need no mapping.
      */
+    fun sanitizePastedToken(raw: String): String {
+        return raw.trim()
+            .removePrefix("Bearer ")
+            .removePrefix("bearer ")
+            .removePrefix("Token ")
+            .removePrefix("token ")
+            .removePrefix("Authorization: token ")
+            .removePrefix("Authorization: Bearer ")
+            .trim()
+    }
+
+    fun detectPatKind(token: String): String? = when {
+        token.startsWith("ghp_") -> "GitHub classic PAT"
+        token.startsWith("github_pat_") -> "GitHub fine-grained PAT"
+        token.startsWith("gho_") -> "GitHub OAuth token"
+        token.startsWith("ghs_") -> "GitHub server token"
+        else -> null
+    }
+
     fun apiHostToTokenHost(apiHost: String): String {
         val normalized = normalize(apiHost)
         return when (normalized) {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
@@ -1,0 +1,23 @@
+package zed.rainxch.core.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HostToken(
+    val host: String,
+    val token: String,
+    val displayName: String? = null,
+    val createdAtEpochMillis: Long,
+)
+
+object HostNames {
+    const val GITHUB = "github.com"
+    const val CODEBERG = "codeberg.org"
+
+    fun normalize(raw: String): String {
+        val trimmed = raw.trim().lowercase()
+        val withoutScheme = trimmed.removePrefix("https://").removePrefix("http://")
+        val hostOnly = withoutScheme.substringBefore('/')
+        return hostOnly.removeSuffix(".")
+    }
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/HostToken.kt
@@ -20,4 +20,24 @@ object HostNames {
         val hostOnly = withoutScheme.substringBefore('/')
         return hostOnly.removeSuffix(".")
     }
+
+    /**
+     * Maps a request URL host to the canonical token storage host.
+     *
+     * GitHub stores the PAT under [GITHUB] (`github.com`), but real API
+     * requests go to `api.github.com` — without this collapse step the
+     * interceptor's `repo.get(request.url.host)` returns null on every
+     * GitHub REST call.
+     *
+     * Forgejo/Codeberg/Gitea instances expose their REST API at
+     * `https://<host>/api/v1/...` (same host as the storage key), so
+     * they need no mapping.
+     */
+    fun apiHostToTokenHost(apiHost: String): String {
+        val normalized = normalize(apiHost)
+        return when (normalized) {
+            "api.github.com", "uploads.github.com", "raw.githubusercontent.com" -> GITHUB
+            else -> normalized
+        }
+    }
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/HostTokenRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/HostTokenRepository.kt
@@ -1,0 +1,22 @@
+package zed.rainxch.core.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import zed.rainxch.core.domain.model.HostToken
+
+interface HostTokenRepository {
+    fun observeAll(): Flow<List<HostToken>>
+
+    suspend fun get(host: String): HostToken?
+
+    suspend fun set(host: String, token: String, displayName: String? = null)
+
+    suspend fun delete(host: String)
+
+    suspend fun validate(host: String, token: String): Result<TokenValidation>
+}
+
+data class TokenValidation(
+    val login: String?,
+    val scopes: List<String>,
+    val rateLimitRemaining: Int?,
+)

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1212,4 +1212,29 @@
     <string name="kao_banner_body">Google's developer-verification policy threatens open Android distribution. GitHub Store stands with the coalition.</string>
     <string name="kao_banner_cta">Learn more</string>
     <string name="kao_banner_dismiss_cd">Dismiss banner</string>
+
+    <!-- Host tokens -->
+    <string name="host_tokens_title">Authentication tokens</string>
+    <string name="host_tokens_entry_subtitle">Personal access tokens per forge host (GitHub, Codeberg, Forgejo)</string>
+    <string name="host_tokens_intro">Personal access tokens stored encrypted per forge host. Used to authenticate direct API calls.</string>
+    <string name="host_tokens_empty_title">No tokens stored</string>
+    <string name="host_tokens_empty_subtitle">Tap + to add a personal access token</string>
+    <string name="host_tokens_add_dialog_title">Add token</string>
+    <string name="host_tokens_field_host">Host (e.g. github.com)</string>
+    <string name="host_tokens_field_token">Personal access token</string>
+    <string name="host_tokens_field_display_name">Display name (optional)</string>
+    <string name="host_tokens_validation_host_required">Host required</string>
+    <string name="host_tokens_validation_host_invalid">Invalid host</string>
+    <string name="host_tokens_validation_token_required">Token required</string>
+    <string name="host_tokens_validation_token_short">Token too short</string>
+    <string name="host_tokens_action_save">Save</string>
+    <string name="host_tokens_action_cancel">Cancel</string>
+    <string name="host_tokens_action_back">Back</string>
+    <string name="host_tokens_action_add">Add token</string>
+    <string name="host_tokens_action_validate">Validate</string>
+    <string name="host_tokens_action_delete">Delete</string>
+    <string name="host_tokens_saved">Saved token for %1$s</string>
+    <string name="host_tokens_removed">Removed token for %1$s</string>
+    <string name="host_tokens_validation_success">Token accepted (login=%1$s, scopes=%2$s)</string>
+    <string name="host_tokens_validation_failed">Validation failed: %1$s</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1248,7 +1248,7 @@
     <string name="host_tokens_compose_will_connect">Will connect to %1$s</string>
     <string name="host_tokens_compose_detected">Detected: %1$s</string>
     <string name="host_tokens_compose_replace_hint">Leave blank to keep the existing token. Type a new value to replace it.</string>
-    <string name="host_tokens_oauth_coexistence">You\'re also signed in to GitHub via the app. Tokens here authenticate direct API calls; the app sign-in is separate.</string>
+    <string name="host_tokens_oauth_coexistence">You\'re signed in to GitHub via the app — that\'s the recommended path. Add a token here only if browser sign-in won\'t work (restrictive network, no browser) or for forges other than GitHub.</string>
     <string name="host_tokens_row_validate">Check</string>
     <string name="host_tokens_row_menu">More</string>
     <string name="host_tokens_row_edit_label">Edit label</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1261,4 +1261,6 @@
     <string name="host_tokens_undo_action">Undo</string>
     <string name="host_tokens_compose_replace_title">Replace token for %1$s</string>
     <string name="host_tokens_compose_add_title">Add token</string>
+    <string name="host_tokens_validation_failed_fallback">unknown error</string>
+    <string name="host_tokens_undo_failed">Couldn\'t restore token for %1$s</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1237,4 +1237,28 @@
     <string name="host_tokens_removed">Removed token for %1$s</string>
     <string name="host_tokens_validation_success">Token accepted (login=%1$s, scopes=%2$s)</string>
     <string name="host_tokens_validation_failed">Validation failed: %1$s</string>
+
+    <!-- Host tokens — picker / forge presets / inline feedback / undo -->
+    <string name="host_tokens_picker_title">Add token for…</string>
+    <string name="host_tokens_picker_other">Other forge</string>
+    <string name="host_tokens_picker_other_subtitle">Forgejo, Gitea, self-hosted</string>
+    <string name="host_tokens_picker_open_page">Open token page</string>
+    <string name="host_tokens_picker_paste">Paste token</string>
+    <string name="host_tokens_compose_field_forge_address">Forge address</string>
+    <string name="host_tokens_compose_will_connect">Will connect to %1$s</string>
+    <string name="host_tokens_compose_detected">Detected: %1$s</string>
+    <string name="host_tokens_compose_replace_hint">Leave blank to keep the existing token. Type a new value to replace it.</string>
+    <string name="host_tokens_oauth_coexistence">You\'re also signed in to GitHub via the app. Tokens here authenticate direct API calls; the app sign-in is separate.</string>
+    <string name="host_tokens_row_validate">Check</string>
+    <string name="host_tokens_row_menu">More</string>
+    <string name="host_tokens_row_edit_label">Edit label</string>
+    <string name="host_tokens_row_replace_token">Replace token</string>
+    <string name="host_tokens_row_open_token_page">Manage on %1$s</string>
+    <string name="host_tokens_row_valid_short">Valid · %1$s</string>
+    <string name="host_tokens_row_valid_rate">%1$s remaining</string>
+    <string name="host_tokens_row_invalid_short">Invalid · %1$s</string>
+    <string name="host_tokens_undo_snackbar">Token for %1$s removed</string>
+    <string name="host_tokens_undo_action">Undo</string>
+    <string name="host_tokens_compose_replace_title">Replace token for %1$s</string>
+    <string name="host_tokens_compose_add_title">Add token</string>
 </resources>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -368,7 +368,8 @@ fun RepositoryCard(
         }
     }
 
-    if (sheetEnabled && showActionsSheet) {
+    val hideAction = onHideClick
+    if (showActionsSheet && hideAction != null) {
         RepositoryActionsBottomSheet(
             repository = discoveryRepositoryUi.repository,
             isSeen = discoveryRepositoryUi.isSeen,
@@ -389,7 +390,7 @@ fun RepositoryCard(
             },
             onHide = {
                 showActionsSheet = false
-                onHideClick()
+                hideAction()
             },
         )
     }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -387,11 +387,9 @@ fun RepositoryCard(
                     it()
                 }
             },
-            onHide = onHideClick?.let {
-                {
-                    showActionsSheet = false
-                    it()
-                }
+            onHide = {
+                showActionsSheet = false
+                onHideClick()
             },
         )
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -550,6 +550,7 @@ class DetailsViewModel(
         val installed = _state.value.installedApp
         val parkedPath = installed?.pendingInstallFilePath
         val packageName = installed?.packageName
+        val isPending = installed?.isPendingInstall == true
         if (installed == null && parkedPath == null) {
             logger.warn("openApkInspectSheet: nothing inspectable in current state")
             return
@@ -563,7 +564,7 @@ class DetailsViewModel(
         }
         viewModelScope.launch {
             val inspection =
-                if (packageName != null && installed?.isPendingInstall == false) {
+                if (packageName != null && !isPending) {
                     apkInspector.inspectInstalled(packageName)
                         ?: parkedPath?.let { apkInspector.inspectFile(it) }
                 } else if (parkedPath != null) {
@@ -1581,7 +1582,7 @@ class DetailsViewModel(
                 // install path (`installRelease`): non-Android installers
                 // never receive the broadcast that releases the gate.
                 val gatePackageName =
-                    if (platform == Platform.ANDROID) warning.pendingApkInfo?.packageName else null
+                    if (platform == Platform.ANDROID) warning.pendingApkInfo.packageName else null
                 if (gatePackageName != null) {
                     systemInstallSerializer.awaitFreeAndMarkPending(gatePackageName)
                 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -47,6 +47,7 @@ fun TweaksRoot(
     onNavigateToMirrorPicker: () -> Unit,
     onNavigateToSkippedUpdates: () -> Unit,
     onNavigateToHiddenRepositories: () -> Unit,
+    onNavigateToHostTokens: () -> Unit = {},
     viewModel: TweaksViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -162,6 +163,7 @@ fun TweaksRoot(
             }
         },
         snackbarState = snackbarState,
+        onNavigateToHostTokens = onNavigateToHostTokens,
     )
 
     if (state.isClearDownloadsDialogVisible) {
@@ -211,6 +213,7 @@ fun TweaksScreen(
     state: TweaksState,
     onAction: (TweaksAction) -> Unit,
     snackbarState: SnackbarHostState,
+    onNavigateToHostTokens: () -> Unit = {},
 ) {
     val bottomNavHeight = LocalBottomNavigationHeight.current
     Scaffold(
@@ -241,6 +244,10 @@ fun TweaksScreen(
             )
 
             item {
+                Spacer(Modifier.height(16.dp))
+                zed.rainxch.tweaks.presentation.hosttokens.HostTokensEntryCard(
+                    onClick = onNavigateToHostTokens,
+                )
                 Spacer(Modifier.height(16.dp))
             }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensAction.kt
@@ -1,13 +1,29 @@
 package zed.rainxch.tweaks.presentation.hosttokens
 
+import zed.rainxch.core.domain.model.ForgeKind
+import zed.rainxch.core.domain.model.HostToken
+
 sealed interface HostTokensAction {
     data object OnNavigateBack : HostTokensAction
+
+    // Picker / dialog lifecycle
     data object OnAddClicked : HostTokensAction
     data object OnAddDismiss : HostTokensAction
+    data class OnPickPresetForge(val kind: ForgeKind) : HostTokensAction
+    data object OnPickOtherForge : HostTokensAction
+    data class OnOpenTokenCreationPage(val kind: ForgeKind) : HostTokensAction
+    data class OnReplaceToken(val existing: HostToken) : HostTokensAction
+    data class OnEditLabel(val existing: HostToken) : HostTokensAction
+
+    // Dialog field edits
     data class OnDraftHostChanged(val value: String) : HostTokensAction
     data class OnDraftTokenChanged(val value: String) : HostTokensAction
     data class OnDraftDisplayNameChanged(val value: String) : HostTokensAction
     data object OnAddConfirm : HostTokensAction
-    data class OnDelete(val host: String) : HostTokensAction
+
+    // Row-level actions
     data class OnValidate(val host: String) : HostTokensAction
+    data class OnDelete(val host: String) : HostTokensAction
+    data object OnUndoDelete : HostTokensAction
+    data object OnDismissUndoDelete : HostTokensAction
 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensAction.kt
@@ -1,0 +1,13 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+sealed interface HostTokensAction {
+    data object OnNavigateBack : HostTokensAction
+    data object OnAddClicked : HostTokensAction
+    data object OnAddDismiss : HostTokensAction
+    data class OnDraftHostChanged(val value: String) : HostTokensAction
+    data class OnDraftTokenChanged(val value: String) : HostTokensAction
+    data class OnDraftDisplayNameChanged(val value: String) : HostTokensAction
+    data object OnAddConfirm : HostTokensAction
+    data class OnDelete(val host: String) : HostTokensAction
+    data class OnValidate(val host: String) : HostTokensAction
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEntryCard.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEntryCard.kt
@@ -1,0 +1,60 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun HostTokensEntryCard(
+    onClick: () -> Unit,
+) {
+    OutlinedCard(
+        onClick = onClick,
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+        shape = RoundedCornerShape(32.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.VpnKey,
+                contentDescription = null,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Authentication tokens",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "Personal access tokens per forge host (GitHub, Codeberg, Forgejo)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+            )
+        }
+    }
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEntryCard.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEntryCard.kt
@@ -18,6 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_entry_subtitle
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_title
 
 @Composable
 fun HostTokensEntryCard(
@@ -42,11 +46,11 @@ fun HostTokensEntryCard(
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Authentication tokens",
+                    text = stringResource(Res.string.host_tokens_title),
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Text(
-                    text = "Personal access tokens per forge host (GitHub, Codeberg, Forgejo)",
+                    text = stringResource(Res.string.host_tokens_entry_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEvent.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEvent.kt
@@ -1,0 +1,5 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+sealed interface HostTokensEvent {
+    data class Message(val text: String) : HostTokensEvent
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEvent.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensEvent.kt
@@ -1,5 +1,13 @@
 package zed.rainxch.tweaks.presentation.hosttokens
 
+import zed.rainxch.core.domain.model.HostToken
+
 sealed interface HostTokensEvent {
     data class Message(val text: String) : HostTokensEvent
+
+    /** Snackbar with undo when a token is removed. */
+    data class TokenDeletedWithUndo(val deleted: HostToken) : HostTokensEvent
+
+    /** Open URL in browser (token creation pages on each forge). */
+    data class OpenUrl(val url: String) : HostTokensEvent
 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
@@ -47,9 +47,25 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.domain.model.HostToken
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_add
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_back
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_cancel
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_delete
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_save
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_validate
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_add_dialog_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_empty_subtitle
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_empty_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_display_name
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_host
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_token
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_intro
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_title
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,10 +89,13 @@ fun HostTokensRoot(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Authentication tokens") },
+                title = { Text(stringResource(Res.string.host_tokens_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.host_tokens_action_back),
+                        )
                     }
                 },
             )
@@ -84,7 +103,10 @@ fun HostTokensRoot(
         snackbarHost = { SnackbarHost(snackbarState) },
         floatingActionButton = {
             FloatingActionButton(onClick = { viewModel.onAction(HostTokensAction.OnAddClicked) }) {
-                Icon(Icons.Default.Add, contentDescription = "Add token")
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = stringResource(Res.string.host_tokens_action_add),
+                )
             }
         },
     ) { padding ->
@@ -96,8 +118,7 @@ fun HostTokensRoot(
         ) {
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "Personal access tokens stored encrypted per forge host. " +
-                    "Used to authenticate direct GitHub / Codeberg / Forgejo API calls.",
+                text = stringResource(Res.string.host_tokens_intro),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -139,11 +160,11 @@ fun HostTokensRoot(
                             )
                             Spacer(Modifier.height(8.dp))
                             Text(
-                                text = "No tokens stored",
+                                text = stringResource(Res.string.host_tokens_empty_title),
                                 style = MaterialTheme.typography.titleMedium,
                             )
                             Text(
-                                text = "Tap + to add a personal access token",
+                                text = stringResource(Res.string.host_tokens_empty_subtitle),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -217,13 +238,16 @@ private fun TokenRow(
                 CircularProgressIndicator(modifier = Modifier.size(20.dp))
             } else {
                 IconButton(onClick = onValidate) {
-                    Icon(Icons.Default.Check, contentDescription = "Validate")
+                    Icon(
+                        Icons.Default.Check,
+                        contentDescription = stringResource(Res.string.host_tokens_action_validate),
+                    )
                 }
             }
             IconButton(onClick = onDelete) {
                 Icon(
                     Icons.Default.Delete,
-                    contentDescription = "Delete",
+                    contentDescription = stringResource(Res.string.host_tokens_action_delete),
                     tint = MaterialTheme.colorScheme.error,
                 )
             }
@@ -243,42 +267,42 @@ private fun AddTokenDialog(
 ) {
     AlertDialog(
         onDismissRequest = { onAction(HostTokensAction.OnAddDismiss) },
-        title = { Text("Add token") },
+        title = { Text(stringResource(Res.string.host_tokens_add_dialog_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
                     value = state.draftHost,
                     onValueChange = { onAction(HostTokensAction.OnDraftHostChanged(it)) },
-                    label = { Text("Host (e.g. github.com)") },
+                    label = { Text(stringResource(Res.string.host_tokens_field_host)) },
                     singleLine = true,
                     isError = state.draftHostError != null,
-                    supportingText = state.draftHostError?.let { { Text(it) } },
+                    supportingText = state.draftHostError?.let { res -> { Text(stringResource(res)) } },
                 )
                 OutlinedTextField(
                     value = state.draftToken,
                     onValueChange = { onAction(HostTokensAction.OnDraftTokenChanged(it)) },
-                    label = { Text("Personal access token") },
+                    label = { Text(stringResource(Res.string.host_tokens_field_token)) },
                     singleLine = true,
                     isError = state.draftTokenError != null,
-                    supportingText = state.draftTokenError?.let { { Text(it) } },
+                    supportingText = state.draftTokenError?.let { res -> { Text(stringResource(res)) } },
                     visualTransformation = PasswordVisualTransformation(),
                 )
                 OutlinedTextField(
                     value = state.draftDisplayName,
                     onValueChange = { onAction(HostTokensAction.OnDraftDisplayNameChanged(it)) },
-                    label = { Text("Display name (optional)") },
+                    label = { Text(stringResource(Res.string.host_tokens_field_display_name)) },
                     singleLine = true,
                 )
             }
         },
         confirmButton = {
             TextButton(onClick = { onAction(HostTokensAction.OnAddConfirm) }) {
-                Text("Save")
+                Text(stringResource(Res.string.host_tokens_action_save))
             }
         },
         dismissButton = {
             TextButton(onClick = { onAction(HostTokensAction.OnAddDismiss) }) {
-                Text("Cancel")
+                Text(stringResource(Res.string.host_tokens_action_cancel))
             }
         },
     )

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
@@ -311,41 +311,50 @@ private fun PresetForgeCard(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, top = 12.dp, end = 8.dp, bottom = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Icon(
-                Icons.Default.VpnKey,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Spacer(Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = kind.displayName,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = kind.tokenHost,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            TextButton(onClick = onOpenTokenCreationPage) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
                 Icon(
-                    Icons.Default.OpenInBrowser,
+                    Icons.Default.VpnKey,
                     contentDescription = null,
-                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary,
                 )
-                Spacer(Modifier.width(4.dp))
-                Text(stringResource(Res.string.host_tokens_picker_open_page))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = kind.displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = kind.tokenHost,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-            TextButton(onClick = onPick) {
-                Text(stringResource(Res.string.host_tokens_picker_paste))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onOpenTokenCreationPage) {
+                    Icon(
+                        Icons.Default.OpenInBrowser,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(Res.string.host_tokens_picker_open_page))
+                }
+                TextButton(onClick = onPick) {
+                    Text(stringResource(Res.string.host_tokens_picker_paste))
+                }
             }
         }
     }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
@@ -20,35 +20,48 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
+import zed.rainxch.core.domain.model.ForgeKind
 import zed.rainxch.core.domain.model.HostToken
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.githubstore.core.presentation.res.Res
@@ -57,15 +70,33 @@ import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_back
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_cancel
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_delete
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_save
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_action_validate
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_add_dialog_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_add_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_detected
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_field_forge_address
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_replace_hint
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_replace_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_compose_will_connect
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_empty_subtitle
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_empty_title
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_display_name
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_host
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_field_token
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_intro
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_oauth_coexistence
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_picker_open_page
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_picker_other
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_picker_other_subtitle
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_picker_paste
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_picker_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_edit_label
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_invalid_short
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_menu
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_open_token_page
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_replace_token
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_valid_rate
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_valid_short
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_row_validate
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_title
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_undo_action
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_undo_snackbar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,12 +107,26 @@ fun HostTokensRoot(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
 
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
             is HostTokensEvent.Message ->
+                coroutineScope.launch { snackbarState.showSnackbar(event.text) }
+            is HostTokensEvent.OpenUrl ->
+                runCatching { uriHandler.openUri(event.url) }
+            is HostTokensEvent.TokenDeletedWithUndo ->
                 coroutineScope.launch {
-                    snackbarState.showSnackbar(event.text)
+                    val result = snackbarState.showSnackbar(
+                        message = getString(Res.string.host_tokens_undo_snackbar, event.deleted.host),
+                        actionLabel = getString(Res.string.host_tokens_undo_action),
+                        withDismissAction = true,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.onAction(HostTokensAction.OnUndoDelete)
+                    } else {
+                        viewModel.onAction(HostTokensAction.OnDismissUndoDelete)
+                    }
                 }
         }
     }
@@ -102,11 +147,10 @@ fun HostTokensRoot(
         },
         snackbarHost = { SnackbarHost(snackbarState) },
         floatingActionButton = {
-            FloatingActionButton(onClick = { viewModel.onAction(HostTokensAction.OnAddClicked) }) {
-                Icon(
-                    Icons.Default.Add,
-                    contentDescription = stringResource(Res.string.host_tokens_action_add),
-                )
+            if (state.tokens.isNotEmpty()) {
+                FloatingActionButton(onClick = { viewModel.onAction(HostTokensAction.OnAddClicked) }) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(Res.string.host_tokens_action_add))
+                }
             }
         },
     ) { padding ->
@@ -116,60 +160,25 @@ fun HostTokensRoot(
                 .padding(padding)
                 .padding(horizontal = 16.dp),
         ) {
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = stringResource(Res.string.host_tokens_intro),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(16.dp))
-
-            state.validationMessage?.let { msg ->
-                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                    Text(
-                        text = msg,
-                        modifier = Modifier.padding(12.dp),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
+            if (state.isOAuthSignedInToGithub) {
+                OAuthCoexistenceNote()
                 Spacer(Modifier.height(12.dp))
             }
-
             when {
                 state.isLoading -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
-                    }
+                    ) { CircularProgressIndicator() }
                 }
                 state.tokens.isEmpty() -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            Icon(
-                                Icons.Default.VpnKey,
-                                contentDescription = null,
-                                modifier = Modifier.size(48.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            Text(
-                                text = stringResource(Res.string.host_tokens_empty_title),
-                                style = MaterialTheme.typography.titleMedium,
-                            )
-                            Text(
-                                text = stringResource(Res.string.host_tokens_empty_subtitle),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
+                    EmptyStatePicker(
+                        onPickPreset = { kind -> viewModel.onAction(HostTokensAction.OnPickPresetForge(kind)) },
+                        onPickOther = { viewModel.onAction(HostTokensAction.OnPickOtherForge) },
+                        onOpenTokenCreationPage = { kind ->
+                            viewModel.onAction(HostTokensAction.OnOpenTokenCreationPage(kind))
+                        },
+                    )
                 }
                 else -> {
                     val listState = rememberLazyListState()
@@ -180,9 +189,15 @@ fun HostTokensRoot(
                         items(state.tokens, key = { it.host }) { token ->
                             TokenRow(
                                 token = token,
-                                isValidating = state.isValidating && state.pendingValidationFor == token.host,
+                                isValidating = token.host in state.validatingHosts,
+                                validation = state.validationByHost[token.host],
                                 onValidate = { viewModel.onAction(HostTokensAction.OnValidate(token.host)) },
                                 onDelete = { viewModel.onAction(HostTokensAction.OnDelete(token.host)) },
+                                onReplace = { viewModel.onAction(HostTokensAction.OnReplaceToken(token)) },
+                                onEditLabel = { viewModel.onAction(HostTokensAction.OnEditLabel(token)) },
+                                onOpenManagePage = { kind ->
+                                    viewModel.onAction(HostTokensAction.OnOpenTokenCreationPage(kind))
+                                },
                             )
                         }
                     }
@@ -191,20 +206,106 @@ fun HostTokensRoot(
         }
     }
 
-    if (state.isAddDialogVisible) {
-        AddTokenDialog(
-            state = state,
-            onAction = viewModel::onAction,
-        )
+    when (val mode = state.draftMode) {
+        DraftMode.Closed -> Unit
+        DraftMode.Picker -> {
+            PickerDialog(
+                onPickPreset = { kind -> viewModel.onAction(HostTokensAction.OnPickPresetForge(kind)) },
+                onPickOther = { viewModel.onAction(HostTokensAction.OnPickOtherForge) },
+                onOpenTokenCreationPage = { kind ->
+                    viewModel.onAction(HostTokensAction.OnOpenTokenCreationPage(kind))
+                },
+                onDismiss = { viewModel.onAction(HostTokensAction.OnAddDismiss) },
+            )
+        }
+        is DraftMode.Compose -> {
+            AddTokenDialog(
+                state = state,
+                replacingExisting = mode.replacingExisting,
+                onAction = viewModel::onAction,
+            )
+        }
     }
 }
 
 @Composable
-private fun TokenRow(
-    token: HostToken,
-    isValidating: Boolean,
-    onValidate: () -> Unit,
-    onDelete: () -> Unit,
+private fun OAuthCoexistenceNote() {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                Icons.Default.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                text = stringResource(Res.string.host_tokens_oauth_coexistence),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyStatePicker(
+    onPickPreset: (ForgeKind) -> Unit,
+    onPickOther: () -> Unit,
+    onOpenTokenCreationPage: (ForgeKind) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.host_tokens_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = stringResource(Res.string.host_tokens_empty_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(Res.string.host_tokens_picker_title),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+        items(ForgeKind.entries, key = { it.tokenHost }) { kind ->
+            PresetForgeCard(
+                kind = kind,
+                onPick = { onPickPreset(kind) },
+                onOpenTokenCreationPage = { onOpenTokenCreationPage(kind) },
+            )
+        }
+        item {
+            OtherForgeCard(onPick = onPickOther)
+        }
+    }
+}
+
+@Composable
+private fun PresetForgeCard(
+    kind: ForgeKind,
+    onPick: () -> Unit,
+    onOpenTokenCreationPage: () -> Unit,
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -224,14 +325,158 @@ private fun TokenRow(
             Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = token.host,
+                    text = kind.displayName,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    text = token.displayName ?: maskedToken(token.token),
+                    text = kind.tokenHost,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(onClick = onOpenTokenCreationPage) {
+                Icon(
+                    Icons.Default.OpenInBrowser,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(Res.string.host_tokens_picker_open_page))
+            }
+            TextButton(onClick = onPick) {
+                Text(stringResource(Res.string.host_tokens_picker_paste))
+            }
+        }
+    }
+}
+
+@Composable
+private fun OtherForgeCard(onPick: () -> Unit) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        onClick = onPick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Default.VpnKey,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(Res.string.host_tokens_picker_other),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = stringResource(Res.string.host_tokens_picker_other_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PickerDialog(
+    onPickPreset: (ForgeKind) -> Unit,
+    onPickOther: () -> Unit,
+    onOpenTokenCreationPage: (ForgeKind) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.host_tokens_picker_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ForgeKind.entries.forEach { kind ->
+                    PresetForgeCard(
+                        kind = kind,
+                        onPick = { onPickPreset(kind) },
+                        onOpenTokenCreationPage = { onOpenTokenCreationPage(kind) },
+                    )
+                }
+                OtherForgeCard(onPick = onPickOther)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.host_tokens_action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun TokenRow(
+    token: HostToken,
+    isValidating: Boolean,
+    validation: ValidationLine?,
+    onValidate: () -> Unit,
+    onDelete: () -> Unit,
+    onReplace: () -> Unit,
+    onEditLabel: () -> Unit,
+    onOpenManagePage: (ForgeKind) -> Unit,
+) {
+    val forge = ForgeKind.fromHost(token.host)
+    var menuOpen by remember { mutableStateOf(false) }
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, top = 12.dp, end = 8.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.VpnKey,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = forge?.displayName ?: token.host,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                val secondary = when {
+                    validation?.isSuccess == true -> {
+                        val login = validation.login ?: token.displayName ?: token.host
+                        if (validation.rateLimitRemaining != null) {
+                            stringResource(Res.string.host_tokens_row_valid_short, login) +
+                                " · " + stringResource(
+                                    Res.string.host_tokens_row_valid_rate,
+                                    validation.rateLimitRemaining,
+                                )
+                        } else {
+                            stringResource(Res.string.host_tokens_row_valid_short, login)
+                        }
+                    }
+                    validation != null -> stringResource(
+                        Res.string.host_tokens_row_invalid_short,
+                        validation.errorMessage.orEmpty(),
+                    )
+                    else -> token.displayName ?: token.host
+                }
+                Text(
+                    text = secondary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (validation != null && !validation.isSuccess) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                 )
             }
             if (isValidating) {
@@ -240,51 +485,101 @@ private fun TokenRow(
                 IconButton(onClick = onValidate) {
                     Icon(
                         Icons.Default.Check,
-                        contentDescription = stringResource(Res.string.host_tokens_action_validate),
+                        contentDescription = stringResource(Res.string.host_tokens_row_validate),
                     )
                 }
             }
-            IconButton(onClick = onDelete) {
-                Icon(
-                    Icons.Default.Delete,
-                    contentDescription = stringResource(Res.string.host_tokens_action_delete),
-                    tint = MaterialTheme.colorScheme.error,
-                )
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(
+                        Icons.Default.MoreVert,
+                        contentDescription = stringResource(Res.string.host_tokens_row_menu),
+                    )
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.host_tokens_row_edit_label)) },
+                        onClick = { menuOpen = false; onEditLabel() },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.host_tokens_row_replace_token)) },
+                        onClick = { menuOpen = false; onReplace() },
+                    )
+                    if (forge != null) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(
+                                        Res.string.host_tokens_row_open_token_page,
+                                        forge.displayName,
+                                    ),
+                                )
+                            },
+                            onClick = { menuOpen = false; onOpenManagePage(forge) },
+                        )
+                    }
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.host_tokens_action_delete)) },
+                        onClick = { menuOpen = false; onDelete() },
+                    )
+                }
             }
         }
     }
 }
 
-private fun maskedToken(token: String): String {
-    if (token.length <= 8) return "•".repeat(token.length)
-    return token.take(4) + "•".repeat(8) + token.takeLast(4)
-}
-
 @Composable
 private fun AddTokenDialog(
     state: HostTokensState,
+    replacingExisting: HostToken?,
     onAction: (HostTokensAction) -> Unit,
 ) {
+    val title = if (replacingExisting != null) {
+        stringResource(Res.string.host_tokens_compose_replace_title, replacingExisting.host)
+    } else {
+        stringResource(Res.string.host_tokens_compose_add_title)
+    }
     AlertDialog(
         onDismissRequest = { onAction(HostTokensAction.OnAddDismiss) },
-        title = { Text(stringResource(Res.string.host_tokens_add_dialog_title)) },
+        title = { Text(title) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = state.draftHost,
-                    onValueChange = { onAction(HostTokensAction.OnDraftHostChanged(it)) },
-                    label = { Text(stringResource(Res.string.host_tokens_field_host)) },
-                    singleLine = true,
-                    isError = state.draftHostError != null,
-                    supportingText = state.draftHostError?.let { res -> { Text(stringResource(res)) } },
-                )
+                if (state.draftForge == null) {
+                    OutlinedTextField(
+                        value = state.draftHost,
+                        onValueChange = { onAction(HostTokensAction.OnDraftHostChanged(it)) },
+                        label = { Text(stringResource(Res.string.host_tokens_compose_field_forge_address)) },
+                        singleLine = true,
+                        isError = state.draftHostError != null,
+                        supportingText = state.draftHostError?.let { res ->
+                            { Text(stringResource(res)) }
+                        } ?: state.draftHostNormalized
+                            .takeIf { it.isNotBlank() && it != state.draftHost.trim() }
+                            ?.let { normalized ->
+                                {
+                                    Text(
+                                        stringResource(
+                                            Res.string.host_tokens_compose_will_connect,
+                                            normalized,
+                                        ),
+                                    )
+                                }
+                            },
+                    )
+                }
                 OutlinedTextField(
                     value = state.draftToken,
                     onValueChange = { onAction(HostTokensAction.OnDraftTokenChanged(it)) },
                     label = { Text(stringResource(Res.string.host_tokens_field_token)) },
                     singleLine = true,
                     isError = state.draftTokenError != null,
-                    supportingText = state.draftTokenError?.let { res -> { Text(stringResource(res)) } },
+                    supportingText = state.draftTokenError?.let { res ->
+                        { Text(stringResource(res)) }
+                    } ?: state.draftDetectedTokenKind?.let { kind ->
+                        { Text(stringResource(Res.string.host_tokens_compose_detected, kind)) }
+                    } ?: replacingExisting?.let {
+                        { Text(stringResource(Res.string.host_tokens_compose_replace_hint)) }
+                    },
                     visualTransformation = PasswordVisualTransformation(),
                 )
                 OutlinedTextField(

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
@@ -173,6 +173,7 @@ fun HostTokensRoot(
                 }
                 state.tokens.isEmpty() -> {
                     EmptyStatePicker(
+                        presetForges = visiblePresetForges(state),
                         onPickPreset = { kind -> viewModel.onAction(HostTokensAction.OnPickPresetForge(kind)) },
                         onPickOther = { viewModel.onAction(HostTokensAction.OnPickOtherForge) },
                         onOpenTokenCreationPage = { kind ->
@@ -210,6 +211,7 @@ fun HostTokensRoot(
         DraftMode.Closed -> Unit
         DraftMode.Picker -> {
             PickerDialog(
+                presetForges = visiblePresetForges(state),
                 onPickPreset = { kind -> viewModel.onAction(HostTokensAction.OnPickPresetForge(kind)) },
                 onPickOther = { viewModel.onAction(HostTokensAction.OnPickOtherForge) },
                 onOpenTokenCreationPage = { kind ->
@@ -224,6 +226,22 @@ fun HostTokensRoot(
                 replacingExisting = mode.replacingExisting,
                 onAction = viewModel::onAction,
             )
+        }
+    }
+}
+
+private fun visiblePresetForges(state: HostTokensState): List<ForgeKind> {
+    // Hide the GitHub preset card when the user is already signed in via
+    // the in-app OAuth flow — for those users a PAT for github.com is
+    // redundant. Power users can still reach it via "Other forge".
+    // Always show forges the user already has a stored token for, so the
+    // picker stays consistent with the row list when those rows exist.
+    val storedHosts = state.tokens.map { it.host }.toSet()
+    return ForgeKind.entries.filter { kind ->
+        when {
+            kind.tokenHost in storedHosts -> true
+            kind == ForgeKind.GITHUB && state.isOAuthSignedInToGithub -> false
+            else -> true
         }
     }
 }
@@ -261,6 +279,7 @@ private fun OAuthCoexistenceNote() {
 
 @Composable
 private fun EmptyStatePicker(
+    presetForges: List<ForgeKind>,
     onPickPreset: (ForgeKind) -> Unit,
     onPickOther: () -> Unit,
     onOpenTokenCreationPage: (ForgeKind) -> Unit,
@@ -288,7 +307,7 @@ private fun EmptyStatePicker(
             )
             Spacer(Modifier.height(8.dp))
         }
-        items(ForgeKind.entries, key = { it.tokenHost }) { kind ->
+        items(presetForges, key = { it.tokenHost }) { kind ->
             PresetForgeCard(
                 kind = kind,
                 onPick = { onPickPreset(kind) },
@@ -396,6 +415,7 @@ private fun OtherForgeCard(onPick: () -> Unit) {
 
 @Composable
 private fun PickerDialog(
+    presetForges: List<ForgeKind>,
     onPickPreset: (ForgeKind) -> Unit,
     onPickOther: () -> Unit,
     onOpenTokenCreationPage: (ForgeKind) -> Unit,
@@ -406,7 +426,7 @@ private fun PickerDialog(
         title = { Text(stringResource(Res.string.host_tokens_picker_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                ForgeKind.entries.forEach { kind ->
+                presetForges.forEach { kind ->
                     PresetForgeCard(
                         kind = kind,
                         onPick = { onPickPreset(kind) },

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensRoot.kt
@@ -1,0 +1,285 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+import org.koin.compose.viewmodel.koinViewModel
+import zed.rainxch.core.domain.model.HostToken
+import zed.rainxch.core.presentation.utils.ObserveAsEvents
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostTokensRoot(
+    onNavigateBack: () -> Unit,
+    viewModel: HostTokensViewModel = koinViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    ObserveAsEvents(viewModel.events) { event ->
+        when (event) {
+            is HostTokensEvent.Message ->
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(event.text)
+                }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Authentication tokens") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { viewModel.onAction(HostTokensAction.OnAddClicked) }) {
+                Icon(Icons.Default.Add, contentDescription = "Add token")
+            }
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+        ) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Personal access tokens stored encrypted per forge host. " +
+                    "Used to authenticate direct GitHub / Codeberg / Forgejo API calls.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            state.validationMessage?.let { msg ->
+                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = msg,
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+            }
+
+            when {
+                state.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.tokens.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Icon(
+                                Icons.Default.VpnKey,
+                                contentDescription = null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = "No tokens stored",
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = "Tap + to add a personal access token",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+                else -> {
+                    val listState = rememberLazyListState()
+                    LazyColumn(
+                        state = listState,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.tokens, key = { it.host }) { token ->
+                            TokenRow(
+                                token = token,
+                                isValidating = state.isValidating && state.pendingValidationFor == token.host,
+                                onValidate = { viewModel.onAction(HostTokensAction.OnValidate(token.host)) },
+                                onDelete = { viewModel.onAction(HostTokensAction.OnDelete(token.host)) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (state.isAddDialogVisible) {
+        AddTokenDialog(
+            state = state,
+            onAction = viewModel::onAction,
+        )
+    }
+}
+
+@Composable
+private fun TokenRow(
+    token: HostToken,
+    isValidating: Boolean,
+    onValidate: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, top = 12.dp, end = 8.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.VpnKey,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = token.host,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = token.displayName ?: maskedToken(token.token),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (isValidating) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp))
+            } else {
+                IconButton(onClick = onValidate) {
+                    Icon(Icons.Default.Check, contentDescription = "Validate")
+                }
+            }
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+private fun maskedToken(token: String): String {
+    if (token.length <= 8) return "•".repeat(token.length)
+    return token.take(4) + "•".repeat(8) + token.takeLast(4)
+}
+
+@Composable
+private fun AddTokenDialog(
+    state: HostTokensState,
+    onAction: (HostTokensAction) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { onAction(HostTokensAction.OnAddDismiss) },
+        title = { Text("Add token") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = state.draftHost,
+                    onValueChange = { onAction(HostTokensAction.OnDraftHostChanged(it)) },
+                    label = { Text("Host (e.g. github.com)") },
+                    singleLine = true,
+                    isError = state.draftHostError != null,
+                    supportingText = state.draftHostError?.let { { Text(it) } },
+                )
+                OutlinedTextField(
+                    value = state.draftToken,
+                    onValueChange = { onAction(HostTokensAction.OnDraftTokenChanged(it)) },
+                    label = { Text("Personal access token") },
+                    singleLine = true,
+                    isError = state.draftTokenError != null,
+                    supportingText = state.draftTokenError?.let { { Text(it) } },
+                    visualTransformation = PasswordVisualTransformation(),
+                )
+                OutlinedTextField(
+                    value = state.draftDisplayName,
+                    onValueChange = { onAction(HostTokensAction.OnDraftDisplayNameChanged(it)) },
+                    label = { Text("Display name (optional)") },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onAction(HostTokensAction.OnAddConfirm) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onAction(HostTokensAction.OnAddDismiss) }) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
@@ -1,0 +1,17 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+import zed.rainxch.core.domain.model.HostToken
+
+data class HostTokensState(
+    val tokens: List<HostToken> = emptyList(),
+    val draftHost: String = "",
+    val draftToken: String = "",
+    val draftDisplayName: String = "",
+    val draftHostError: String? = null,
+    val draftTokenError: String? = null,
+    val isAddDialogVisible: Boolean = false,
+    val isValidating: Boolean = false,
+    val pendingValidationFor: String? = null,
+    val validationMessage: String? = null,
+    val isLoading: Boolean = false,
+)

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
@@ -1,18 +1,46 @@
 package zed.rainxch.tweaks.presentation.hosttokens
 
 import org.jetbrains.compose.resources.StringResource
+import zed.rainxch.core.domain.model.ForgeKind
 import zed.rainxch.core.domain.model.HostToken
 
 data class HostTokensState(
     val tokens: List<HostToken> = emptyList(),
+    // Inline validate feedback per row. Survives Snackbar dismiss so the
+    // user can re-check it on screen.
+    val validationByHost: Map<String, ValidationLine> = emptyMap(),
+    // Hosts whose validate request is in flight (row spinner).
+    val validatingHosts: Set<String> = emptySet(),
+
+    val draftMode: DraftMode = DraftMode.Closed,
+    val draftForge: ForgeKind? = null,
     val draftHost: String = "",
+    val draftHostNormalized: String = "",
     val draftToken: String = "",
     val draftDisplayName: String = "",
     val draftHostError: StringResource? = null,
     val draftTokenError: StringResource? = null,
-    val isAddDialogVisible: Boolean = false,
-    val isValidating: Boolean = false,
-    val pendingValidationFor: String? = null,
-    val validationMessage: String? = null,
+    val draftDetectedTokenKind: String? = null,
     val isLoading: Boolean = false,
+    val isOAuthSignedInToGithub: Boolean = false,
+    val pendingUndoDelete: HostToken? = null,
 )
+
+sealed interface DraftMode {
+    data object Closed : DraftMode
+
+    /** Forge picker step — shown on add tap or empty state. */
+    data object Picker : DraftMode
+
+    /** Token entry dialog. */
+    data class Compose(val replacingExisting: HostToken? = null) : DraftMode
+}
+
+data class ValidationLine(
+    val login: String?,
+    val scopes: List<String>,
+    val rateLimitRemaining: Int?,
+    val errorMessage: String?,
+) {
+    val isSuccess: Boolean get() = errorMessage == null
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensState.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.tweaks.presentation.hosttokens
 
+import org.jetbrains.compose.resources.StringResource
 import zed.rainxch.core.domain.model.HostToken
 
 data class HostTokensState(
@@ -7,8 +8,8 @@ data class HostTokensState(
     val draftHost: String = "",
     val draftToken: String = "",
     val draftDisplayName: String = "",
-    val draftHostError: String? = null,
-    val draftTokenError: String? = null,
+    val draftHostError: StringResource? = null,
+    val draftTokenError: StringResource? = null,
     val isAddDialogVisible: Boolean = false,
     val isValidating: Boolean = false,
     val pendingValidationFor: String? = null,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
@@ -9,20 +9,21 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
+import zed.rainxch.core.domain.model.ForgeKind
 import zed.rainxch.core.domain.model.HostNames
+import zed.rainxch.core.domain.repository.AuthenticationState
 import zed.rainxch.core.domain.repository.HostTokenRepository
 import zed.rainxch.githubstore.core.presentation.res.Res
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_removed
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_saved
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_failed
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_invalid
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_required
-import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_success
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_token_required
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_token_short
 
 class HostTokensViewModel(
     private val repository: HostTokenRepository,
+    private val authenticationState: AuthenticationState,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HostTokensState(isLoading = true))
@@ -34,7 +35,17 @@ class HostTokensViewModel(
     init {
         viewModelScope.launch {
             repository.observeAll().collect { tokens ->
-                _state.update { it.copy(tokens = tokens.sortedBy { t -> t.host }, isLoading = false) }
+                _state.update {
+                    it.copy(
+                        tokens = tokens.sortedBy { t -> t.host },
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+        viewModelScope.launch {
+            authenticationState.isUserLoggedIn().collect { signedIn ->
+                _state.update { it.copy(isOAuthSignedInToGithub = signedIn) }
             }
         }
     }
@@ -42,83 +53,149 @@ class HostTokensViewModel(
     fun onAction(action: HostTokensAction) {
         when (action) {
             HostTokensAction.OnNavigateBack -> { /* host handles */ }
+
             HostTokensAction.OnAddClicked ->
+                _state.update { it.copy(draftMode = DraftMode.Picker) }
+            HostTokensAction.OnAddDismiss -> closeDraft()
+
+            is HostTokensAction.OnPickPresetForge ->
+                openCompose(forge = action.kind, host = action.kind.tokenHost)
+            HostTokensAction.OnPickOtherForge -> openCompose(forge = null, host = "")
+            is HostTokensAction.OnOpenTokenCreationPage ->
+                viewModelScope.launch {
+                    _events.send(HostTokensEvent.OpenUrl(action.kind.tokenCreationUrl))
+                }
+            is HostTokensAction.OnReplaceToken ->
                 _state.update {
                     it.copy(
-                        isAddDialogVisible = true,
-                        draftHost = "",
+                        draftMode = DraftMode.Compose(replacingExisting = action.existing),
+                        draftForge = ForgeKind.fromHost(action.existing.host),
+                        draftHost = action.existing.host,
+                        draftHostNormalized = action.existing.host,
                         draftToken = "",
-                        draftDisplayName = "",
+                        draftDisplayName = action.existing.displayName.orEmpty(),
                         draftHostError = null,
                         draftTokenError = null,
-                        validationMessage = null,
+                        draftDetectedTokenKind = null,
                     )
                 }
-            HostTokensAction.OnAddDismiss ->
-                _state.update { it.copy(isAddDialogVisible = false) }
-            is HostTokensAction.OnDraftHostChanged ->
+            is HostTokensAction.OnEditLabel ->
+                _state.update {
+                    it.copy(
+                        draftMode = DraftMode.Compose(replacingExisting = action.existing),
+                        draftForge = ForgeKind.fromHost(action.existing.host),
+                        draftHost = action.existing.host,
+                        draftHostNormalized = action.existing.host,
+                        draftToken = "",
+                        draftDisplayName = action.existing.displayName.orEmpty(),
+                        draftHostError = null,
+                        draftTokenError = null,
+                        draftDetectedTokenKind = null,
+                    )
+                }
+
+            is HostTokensAction.OnDraftHostChanged -> {
+                val normalized = HostNames.normalize(action.value)
                 _state.update {
                     it.copy(
                         draftHost = action.value,
-                        draftHostError = validateHost(action.value),
+                        draftHostNormalized = normalized,
+                        draftHostError = validateHost(normalized),
                     )
                 }
-            is HostTokensAction.OnDraftTokenChanged ->
+            }
+            is HostTokensAction.OnDraftTokenChanged -> {
+                val sanitized = HostNames.sanitizePastedToken(action.value)
                 _state.update {
                     it.copy(
-                        draftToken = action.value,
-                        draftTokenError = validateToken(action.value),
+                        draftToken = sanitized,
+                        draftTokenError = validateToken(sanitized),
+                        draftDetectedTokenKind = HostNames.detectPatKind(sanitized),
                     )
                 }
+            }
             is HostTokensAction.OnDraftDisplayNameChanged ->
                 _state.update { it.copy(draftDisplayName = action.value) }
+
             HostTokensAction.OnAddConfirm -> persistDraft()
             is HostTokensAction.OnDelete -> deleteHost(action.host)
+            HostTokensAction.OnUndoDelete -> undoDelete()
+            HostTokensAction.OnDismissUndoDelete ->
+                _state.update { it.copy(pendingUndoDelete = null) }
             is HostTokensAction.OnValidate -> validateExisting(action.host)
         }
     }
 
-    private fun validateHost(value: String): org.jetbrains.compose.resources.StringResource? {
-        val normalized = HostNames.normalize(value)
-        if (normalized.isEmpty()) return Res.string.host_tokens_validation_host_required
-        if (!normalized.contains('.')) return Res.string.host_tokens_validation_host_invalid
-        return null
+    private fun openCompose(forge: ForgeKind?, host: String) {
+        _state.update {
+            it.copy(
+                draftMode = DraftMode.Compose(replacingExisting = null),
+                draftForge = forge,
+                draftHost = host,
+                draftHostNormalized = host,
+                draftToken = "",
+                draftDisplayName = "",
+                draftHostError = null,
+                draftTokenError = null,
+                draftDetectedTokenKind = null,
+            )
+        }
+    }
+
+    private fun closeDraft() {
+        _state.update {
+            it.copy(
+                draftMode = DraftMode.Closed,
+                draftForge = null,
+                draftHost = "",
+                draftHostNormalized = "",
+                draftToken = "",
+                draftDisplayName = "",
+                draftHostError = null,
+                draftTokenError = null,
+                draftDetectedTokenKind = null,
+            )
+        }
+    }
+
+    private fun validateHost(normalized: String): org.jetbrains.compose.resources.StringResource? = when {
+        normalized.isEmpty() -> Res.string.host_tokens_validation_host_required
+        !normalized.contains('.') -> Res.string.host_tokens_validation_host_invalid
+        else -> null
     }
 
     private fun validateToken(value: String): org.jetbrains.compose.resources.StringResource? {
         val trimmed = value.trim()
-        if (trimmed.isEmpty()) return Res.string.host_tokens_validation_token_required
-        if (trimmed.length < 8) return Res.string.host_tokens_validation_token_short
-        return null
+        return when {
+            trimmed.isEmpty() -> Res.string.host_tokens_validation_token_required
+            trimmed.length < 8 -> Res.string.host_tokens_validation_token_short
+            else -> null
+        }
     }
 
     private fun persistDraft() {
         val current = state.value
-        val hostError = validateHost(current.draftHost)
-        val tokenError = validateToken(current.draftToken)
+        val mode = current.draftMode as? DraftMode.Compose ?: return
+        val replacing = mode.replacingExisting
+
+        val hostError = validateHost(current.draftHostNormalized)
+        val token = current.draftToken.trim()
+        val keepExistingToken = replacing != null && token.isEmpty()
+        val tokenError = if (keepExistingToken) null else validateToken(token)
         if (hostError != null || tokenError != null) {
             _state.update { it.copy(draftHostError = hostError, draftTokenError = tokenError) }
             return
         }
-        val host = HostNames.normalize(current.draftHost)
-        val token = current.draftToken.trim()
+        val host = current.draftHostNormalized
+        val effectiveToken = if (keepExistingToken) replacing!!.token else token
         val displayName = current.draftDisplayName.trim().takeIf { it.isNotEmpty() }
         viewModelScope.launch {
-            val saveResult = runCatching { repository.set(host, token, displayName) }
+            val saveResult = runCatching { repository.set(host, effectiveToken, displayName) }
             if (saveResult.isSuccess) {
-                _state.update {
-                    it.copy(
-                        isAddDialogVisible = false,
-                        draftHost = "",
-                        draftToken = "",
-                        draftDisplayName = "",
-                    )
-                }
+                closeDraft()
                 _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_saved, host)))
+                validateExisting(host, fromAdd = true)
             } else {
-                // Keep the dialog open with the draft intact so the user can
-                // retry — the persistence failure (Keystore unavailable,
-                // device locked, etc.) should not look like a silent success.
                 val msg = saveResult.exceptionOrNull()?.message.orEmpty()
                 _events.send(
                     HostTokensEvent.Message(
@@ -131,11 +208,19 @@ class HostTokensViewModel(
 
     private fun deleteHost(host: String) {
         viewModelScope.launch {
+            val snapshot = state.value.tokens.firstOrNull { it.host == host }
             val result = runCatching { repository.delete(host) }
             if (result.isSuccess) {
-                _events.send(
-                    HostTokensEvent.Message(getString(Res.string.host_tokens_removed, host)),
-                )
+                _state.update {
+                    it.copy(
+                        pendingUndoDelete = snapshot,
+                        validationByHost = it.validationByHost - host,
+                        validatingHosts = it.validatingHosts - host,
+                    )
+                }
+                if (snapshot != null) {
+                    _events.send(HostTokensEvent.TokenDeletedWithUndo(snapshot))
+                }
             } else {
                 val msg = result.exceptionOrNull()?.message.orEmpty()
                 _events.send(
@@ -147,34 +232,48 @@ class HostTokensViewModel(
         }
     }
 
-    private fun validateExisting(host: String) {
-        // Refuse to start another validation while one is in flight against
-        // the same host — concurrent calls would race shared UI flags
-        // (`isValidating`, `pendingValidationFor`) and emit stale messages.
-        if (state.value.isValidating && state.value.pendingValidationFor == host) return
+    private fun undoDelete() {
+        val pending = state.value.pendingUndoDelete ?: return
+        viewModelScope.launch {
+            runCatching { repository.set(pending.host, pending.token, pending.displayName) }
+            _state.update { it.copy(pendingUndoDelete = null) }
+        }
+    }
+
+    private fun validateExisting(host: String, fromAdd: Boolean = false) {
+        if (host in state.value.validatingHosts) return
         viewModelScope.launch {
             val token = runCatching { repository.get(host)?.token }.getOrNull() ?: return@launch
-            _state.update { it.copy(isValidating = true, pendingValidationFor = host, validationMessage = null) }
+            _state.update { it.copy(validatingHosts = it.validatingHosts + host) }
             val result = repository.validate(host, token)
-            val message = result.fold(
+            val line = result.fold(
                 onSuccess = { v ->
-                    val login = v.login ?: "?"
-                    val scopes = if (v.scopes.isEmpty()) "-" else v.scopes.joinToString(",")
-                    getString(Res.string.host_tokens_validation_success, login, scopes)
+                    ValidationLine(
+                        login = v.login,
+                        scopes = v.scopes,
+                        rateLimitRemaining = v.rateLimitRemaining,
+                        errorMessage = null,
+                    )
                 },
                 onFailure = { t ->
-                    getString(Res.string.host_tokens_validation_failed, t.message ?: "")
+                    ValidationLine(
+                        login = null,
+                        scopes = emptyList(),
+                        rateLimitRemaining = null,
+                        errorMessage = t.message ?: "validation failed",
+                    )
                 },
             )
             _state.update {
-                // Only clear the in-flight flags if THIS host is still the
-                // one being shown as pending — defends against a second
-                // validation racing in past the guard above (e.g. for a
-                // different host).
-                if (it.pendingValidationFor == host) {
-                    it.copy(isValidating = false, pendingValidationFor = null, validationMessage = message)
-                } else {
-                    it.copy(validationMessage = message)
+                it.copy(
+                    validatingHosts = it.validatingHosts - host,
+                    validationByHost = it.validationByHost + (host to line),
+                )
+            }
+            if (fromAdd && line.isSuccess && !line.login.isNullOrBlank()) {
+                val current = repository.get(host)
+                if (current != null && current.displayName.isNullOrBlank()) {
+                    runCatching { repository.set(host, current.token, line.login) }
                 }
             }
         }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -15,7 +16,9 @@ import zed.rainxch.core.domain.repository.AuthenticationState
 import zed.rainxch.core.domain.repository.HostTokenRepository
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_saved
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_undo_failed
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_failed
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_failed_fallback
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_invalid
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_required
 import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_token_required
@@ -29,24 +32,39 @@ class HostTokensViewModel(
     private val _state = MutableStateFlow(HostTokensState(isLoading = true))
     val state = _state.asStateFlow()
 
-    private val _events = Channel<HostTokensEvent>()
+    private val _events = Channel<HostTokensEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {
         viewModelScope.launch {
-            repository.observeAll().collect { tokens ->
-                _state.update {
-                    it.copy(
-                        tokens = tokens.sortedBy { t -> t.host },
-                        isLoading = false,
+            // .catch so a downstream KSafe / serialization throw doesn't
+            // tear down the collector and leave the screen stuck on the
+            // initial loading spinner. We surface the failure once via
+            // Message and drop isLoading so the UI shows the empty state.
+            repository.observeAll()
+                .catch { t ->
+                    _state.update { it.copy(isLoading = false) }
+                    _events.send(
+                        HostTokensEvent.Message(
+                            getString(Res.string.host_tokens_validation_failed, t.message.orEmpty()),
+                        ),
                     )
                 }
-            }
+                .collect { tokens ->
+                    _state.update {
+                        it.copy(
+                            tokens = tokens.sortedBy { t -> t.host },
+                            isLoading = false,
+                        )
+                    }
+                }
         }
         viewModelScope.launch {
-            authenticationState.isUserLoggedIn().collect { signedIn ->
-                _state.update { it.copy(isOAuthSignedInToGithub = signedIn) }
-            }
+            authenticationState.isUserLoggedIn()
+                .catch { /* swallow — OAuth state is non-critical for this screen */ }
+                .collect { signedIn ->
+                    _state.update { it.copy(isOAuthSignedInToGithub = signedIn) }
+                }
         }
     }
 
@@ -235,8 +253,22 @@ class HostTokensViewModel(
     private fun undoDelete() {
         val pending = state.value.pendingUndoDelete ?: return
         viewModelScope.launch {
-            runCatching { repository.set(pending.host, pending.token, pending.displayName) }
-            _state.update { it.copy(pendingUndoDelete = null) }
+            val result = runCatching {
+                repository.set(pending.host, pending.token, pending.displayName)
+            }
+            if (result.isSuccess) {
+                _state.update { it.copy(pendingUndoDelete = null) }
+            } else {
+                // Surface the failure but keep `pendingUndoDelete` populated so
+                // the user could trigger another undo (if surfaced) instead of
+                // losing the bytes silently. The actual "another undo" surface
+                // does not exist today; at minimum we emit the error.
+                _events.send(
+                    HostTokensEvent.Message(
+                        getString(Res.string.host_tokens_undo_failed, pending.host),
+                    ),
+                )
+            }
         }
     }
 
@@ -260,7 +292,8 @@ class HostTokensViewModel(
                         login = null,
                         scopes = emptyList(),
                         rateLimitRemaining = null,
-                        errorMessage = t.message ?: "validation failed",
+                        errorMessage = t.message
+                            ?: getString(Res.string.host_tokens_validation_failed_fallback),
                     )
                 },
             )

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
@@ -1,0 +1,133 @@
+package zed.rainxch.tweaks.presentation.hosttokens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import zed.rainxch.core.domain.model.HostNames
+import zed.rainxch.core.domain.repository.HostTokenRepository
+
+class HostTokensViewModel(
+    private val repository: HostTokenRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HostTokensState(isLoading = true))
+    val state = _state.asStateFlow()
+
+    private val _events = Channel<HostTokensEvent>()
+    val events = _events.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeAll().collect { tokens ->
+                _state.update { it.copy(tokens = tokens.sortedBy { t -> t.host }, isLoading = false) }
+            }
+        }
+    }
+
+    fun onAction(action: HostTokensAction) {
+        when (action) {
+            HostTokensAction.OnNavigateBack -> { /* host handles */ }
+            HostTokensAction.OnAddClicked ->
+                _state.update {
+                    it.copy(
+                        isAddDialogVisible = true,
+                        draftHost = "",
+                        draftToken = "",
+                        draftDisplayName = "",
+                        draftHostError = null,
+                        draftTokenError = null,
+                        validationMessage = null,
+                    )
+                }
+            HostTokensAction.OnAddDismiss ->
+                _state.update { it.copy(isAddDialogVisible = false) }
+            is HostTokensAction.OnDraftHostChanged ->
+                _state.update {
+                    it.copy(
+                        draftHost = action.value,
+                        draftHostError = validateHost(action.value),
+                    )
+                }
+            is HostTokensAction.OnDraftTokenChanged ->
+                _state.update {
+                    it.copy(
+                        draftToken = action.value,
+                        draftTokenError = validateToken(action.value),
+                    )
+                }
+            is HostTokensAction.OnDraftDisplayNameChanged ->
+                _state.update { it.copy(draftDisplayName = action.value) }
+            HostTokensAction.OnAddConfirm -> persistDraft()
+            is HostTokensAction.OnDelete -> deleteHost(action.host)
+            is HostTokensAction.OnValidate -> validateExisting(action.host)
+        }
+    }
+
+    private fun validateHost(value: String): String? {
+        val normalized = HostNames.normalize(value)
+        if (normalized.isEmpty()) return "Host required"
+        if (!normalized.contains('.')) return "Invalid host"
+        return null
+    }
+
+    private fun validateToken(value: String): String? {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) return "Token required"
+        if (trimmed.length < 8) return "Token too short"
+        return null
+    }
+
+    private fun persistDraft() {
+        val current = state.value
+        val hostError = validateHost(current.draftHost)
+        val tokenError = validateToken(current.draftToken)
+        if (hostError != null || tokenError != null) {
+            _state.update { it.copy(draftHostError = hostError, draftTokenError = tokenError) }
+            return
+        }
+        val host = HostNames.normalize(current.draftHost)
+        val token = current.draftToken.trim()
+        val displayName = current.draftDisplayName.trim().takeIf { it.isNotEmpty() }
+        viewModelScope.launch {
+            repository.set(host, token, displayName)
+            _state.update {
+                it.copy(
+                    isAddDialogVisible = false,
+                    draftHost = "",
+                    draftToken = "",
+                    draftDisplayName = "",
+                )
+            }
+            _events.send(HostTokensEvent.Message("Saved token for $host"))
+        }
+    }
+
+    private fun deleteHost(host: String) {
+        viewModelScope.launch {
+            repository.delete(host)
+            _events.send(HostTokensEvent.Message("Removed token for $host"))
+        }
+    }
+
+    private fun validateExisting(host: String) {
+        viewModelScope.launch {
+            val token = repository.get(host)?.token ?: return@launch
+            _state.update { it.copy(isValidating = true, pendingValidationFor = host, validationMessage = null) }
+            val result = repository.validate(host, token)
+            val message = result.fold(
+                onSuccess = { v ->
+                    val login = v.login ?: "(unknown)"
+                    val scopes = if (v.scopes.isEmpty()) "no scopes" else v.scopes.joinToString(",")
+                    "✓ $host accepts token (login=$login, scopes=$scopes)"
+                },
+                onFailure = { t -> "✗ ${t.message ?: "validation failed"}" },
+            )
+            _state.update { it.copy(isValidating = false, pendingValidationFor = null, validationMessage = message) }
+        }
+    }
+}

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
@@ -8,8 +8,18 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import zed.rainxch.core.domain.model.HostNames
 import zed.rainxch.core.domain.repository.HostTokenRepository
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_removed
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_saved
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_failed
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_invalid
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_host_required
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_success
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_token_required
+import zed.rainxch.githubstore.core.presentation.res.host_tokens_validation_token_short
 
 class HostTokensViewModel(
     private val repository: HostTokenRepository,
@@ -68,17 +78,17 @@ class HostTokensViewModel(
         }
     }
 
-    private fun validateHost(value: String): String? {
+    private fun validateHost(value: String): org.jetbrains.compose.resources.StringResource? {
         val normalized = HostNames.normalize(value)
-        if (normalized.isEmpty()) return "Host required"
-        if (!normalized.contains('.')) return "Invalid host"
+        if (normalized.isEmpty()) return Res.string.host_tokens_validation_host_required
+        if (!normalized.contains('.')) return Res.string.host_tokens_validation_host_invalid
         return null
     }
 
-    private fun validateToken(value: String): String? {
+    private fun validateToken(value: String): org.jetbrains.compose.resources.StringResource? {
         val trimmed = value.trim()
-        if (trimmed.isEmpty()) return "Token required"
-        if (trimmed.length < 8) return "Token too short"
+        if (trimmed.isEmpty()) return Res.string.host_tokens_validation_token_required
+        if (trimmed.length < 8) return Res.string.host_tokens_validation_token_short
         return null
     }
 
@@ -103,14 +113,14 @@ class HostTokensViewModel(
                     draftDisplayName = "",
                 )
             }
-            _events.send(HostTokensEvent.Message("Saved token for $host"))
+            _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_saved, host)))
         }
     }
 
     private fun deleteHost(host: String) {
         viewModelScope.launch {
             repository.delete(host)
-            _events.send(HostTokensEvent.Message("Removed token for $host"))
+            _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_removed, host)))
         }
     }
 
@@ -121,11 +131,13 @@ class HostTokensViewModel(
             val result = repository.validate(host, token)
             val message = result.fold(
                 onSuccess = { v ->
-                    val login = v.login ?: "(unknown)"
-                    val scopes = if (v.scopes.isEmpty()) "no scopes" else v.scopes.joinToString(",")
-                    "✓ $host accepts token (login=$login, scopes=$scopes)"
+                    val login = v.login ?: "?"
+                    val scopes = if (v.scopes.isEmpty()) "-" else v.scopes.joinToString(",")
+                    getString(Res.string.host_tokens_validation_success, login, scopes)
                 },
-                onFailure = { t -> "✗ ${t.message ?: "validation failed"}" },
+                onFailure = { t ->
+                    getString(Res.string.host_tokens_validation_failed, t.message ?: "")
+                },
             )
             _state.update { it.copy(isValidating = false, pendingValidationFor = null, validationMessage = message) }
         }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hosttokens/HostTokensViewModel.kt
@@ -104,29 +104,56 @@ class HostTokensViewModel(
         val token = current.draftToken.trim()
         val displayName = current.draftDisplayName.trim().takeIf { it.isNotEmpty() }
         viewModelScope.launch {
-            repository.set(host, token, displayName)
-            _state.update {
-                it.copy(
-                    isAddDialogVisible = false,
-                    draftHost = "",
-                    draftToken = "",
-                    draftDisplayName = "",
+            val saveResult = runCatching { repository.set(host, token, displayName) }
+            if (saveResult.isSuccess) {
+                _state.update {
+                    it.copy(
+                        isAddDialogVisible = false,
+                        draftHost = "",
+                        draftToken = "",
+                        draftDisplayName = "",
+                    )
+                }
+                _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_saved, host)))
+            } else {
+                // Keep the dialog open with the draft intact so the user can
+                // retry — the persistence failure (Keystore unavailable,
+                // device locked, etc.) should not look like a silent success.
+                val msg = saveResult.exceptionOrNull()?.message.orEmpty()
+                _events.send(
+                    HostTokensEvent.Message(
+                        getString(Res.string.host_tokens_validation_failed, msg),
+                    ),
                 )
             }
-            _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_saved, host)))
         }
     }
 
     private fun deleteHost(host: String) {
         viewModelScope.launch {
-            repository.delete(host)
-            _events.send(HostTokensEvent.Message(getString(Res.string.host_tokens_removed, host)))
+            val result = runCatching { repository.delete(host) }
+            if (result.isSuccess) {
+                _events.send(
+                    HostTokensEvent.Message(getString(Res.string.host_tokens_removed, host)),
+                )
+            } else {
+                val msg = result.exceptionOrNull()?.message.orEmpty()
+                _events.send(
+                    HostTokensEvent.Message(
+                        getString(Res.string.host_tokens_validation_failed, msg),
+                    ),
+                )
+            }
         }
     }
 
     private fun validateExisting(host: String) {
+        // Refuse to start another validation while one is in flight against
+        // the same host — concurrent calls would race shared UI flags
+        // (`isValidating`, `pendingValidationFor`) and emit stale messages.
+        if (state.value.isValidating && state.value.pendingValidationFor == host) return
         viewModelScope.launch {
-            val token = repository.get(host)?.token ?: return@launch
+            val token = runCatching { repository.get(host)?.token }.getOrNull() ?: return@launch
             _state.update { it.copy(isValidating = true, pendingValidationFor = host, validationMessage = null) }
             val result = repository.validate(host, token)
             val message = result.fold(
@@ -139,7 +166,17 @@ class HostTokensViewModel(
                     getString(Res.string.host_tokens_validation_failed, t.message ?: "")
                 },
             )
-            _state.update { it.copy(isValidating = false, pendingValidationFor = null, validationMessage = message) }
+            _state.update {
+                // Only clear the in-flight flags if THIS host is still the
+                // one being shown as pending — defends against a second
+                // validation racing in past the guard above (e.g. for a
+                // different host).
+                if (it.pendingValidationFor == host) {
+                    it.copy(isValidating = false, pendingValidationFor = null, validationMessage = message)
+                } else {
+                    it.copy(validationMessage = message)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `HostTokenRepository` + KSafe-backed impl (per-host PAT vault inside existing `ghs_tokens` vault).
- `HostTokens` sub-screen under Tweaks with add / validate / delete + dialog.
- `HostTokenInterceptor` Ktor plugin (opt-in, not wired into existing GitHub client yet).
- Snapshot wiring: Domain → Data → DI → ViewModel → Sub-screen + entry card.

## Test plan
- [ ] Android: open Tweaks → "Authentication tokens" → add github.com PAT → validate → delete
- [ ] Desktop: same path
- [ ] Token persists across app restart (KSafe encrypted)
- [ ] Compile both targets — ✓ verified

## Notes
- Wiring to Codeberg / Forgejo clients lives on `feat/e8-codeberg-forgejo`; rebase or merge order is up to you.
- No regression to existing OAuth path — interceptor is unused until wired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host Tokens UI: manage per-host personal access tokens (add/edit/replace/delete), masked entry, forge presets, picker, validation, undo snackbar, and OAuth coexistence messaging.
  * Host Tokens reachable from Tweaks and app navigation; includes list, FAB, dialogs, row actions, and localized strings.
  * Tokens are persisted and automatically applied to outgoing requests when relevant; token validation shows login/scopes/rate info.

* **Bug Fixes**
  * Fixed version-matching logic for pending app installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->