### PR TITLE
feat(details): auto-translate README + release notes on open

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -215,6 +215,29 @@ class TweaksRepositoryImpl(
         }
     }
 
+    override fun getAutoTranslateEnabled(): Flow<Boolean> =
+        gatedGetFlow(K_AUTO_TRANSLATE_ENABLED, false)
+
+    override suspend fun setAutoTranslateEnabled(enabled: Boolean) {
+        migrationDeferred.await()
+        ksafe.put(K_AUTO_TRANSLATE_ENABLED, enabled)
+    }
+
+    override fun getAutoTranslateTargetLang(): Flow<String?> =
+        gatedGetFlow<String?>(K_AUTO_TRANSLATE_TARGET, null).map { raw ->
+            raw?.trim()?.takeIf { it.isNotEmpty() }
+        }
+
+    override suspend fun setAutoTranslateTargetLang(tag: String?) {
+        migrationDeferred.await()
+        val normalized = tag?.trim().orEmpty()
+        if (normalized.isEmpty()) {
+            ksafe.delete(K_AUTO_TRANSLATE_TARGET)
+        } else {
+            ksafe.put(K_AUTO_TRANSLATE_TARGET, normalized)
+        }
+    }
+
     override fun getExternalImportEnabled(): Flow<Boolean> = gatedGetFlow(K_EXTERNAL_IMPORT_ENABLED, true)
     override suspend fun setExternalImportEnabled(enabled: Boolean) { migrationDeferred.await(); ksafe.put(K_EXTERNAL_IMPORT_ENABLED, enabled) }
 
@@ -322,6 +345,8 @@ class TweaksRepositoryImpl(
         MigrationEntry(stringPreferencesKey("youdao_app_key"), K_YOUDAO_APP_KEY),
         MigrationEntry(stringPreferencesKey("youdao_app_secret"), K_YOUDAO_APP_SECRET),
         MigrationEntry(stringPreferencesKey("app_language"), K_APP_LANGUAGE),
+        MigrationEntry(booleanPreferencesKey("auto_translate_enabled"), K_AUTO_TRANSLATE_ENABLED),
+        MigrationEntry(stringPreferencesKey("auto_translate_target_lang"), K_AUTO_TRANSLATE_TARGET),
         MigrationEntry(booleanPreferencesKey("external_import_enabled"), K_EXTERNAL_IMPORT_ENABLED),
         MigrationEntry(booleanPreferencesKey("external_match_search_enabled"), K_EXTERNAL_MATCH_SEARCH_ENABLED),
         MigrationEntry(intPreferencesKey("external_import_banner_dismissed_at"), K_EXTERNAL_IMPORT_BANNER_DISMISSED_AT),
@@ -363,6 +388,8 @@ class TweaksRepositoryImpl(
         private const val K_YOUDAO_APP_KEY = "youdao_app_key"
         private const val K_YOUDAO_APP_SECRET = "youdao_app_secret"
         private const val K_APP_LANGUAGE = "app_language"
+        private const val K_AUTO_TRANSLATE_ENABLED = "auto_translate_enabled"
+        private const val K_AUTO_TRANSLATE_TARGET = "auto_translate_target_lang"
         private const val K_EXTERNAL_IMPORT_ENABLED = "external_import_enabled"
         private const val K_EXTERNAL_MATCH_SEARCH_ENABLED = "external_match_search_enabled"
         private const val K_EXTERNAL_IMPORT_BANNER_DISMISSED_AT = "external_import_banner_dismissed_at"

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/SupportedTranslationLanguage.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/SupportedTranslationLanguage.kt
@@ -1,0 +1,48 @@
+package zed.rainxch.core.domain.model
+
+data class SupportedTranslationLanguage(
+    val code: String,
+    val displayName: String,
+)
+
+object SupportedTranslationLanguages {
+    val all: List<SupportedTranslationLanguage> =
+        listOf(
+            SupportedTranslationLanguage("ar", "Arabic"),
+            SupportedTranslationLanguage("bn", "Bengali"),
+            SupportedTranslationLanguage("zh-CN", "Chinese (Simplified)"),
+            SupportedTranslationLanguage("zh-TW", "Chinese (Traditional)"),
+            SupportedTranslationLanguage("cs", "Czech"),
+            SupportedTranslationLanguage("da", "Danish"),
+            SupportedTranslationLanguage("nl", "Dutch"),
+            SupportedTranslationLanguage("en", "English"),
+            SupportedTranslationLanguage("fi", "Finnish"),
+            SupportedTranslationLanguage("fr", "French"),
+            SupportedTranslationLanguage("de", "German"),
+            SupportedTranslationLanguage("el", "Greek"),
+            SupportedTranslationLanguage("he", "Hebrew"),
+            SupportedTranslationLanguage("hi", "Hindi"),
+            SupportedTranslationLanguage("hu", "Hungarian"),
+            SupportedTranslationLanguage("id", "Indonesian"),
+            SupportedTranslationLanguage("it", "Italian"),
+            SupportedTranslationLanguage("ja", "Japanese"),
+            SupportedTranslationLanguage("ko", "Korean"),
+            SupportedTranslationLanguage("ms", "Malay"),
+            SupportedTranslationLanguage("no", "Norwegian"),
+            SupportedTranslationLanguage("pl", "Polish"),
+            SupportedTranslationLanguage("pt", "Portuguese"),
+            SupportedTranslationLanguage("pt-BR", "Portuguese (Brazil)"),
+            SupportedTranslationLanguage("ro", "Romanian"),
+            SupportedTranslationLanguage("ru", "Russian"),
+            SupportedTranslationLanguage("es", "Spanish"),
+            SupportedTranslationLanguage("sv", "Swedish"),
+            SupportedTranslationLanguage("th", "Thai"),
+            SupportedTranslationLanguage("tr", "Turkish"),
+            SupportedTranslationLanguage("uk", "Ukrainian"),
+            SupportedTranslationLanguage("uz", "Uzbek"),
+            SupportedTranslationLanguage("vi", "Vietnamese"),
+        )
+
+    fun findByCode(code: String?): SupportedTranslationLanguage? =
+        code?.let { c -> all.firstOrNull { it.code.equals(c, ignoreCase = true) } }
+}

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -92,6 +92,24 @@ interface TweaksRepository {
 
     suspend fun setAppLanguage(tag: String?)
 
+    /**
+     * When `true`, Details kicks off a translation of the README and
+     * release notes immediately on load, using
+     * [getAutoTranslateTargetLang] as the target. Default `false`.
+     */
+    fun getAutoTranslateEnabled(): Flow<Boolean>
+
+    suspend fun setAutoTranslateEnabled(enabled: Boolean)
+
+    /**
+     * BCP 47 tag of the language Details auto-translates into when
+     * [getAutoTranslateEnabled] is `true`. `null` falls back to the
+     * UI language ([getAppLanguage]) at translate time.
+     */
+    fun getAutoTranslateTargetLang(): Flow<String?>
+
+    suspend fun setAutoTranslateTargetLang(tag: String?)
+
     fun getExternalImportEnabled(): Flow<Boolean>
 
     suspend fun setExternalImportEnabled(enabled: Boolean)

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1216,4 +1216,6 @@
     <!-- Auto-translate -->
     <string name="translation_auto_title">Auto-translate repositories</string>
     <string name="translation_auto_subtitle">Translate README and release notes automatically when opening a repository. Uses your app language as the target.</string>
+    <string name="translation_auto_target">Target: %1$s</string>
+    <string name="translation_auto_target_reset">Reset</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1218,4 +1218,6 @@
     <string name="translation_auto_subtitle">Translate README and release notes automatically when opening a repository. Uses your app language as the target.</string>
     <string name="translation_auto_target">Target: %1$s</string>
     <string name="translation_auto_target_reset">Reset</string>
+    <string name="translation_auto_target_label">Translate into</string>
+    <string name="translation_auto_target_followup">Following app language (%1$s)</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1212,4 +1212,8 @@
     <string name="kao_banner_body">Google's developer-verification policy threatens open Android distribution. GitHub Store stands with the coalition.</string>
     <string name="kao_banner_cta">Learn more</string>
     <string name="kao_banner_dismiss_cd">Dismiss banner</string>
+
+    <!-- Auto-translate -->
+    <string name="translation_auto_title">Auto-translate repositories</string>
+    <string name="translation_auto_subtitle">Translate README and release notes automatically when opening a repository. Uses your app language as the target.</string>
 </resources>

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -2895,10 +2895,15 @@ class DetailsViewModel(
                 tweaksRepository.getAutoTranslateEnabled().first()
             }.getOrDefault(false)
             if (!enabled) return@launch
+            // Treat blank explicit target as "unset" so fallback chain can
+            // run — `explicit = ""` would otherwise short-circuit the
+            // `?:` operator and disable auto-translate.
             val explicit = runCatching {
                 tweaksRepository.getAutoTranslateTargetLang().first()
-            }.getOrNull()
-            val app = runCatching { tweaksRepository.getAppLanguage().first() }.getOrNull()
+            }.getOrNull()?.takeIf { it.isNotBlank() }
+            val app = runCatching {
+                tweaksRepository.getAppLanguage().first()
+            }.getOrNull()?.takeIf { it.isNotBlank() }
             val target = explicit ?: app ?: translationRepository.getDeviceLanguageCode()
             if (target.isBlank()) return@launch
 
@@ -2915,8 +2920,16 @@ class DetailsViewModel(
                     getCurrentState = { _state.value.aboutTranslation },
                 )
             }
+            // Source-language guard mirrors the README branch — if the
+            // release-notes source language already matches the target,
+            // skip the translation round-trip. The release model carries
+            // no language hint, so we fall back to `readmeLanguage` as the
+            // best available signal for repositories that consistently
+            // author release notes in the repo's primary language.
+            val releaseSourceLang = currentReadmeLang
             if (!releaseDescription.isNullOrBlank() &&
-                _state.value.whatsNewTranslation.translatedText == null
+                _state.value.whatsNewTranslation.translatedText == null &&
+                releaseSourceLang?.equals(target, ignoreCase = true) != true
             ) {
                 whatsNewTranslationJob?.cancel()
                 whatsNewTranslationJob = translateContent(

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -2717,6 +2717,11 @@ class DetailsViewModel(
                 telemetryRepository.recordRepoViewed(repo.id)
 
                 observeInstalledApp(repo.id)
+
+                maybeAutoTranslate(
+                    readmeBody = readme?.first,
+                    releaseDescription = selectedRelease?.description,
+                )
             } catch (e: RateLimitException) {
                 logger.error("Rate limited: ${e.message}")
                 val seconds = e.rateLimitInfo.timeUntilReset().inWholeSeconds
@@ -2879,6 +2884,46 @@ class DetailsViewModel(
                 _state.update { it.copy(isRefreshing = false) }
                 _events.send(
                     DetailsEvent.OnRefreshError(kind = RefreshError.GENERIC),
+                )
+            }
+        }
+    }
+
+    private fun maybeAutoTranslate(readmeBody: String?, releaseDescription: String?) {
+        viewModelScope.launch {
+            val enabled = runCatching {
+                tweaksRepository.getAutoTranslateEnabled().first()
+            }.getOrDefault(false)
+            if (!enabled) return@launch
+            val explicit = runCatching {
+                tweaksRepository.getAutoTranslateTargetLang().first()
+            }.getOrNull()
+            val app = runCatching { tweaksRepository.getAppLanguage().first() }.getOrNull()
+            val target = explicit ?: app ?: translationRepository.getDeviceLanguageCode()
+            if (target.isBlank()) return@launch
+
+            val currentReadmeLang = _state.value.readmeLanguage
+            if (!readmeBody.isNullOrBlank() &&
+                _state.value.aboutTranslation.translatedText == null &&
+                currentReadmeLang?.equals(target, ignoreCase = true) != true
+            ) {
+                aboutTranslationJob?.cancel()
+                aboutTranslationJob = translateContent(
+                    text = readmeBody,
+                    targetLanguageCode = target,
+                    updateState = { ts -> _state.update { it.copy(aboutTranslation = ts) } },
+                    getCurrentState = { _state.value.aboutTranslation },
+                )
+            }
+            if (!releaseDescription.isNullOrBlank() &&
+                _state.value.whatsNewTranslation.translatedText == null
+            ) {
+                whatsNewTranslationJob?.cancel()
+                whatsNewTranslationJob = translateContent(
+                    text = releaseDescription,
+                    targetLanguageCode = target,
+                    updateState = { ts -> _state.update { it.copy(whatsNewTranslation = ts) } },
+                    getCurrentState = { _state.value.whatsNewTranslation },
                 )
             }
         }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
@@ -155,6 +155,14 @@ sealed interface TweaksAction {
 
     data object OnYoudaoCredentialsSave : TweaksAction
 
+    data class OnAutoTranslateEnabledToggle(
+        val enabled: Boolean,
+    ) : TweaksAction
+
+    data class OnAutoTranslateTargetSelected(
+        val tag: String?,
+    ) : TweaksAction
+
     /**
      * User picked a UI language. `tag == null` means "follow system
      * locale" — cleared persisted preference.

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
@@ -58,6 +58,8 @@ data class TweaksState(
      * which chip is selected.
      */
     val selectedAppLanguage: String? = null,
+    val autoTranslateEnabled: Boolean = false,
+    val autoTranslateTargetLang: String? = null,
     val isFeedbackSheetVisible: Boolean = false,
     /**
      * True only on aggressive-OEM Android devices (Oppo, OnePlus, Realme,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -108,6 +108,7 @@ class TweaksViewModel(
                     loadTelemetryEnabled()
                     loadTranslationSettings()
                     loadAppLanguage()
+                    loadAutoTranslate()
 
                     observeShizukuStatus()
                     observeDhizukuStatus()
@@ -499,6 +500,19 @@ class TweaksViewModel(
         viewModelScope.launch {
             tweaksRepository.getAppLanguage().collect { tag ->
                 _state.update { it.copy(selectedAppLanguage = tag) }
+            }
+        }
+    }
+
+    private fun loadAutoTranslate() {
+        viewModelScope.launch {
+            tweaksRepository.getAutoTranslateEnabled().collect { enabled ->
+                _state.update { it.copy(autoTranslateEnabled = enabled) }
+            }
+        }
+        viewModelScope.launch {
+            tweaksRepository.getAutoTranslateTargetLang().collect { tag ->
+                _state.update { it.copy(autoTranslateTargetLang = tag) }
             }
         }
     }
@@ -968,6 +982,18 @@ class TweaksViewModel(
                     if (getPlatform() != Platform.ANDROID) {
                         _events.send(TweaksEvent.OnAppLanguageChangeRequiresRestart)
                     }
+                }
+            }
+
+            is TweaksAction.OnAutoTranslateEnabledToggle -> {
+                viewModelScope.launch {
+                    tweaksRepository.setAutoTranslateEnabled(action.enabled)
+                }
+            }
+
+            is TweaksAction.OnAutoTranslateTargetSelected -> {
+                viewModelScope.launch {
+                    tweaksRepository.setAutoTranslateTargetLang(action.tag)
                 }
             }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Language.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Language.kt
@@ -103,7 +103,7 @@ private fun LanguagePickerCard(
 }
 
 @Composable
-private fun LanguageDropdown(
+internal fun LanguageDropdown(
     selectedTag: String?,
     onLanguageSelected: (String?) -> Unit,
 ) {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -75,8 +75,8 @@ fun LazyListScope.translationSection(
             targetLanguageTag = state.autoTranslateTargetLang,
             appLanguageTag = state.selectedAppLanguage,
             onToggle = { onAction(TweaksAction.OnAutoTranslateEnabledToggle(it)) },
-            onClearExplicitTarget = {
-                onAction(TweaksAction.OnAutoTranslateTargetSelected(null))
+            onTargetSelected = { tag ->
+                onAction(TweaksAction.OnAutoTranslateTargetSelected(tag))
             },
         )
     }
@@ -88,7 +88,7 @@ private fun AutoTranslateCard(
     targetLanguageTag: String?,
     appLanguageTag: String?,
     onToggle: (Boolean) -> Unit,
-    onClearExplicitTarget: () -> Unit,
+    onTargetSelected: (String?) -> Unit,
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -121,26 +121,31 @@ private fun AutoTranslateCard(
                 )
             }
             if (enabled) {
-                val effectiveTarget = (targetLanguageTag ?: appLanguageTag).orEmpty()
-                Row(
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = stringResource(
-                            Res.string.translation_auto_target,
-                            effectiveTarget.ifBlank { stringResource(Res.string.language_follow_system) },
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
+                        text = stringResource(Res.string.translation_auto_target_label),
+                        style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.weight(1f),
                     )
-                    if (targetLanguageTag != null) {
-                        androidx.compose.material3.TextButton(onClick = onClearExplicitTarget) {
-                            Text(stringResource(Res.string.translation_auto_target_reset))
-                        }
+                    Spacer(Modifier.height(6.dp))
+                    LanguageDropdown(
+                        selectedTag = targetLanguageTag,
+                        onLanguageSelected = onTargetSelected,
+                    )
+                    if (targetLanguageTag == null && !appLanguageTag.isNullOrBlank()) {
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            text = stringResource(
+                                Res.string.translation_auto_target_followup,
+                                appLanguageTag,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                 }
             }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,15 +15,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
@@ -32,7 +39,12 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -42,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
 import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.model.SupportedTranslationLanguages
 import zed.rainxch.core.domain.model.TranslationProvider
 import zed.rainxch.githubstore.core.presentation.res.*
 import zed.rainxch.tweaks.presentation.TweaksAction
@@ -132,7 +145,7 @@ private fun AutoTranslateCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Spacer(Modifier.height(6.dp))
-                    LanguageDropdown(
+                    TranslationTargetDropdown(
                         selectedTag = targetLanguageTag,
                         onLanguageSelected = onTargetSelected,
                     )
@@ -229,6 +242,98 @@ private fun providerLabel(provider: TranslationProvider): String =
         TranslationProvider.GOOGLE -> stringResource(Res.string.translation_provider_google)
         TranslationProvider.YOUDAO -> stringResource(Res.string.translation_provider_youdao)
     }
+
+/**
+ * Dropdown for picking the auto-translate target language.
+ *
+ * Distinct from [LanguageDropdown]: that one is bound to `AppLanguages` —
+ * the 13 locales the app ships UI translations for. Translation targets
+ * are a wider set ([SupportedTranslationLanguages.all] — 33 entries
+ * spanning everything the translation service can produce, including
+ * German, Dutch, Portuguese, Ukrainian, Vietnamese, etc. that the app
+ * itself isn't translated into).
+ */
+@Composable
+private fun TranslationTargetDropdown(
+    selectedTag: String?,
+    onLanguageSelected: (String?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val currentLabel = when (val match = SupportedTranslationLanguages.findByCode(selectedTag)) {
+        null -> stringResource(Res.string.language_follow_system)
+        else -> match.displayName
+    }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .clickable { expanded = true }
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = currentLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            Spacer(Modifier.size(8.dp))
+            Icon(
+                imageVector = Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            shape = RoundedCornerShape(20.dp),
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.language_follow_system)) },
+                onClick = {
+                    onLanguageSelected(null)
+                    expanded = false
+                },
+                trailingIcon = {
+                    if (selectedTag == null) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                },
+            )
+            SupportedTranslationLanguages.all.forEach { lang ->
+                DropdownMenuItem(
+                    text = { Text(lang.displayName) },
+                    onClick = {
+                        onLanguageSelected(lang.code)
+                        expanded = false
+                    },
+                    trailingIcon = {
+                        if (selectedTag.equals(lang.code, ignoreCase = true)) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
 
 @Composable
 private fun YoudaoCredentialsForm(

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,7 +72,12 @@ fun LazyListScope.translationSection(
 
         AutoTranslateCard(
             enabled = state.autoTranslateEnabled,
+            targetLanguageTag = state.autoTranslateTargetLang,
+            appLanguageTag = state.selectedAppLanguage,
             onToggle = { onAction(TweaksAction.OnAutoTranslateEnabledToggle(it)) },
+            onClearExplicitTarget = {
+                onAction(TweaksAction.OnAutoTranslateTargetSelected(null))
+            },
         )
     }
 }
@@ -79,7 +85,10 @@ fun LazyListScope.translationSection(
 @Composable
 private fun AutoTranslateCard(
     enabled: Boolean,
+    targetLanguageTag: String?,
+    appLanguageTag: String?,
     onToggle: (Boolean) -> Unit,
+    onClearExplicitTarget: () -> Unit,
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -88,27 +97,53 @@ private fun AutoTranslateCard(
         ),
         shape = RoundedCornerShape(32.dp),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(Res.string.translation_auto_title),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = stringResource(Res.string.translation_auto_subtitle),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(Res.string.translation_auto_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(Res.string.translation_auto_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = onToggle,
                 )
             }
-            androidx.compose.material3.Switch(
-                checked = enabled,
-                onCheckedChange = onToggle,
-            )
+            if (enabled) {
+                val effectiveTarget = (targetLanguageTag ?: appLanguageTag).orEmpty()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(
+                            Res.string.translation_auto_target,
+                            effectiveTarget.ifBlank { stringResource(Res.string.language_follow_system) },
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (targetLanguageTag != null) {
+                        androidx.compose.material3.TextButton(onClick = onClearExplicitTarget) {
+                            Text(stringResource(Res.string.translation_auto_target_reset))
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -66,6 +66,50 @@ fun LazyListScope.translationSection(
             state = state,
             onAction = onAction,
         )
+
+        Spacer(Modifier.height(8.dp))
+
+        AutoTranslateCard(
+            enabled = state.autoTranslateEnabled,
+            onToggle = { onAction(TweaksAction.OnAutoTranslateEnabledToggle(it)) },
+        )
+    }
+}
+
+@Composable
+private fun AutoTranslateCard(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+        shape = RoundedCornerShape(32.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(Res.string.translation_auto_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = stringResource(Res.string.translation_auto_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            androidx.compose.material3.Switch(
+                checked = enabled,
+                onCheckedChange = onToggle,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Two new `TweaksRepository` prefs (`auto_translate_enabled`, `auto_translate_target_lang`) with KSafe migration entries.
- `Auto-translate repositories` toggle in Tweaks → Translation section.
- `DetailsViewModel.maybeAutoTranslate` kicks off `TranslateAbout` + `TranslateWhatsNew` once when readme and release description first load and the user's app language differs from the source.
- Target resolution: explicit pref → app language → device locale.

Closes #423.

## Test plan
- [ ] Toggle on, open a repo with English README and Chinese app language → README + release notes auto-translate
- [ ] Toggle off, same flow → no auto-translation
- [ ] Compile both targets — ✓ verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-translate for READMEs and release notes with enable/disable toggle and language picker (select/reset).
  * Automatic conditional translation during initial content load, using explicit target, app language, or device language as fallback.
  * New UI strings and controls for configuring auto-translate.

* **Chores**
  * Preferences added and migrated so auto-translate settings persist across updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->