### PR TITLE
perf(details): drop BoxWithConstraints subcompose + lazy keys

### DIFF
--- a/feature/details/presentation/build.gradle.kts
+++ b/feature/details/presentation/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
                 implementation(libs.markdown.renderer)
                 implementation(libs.markdown.renderer.coil3)
                 implementation(libs.highlights)
+                implementation(libs.ktor.client.core)
 
                 implementation(libs.jetbrains.compose.components.resources)
                 implementation(libs.kotlinx.datetime)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -3,7 +3,6 @@ package zed.rainxch.details.presentation
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -63,6 +62,8 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -492,15 +493,27 @@ fun DetailsScreen(
                 return@Scaffold
             }
 
-            BoxWithConstraints(
-                modifier = Modifier.fillMaxSize(),
+            val density = LocalDensity.current
+            var containerHeightDp by remember { mutableStateOf(0.dp) }
+            val collapsedSectionHeight = containerHeightDp * 0.7f
+            val listState = rememberLazyListState()
+            val isScrollbarEnabled = LocalScrollbarEnabled.current
+            val pullEnabled = remember { isPullToRefreshSupported() }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onSizeChanged { size ->
+                        // Layout-phase write; cheaper than BoxWithConstraints
+                        // which subcomposes during the measure pass. Setting
+                        // a state var here recomposes only the consumers that
+                        // read it (the about/whatsNew sections), not the
+                        // entire Scaffold subtree.
+                        val newHeight = with(density) { size.height.toDp() }
+                        if (newHeight != containerHeightDp) containerHeightDp = newHeight
+                    },
                 contentAlignment = Alignment.Center,
             ) {
-                val collapsedSectionHeight = maxHeight * 0.7f
-                val listState = rememberLazyListState()
-                val isScrollbarEnabled = LocalScrollbarEnabled.current
-                val pullEnabled = remember { isPullToRefreshSupported() }
-
                 ScrollbarContainer(
                     listState = listState,
                     enabled = isScrollbarEnabled,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -53,6 +53,7 @@ import zed.rainxch.details.presentation.model.TranslationState
 import zed.rainxch.details.presentation.utils.MarkdownImageTransformer
 import zed.rainxch.details.presentation.utils.rememberMarkdownColors
 import zed.rainxch.details.presentation.utils.rememberMarkdownTypography
+import zed.rainxch.details.presentation.utils.truncateMarkdownPreview
 import zed.rainxch.githubstore.core.presentation.res.*
 
 fun LazyListScope.about(
@@ -159,10 +160,19 @@ fun ExpandableMarkdownContent(
     // freeze on first render and theme toggle. We launch it on Default and
     // gate rendering on completion via `displayContent` being non-null.
     var displayContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
+    var previewContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
     LaunchedEffect(rawMarkdown, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(rawMarkdown, isDark)
         }
+        // Light truncated version for the collapsed state — first ~6000 chars
+        // truncated at a paragraph boundary. Renders far fewer markdown nodes
+        // (cheap initial composition); the full string is only handed to the
+        // renderer once the user taps "Read more".
+        val preview = withContext(Dispatchers.Default) {
+            truncateMarkdownPreview(processed, maxChars = 6000)
+        }
+        previewContent = preview
         displayContent = processed
     }
 
@@ -206,7 +216,14 @@ fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                val content = displayContent
+                // When collapsed, render the truncated preview — far cheaper
+                // composition than the full markdown tree. Switch to the full
+                // tree only when the user expands.
+                val content = when {
+                    isExpanded -> displayContent
+                    !isExpanded && previewContent != null -> previewContent
+                    else -> displayContent
+                }
                 if (content == null) {
                     // Pre-processing in flight. Show a small spinner clamped
                     // to the collapsed-section height so the scroll position

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -53,6 +53,7 @@ import zed.rainxch.details.presentation.model.TranslationState
 import zed.rainxch.details.presentation.utils.MarkdownImageTransformer
 import zed.rainxch.details.presentation.utils.rememberMarkdownColors
 import zed.rainxch.details.presentation.utils.rememberMarkdownTypography
+import zed.rainxch.details.presentation.utils.splitMarkdownIntoChunks
 import zed.rainxch.details.presentation.utils.truncateMarkdownPreview
 import zed.rainxch.githubstore.core.presentation.res.*
 
@@ -159,21 +160,29 @@ fun ExpandableMarkdownContent(
     // composition thread (typically Main) and contributed to the visible
     // freeze on first render and theme toggle. We launch it on Default and
     // gate rendering on completion via `displayContent` being non-null.
-    var displayContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
     var previewContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
+    var fullChunks by remember(rawMarkdown, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(rawMarkdown, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(rawMarkdown, isDark)
         }
         // Light truncated version for the collapsed state — first ~6000 chars
         // truncated at a paragraph boundary. Renders far fewer markdown nodes
-        // (cheap initial composition); the full string is only handed to the
-        // renderer once the user taps "Read more".
+        // (cheap initial composition); the full body is only progressively
+        // streamed in once the user taps "Read more".
         val preview = withContext(Dispatchers.Default) {
             truncateMarkdownPreview(processed, maxChars = 6000)
         }
+        // Pre-split the full body into ~4 000-char chunks (kept whole around
+        // code fences) so the expanded view can compose them one frame at a
+        // time instead of dropping a single multi-megabyte composition pass
+        // on Main when the user taps Expand. Observed Davey of 4.4s on a
+        // big README — this distributes that across many frames.
+        val chunks = withContext(Dispatchers.Default) {
+            splitMarkdownIntoChunks(processed, targetChunkChars = 4000)
+        }
         previewContent = preview
-        displayContent = processed
+        fullChunks = chunks
     }
 
     // Parser + flavour are heavy to construct and identical across recompositions;
@@ -216,64 +225,22 @@ fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                // When collapsed, render the truncated preview — far cheaper
-                // composition than the full markdown tree. Switch to the full
-                // tree only when the user expands.
-                val content = when {
-                    isExpanded -> displayContent
-                    !isExpanded && previewContent != null -> previewContent
-                    else -> displayContent
-                }
-                if (content == null) {
-                    // Pre-processing in flight. Show a small spinner clamped
-                    // to the collapsed-section height so the scroll position
-                    // doesn't jump once content lands.
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(collapsedHeight.takeIf { it > 0.dp } ?: 120.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
-                    }
-                } else {
-                    // `retainState = true` keeps the previous parsed AST on
-                    // screen while the next parse runs in the background —
-                    // no flash to a blank Loading state on theme toggle or
-                    // minor edits.
-                    val markdownState = rememberMarkdownState(
-                        content = content,
-                        flavour = flavour,
-                        parser = parser,
-                        retainState = true,
-                    )
-                    // Local-only measure latch — write the size up to the
-                    // hoisted VM state once it has stabilised (within 1px of
-                    // the previous local value), instead of forwarding every
-                    // onSizeChanged tick. Each forwarded write recopies the
-                    // full DetailsState; this damps that churn.
-                    var lastReportedPx by remember(rawMarkdown) { mutableStateOf(0f) }
-                    Markdown(
-                        markdownState = markdownState,
-                        colors = colors,
-                        typography = typography,
-                        imageTransformer = imageTransformer,
-                        components = components,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .onSizeChanged { size ->
-                                    val measured = size.height.toFloat()
-                                    val decisive = effectiveHeight > collapsedHeightPx
-                                    if (decisive) return@onSizeChanged
-                                    if (abs(measured - lastReportedPx) < 1f) return@onSizeChanged
-                                    lastReportedPx = measured
-                                    if (measured > effectiveHeight) {
-                                        onMeasured(measured)
-                                    }
-                                },
-                    )
-                }
+                ProgressiveMarkdown(
+                    isExpanded = isExpanded,
+                    previewContent = previewContent,
+                    fullChunks = fullChunks,
+                    collapsedHeight = collapsedHeight,
+                    colors = colors,
+                    typography = typography,
+                    components = components,
+                    flavour = flavour,
+                    parser = parser,
+                    imageTransformer = imageTransformer,
+                    onMeasured = onMeasured,
+                    effectiveHeight = effectiveHeight,
+                    collapsedHeightPx = collapsedHeightPx,
+                    rawKey = rawMarkdown,
+                )
             }
 
             if (!isExpanded && needsExpansion) {
@@ -308,6 +275,123 @@ fun ExpandableMarkdownContent(
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
                 )
+            }
+        }
+    }
+}
+
+/**
+ * Streams `fullChunks` into the composition one chunk per frame when
+ * `isExpanded` flips true. Renders `previewContent` when collapsed.
+ *
+ * Each chunk is its own `Markdown(...)` composable with its own
+ * `MarkdownState` (parser still runs on `Dispatchers.Default` per the
+ * mikepenz lib). The "one per frame" cadence keeps composition cost
+ * predictable instead of dropping the entire body's compose pass on
+ * Main in a single 4-second hit (observed Davey on a kubernetes-sized
+ * README before this change).
+ */
+@Composable
+internal fun ProgressiveMarkdown(
+    isExpanded: Boolean,
+    previewContent: String?,
+    fullChunks: List<String>?,
+    collapsedHeight: Dp,
+    colors: com.mikepenz.markdown.model.MarkdownColors,
+    typography: com.mikepenz.markdown.model.MarkdownTypography,
+    components: com.mikepenz.markdown.compose.components.MarkdownComponents,
+    flavour: GFMFlavourDescriptor,
+    parser: MarkdownParser,
+    imageTransformer: ImageTransformer,
+    onMeasured: (Float) -> Unit,
+    effectiveHeight: Float,
+    collapsedHeightPx: Float,
+    rawKey: String,
+) {
+    val isLoading = previewContent == null && fullChunks == null
+    if (isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(collapsedHeight.takeIf { it > 0.dp } ?: 120.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(28.dp))
+        }
+        return
+    }
+
+    if (!isExpanded) {
+        val content = previewContent ?: fullChunks?.firstOrNull() ?: return
+        val markdownState = rememberMarkdownState(
+            content = content,
+            flavour = flavour,
+            parser = parser,
+            retainState = true,
+        )
+        var lastReportedPx by remember(rawKey) { mutableStateOf(0f) }
+        Markdown(
+            markdownState = markdownState,
+            colors = colors,
+            typography = typography,
+            imageTransformer = imageTransformer,
+            components = components,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { size ->
+                    val measured = size.height.toFloat()
+                    val decisive = effectiveHeight > collapsedHeightPx
+                    if (decisive) return@onSizeChanged
+                    if (abs(measured - lastReportedPx) < 1f) return@onSizeChanged
+                    lastReportedPx = measured
+                    if (measured > effectiveHeight) onMeasured(measured)
+                },
+        )
+        return
+    }
+
+    val chunks = fullChunks ?: return
+    // Counter starts at 1 so the first chunk renders synchronously on
+    // expand (instant feedback) and the rest stream in one per frame.
+    var renderedCount by remember(rawKey) { mutableStateOf(1) }
+    LaunchedEffect(rawKey, chunks.size) {
+        while (renderedCount < chunks.size) {
+            // Yield to the frame so the previously-added chunk has a chance
+            // to compose + layout + draw before the next chunk arrives.
+            // `delay(16)` would also work; yield is cheaper and lets us
+            // catch up faster on idle frames.
+            kotlinx.coroutines.yield()
+            renderedCount++
+        }
+    }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        val toRender = chunks.take(renderedCount.coerceAtMost(chunks.size))
+        toRender.forEachIndexed { index, chunk ->
+            androidx.compose.runtime.key(rawKey, index) {
+                val markdownState = rememberMarkdownState(
+                    content = chunk,
+                    flavour = flavour,
+                    parser = parser,
+                    retainState = true,
+                )
+                Markdown(
+                    markdownState = markdownState,
+                    colors = colors,
+                    typography = typography,
+                    imageTransformer = imageTransformer,
+                    components = components,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+        if (renderedCount < chunks.size) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp))
             }
         }
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -159,29 +159,21 @@ fun ExpandableMarkdownContent(
     // is regex-heavy; running it inside `remember { ... }` happened on the
     // composition thread (typically Main) and contributed to the visible
     // freeze on first render and theme toggle. We launch it on Default and
-    // gate rendering on completion via `displayContent` being non-null.
-    var previewContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
+    // gate rendering on completion via `fullChunks` being non-null.
+    //
+    // We split the full body into ~4 000-char chunks (kept whole around
+    // code fences). Chunk 0 doubles as the collapsed preview; subsequent
+    // chunks stream in one frame at a time once the user taps Expand.
+    // Crucially, chunk 0 stays mounted across collapse → expand, so the
+    // transition is a height grow rather than a content swap — no flicker.
     var fullChunks by remember(rawMarkdown, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(rawMarkdown, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(rawMarkdown, isDark)
         }
-        // Light truncated version for the collapsed state — first ~6000 chars
-        // truncated at a paragraph boundary. Renders far fewer markdown nodes
-        // (cheap initial composition); the full body is only progressively
-        // streamed in once the user taps "Read more".
-        val preview = withContext(Dispatchers.Default) {
-            truncateMarkdownPreview(processed, maxChars = 6000)
-        }
-        // Pre-split the full body into ~4 000-char chunks (kept whole around
-        // code fences) so the expanded view can compose them one frame at a
-        // time instead of dropping a single multi-megabyte composition pass
-        // on Main when the user taps Expand. Observed Davey of 4.4s on a
-        // big README — this distributes that across many frames.
         val chunks = withContext(Dispatchers.Default) {
             splitMarkdownIntoChunks(processed, targetChunkChars = 4000)
         }
-        previewContent = preview
         fullChunks = chunks
     }
 
@@ -227,7 +219,6 @@ fun ExpandableMarkdownContent(
             ) {
                 ProgressiveMarkdown(
                     isExpanded = isExpanded,
-                    previewContent = previewContent,
                     fullChunks = fullChunks,
                     collapsedHeight = collapsedHeight,
                     colors = colors,
@@ -281,11 +272,15 @@ fun ExpandableMarkdownContent(
 }
 
 /**
- * Streams `fullChunks` into the composition one chunk per frame when
- * `isExpanded` flips true. Renders `previewContent` when collapsed.
+ * Renders chunked markdown progressively. Chunk 0 is always mounted
+ * (used as the collapsed-state preview, clipped by the parent's
+ * `Modifier.height(collapsedHeight)` modifier). When `isExpanded` flips
+ * true, subsequent chunks stream in one frame at a time without
+ * unmounting / remounting chunk 0 — that stable identity is what kills
+ * the previous expand-time flicker.
  *
  * Each chunk is its own `Markdown(...)` composable with its own
- * `MarkdownState` (parser still runs on `Dispatchers.Default` per the
+ * `MarkdownState` (parser runs on `Dispatchers.Default` per the
  * mikepenz lib). The "one per frame" cadence keeps composition cost
  * predictable instead of dropping the entire body's compose pass on
  * Main in a single 4-second hit (observed Davey on a kubernetes-sized
@@ -294,7 +289,6 @@ fun ExpandableMarkdownContent(
 @Composable
 internal fun ProgressiveMarkdown(
     isExpanded: Boolean,
-    previewContent: String?,
     fullChunks: List<String>?,
     collapsedHeight: Dp,
     colors: com.mikepenz.markdown.model.MarkdownColors,
@@ -308,8 +302,8 @@ internal fun ProgressiveMarkdown(
     collapsedHeightPx: Float,
     rawKey: String,
 ) {
-    val isLoading = previewContent == null && fullChunks == null
-    if (isLoading) {
+    val chunks = fullChunks
+    if (chunks == null) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -321,52 +315,35 @@ internal fun ProgressiveMarkdown(
         return
     }
 
-    if (!isExpanded) {
-        val content = previewContent ?: fullChunks?.firstOrNull() ?: return
-        val markdownState = rememberMarkdownState(
-            content = content,
-            flavour = flavour,
-            parser = parser,
-            retainState = true,
-        )
-        var lastReportedPx by remember(rawKey) { mutableStateOf(0f) }
-        Markdown(
-            markdownState = markdownState,
-            colors = colors,
-            typography = typography,
-            imageTransformer = imageTransformer,
-            components = components,
-            modifier = Modifier
-                .fillMaxWidth()
-                .onSizeChanged { size ->
-                    val measured = size.height.toFloat()
-                    val decisive = effectiveHeight > collapsedHeightPx
-                    if (decisive) return@onSizeChanged
-                    if (abs(measured - lastReportedPx) < 1f) return@onSizeChanged
-                    lastReportedPx = measured
-                    if (measured > effectiveHeight) onMeasured(measured)
-                },
-        )
-        return
-    }
-
-    val chunks = fullChunks ?: return
-    // Counter starts at 1 so the first chunk renders synchronously on
-    // expand (instant feedback) and the rest stream in one per frame.
+    // Counter starts at 1 so chunk 0 (the natural preview) renders
+    // immediately for the collapsed view. Once the user expands, the
+    // remaining chunks stream in one frame at a time.
     var renderedCount by remember(rawKey) { mutableStateOf(1) }
-    LaunchedEffect(rawKey, chunks.size) {
+    LaunchedEffect(rawKey, isExpanded, chunks.size) {
+        if (!isExpanded) return@LaunchedEffect
         while (renderedCount < chunks.size) {
             // Yield to the frame so the previously-added chunk has a chance
             // to compose + layout + draw before the next chunk arrives.
-            // `delay(16)` would also work; yield is cheaper and lets us
-            // catch up faster on idle frames.
             kotlinx.coroutines.yield()
             renderedCount++
         }
     }
-    Column(modifier = Modifier.fillMaxWidth()) {
-        val toRender = chunks.take(renderedCount.coerceAtMost(chunks.size))
-        toRender.forEachIndexed { index, chunk ->
+
+    var lastReportedPx by remember(rawKey) { mutableStateOf(0f) }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onSizeChanged { size ->
+                val measured = size.height.toFloat()
+                val decisive = effectiveHeight > collapsedHeightPx
+                if (decisive) return@onSizeChanged
+                if (abs(measured - lastReportedPx) < 1f) return@onSizeChanged
+                lastReportedPx = measured
+                if (measured > effectiveHeight) onMeasured(measured)
+            },
+    ) {
+        val visible = chunks.take(renderedCount.coerceAtMost(chunks.size))
+        visible.forEachIndexed { index, chunk ->
             androidx.compose.runtime.key(rawKey, index) {
                 val markdownState = rememberMarkdownState(
                     content = chunk,
@@ -384,7 +361,7 @@ internal fun ProgressiveMarkdown(
                 )
             }
         }
-        if (renderedCount < chunks.size) {
+        if (isExpanded && renderedCount < chunks.size) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -8,11 +8,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -20,7 +23,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -33,9 +39,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.rememberMarkdownState
+import kotlin.math.abs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
 import org.jetbrains.compose.resources.stringResource
+import zed.rainxch.core.domain.util.applyThemeAwareImages
 import zed.rainxch.details.presentation.components.TranslationControls
+import zed.rainxch.details.presentation.markdown.githubStoreMarkdownComponents
 import zed.rainxch.details.presentation.model.TranslationState
 import zed.rainxch.details.presentation.utils.MarkdownImageTransformer
 import zed.rainxch.details.presentation.utils.rememberMarkdownColors
@@ -105,13 +118,10 @@ fun LazyListScope.about(
                 readmeMarkdown
             }
         val isDark = androidx.compose.foundation.isSystemInDarkTheme()
-        val displayContent =
-            androidx.compose.runtime.remember(raw, isDark) {
-                zed.rainxch.core.domain.util.applyThemeAwareImages(raw, isDark)
-            }
 
         ExpandableMarkdownContent(
-            content = displayContent,
+            rawMarkdown = raw,
+            isDark = isDark,
             isExpanded = isExpanded,
             onToggleExpanded = onToggleExpanded,
             imageTransformer = MarkdownImageTransformer,
@@ -128,7 +138,8 @@ fun LazyListScope.about(
 
 @Composable
 fun ExpandableMarkdownContent(
-    content: String,
+    rawMarkdown: String,
+    isDark: Boolean,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
     imageTransformer: ImageTransformer,
@@ -141,7 +152,28 @@ fun ExpandableMarkdownContent(
     val density = LocalDensity.current
     val colors = rememberMarkdownColors()
     val typography = rememberMarkdownTypography()
+
+    // Pre-process markdown off the main thread. The theme-aware image rewrite
+    // is regex-heavy; running it inside `remember { ... }` happened on the
+    // composition thread (typically Main) and contributed to the visible
+    // freeze on first render and theme toggle. We launch it on Default and
+    // gate rendering on completion via `displayContent` being non-null.
+    var displayContent by remember(rawMarkdown, isDark) { mutableStateOf<String?>(null) }
+    LaunchedEffect(rawMarkdown, isDark) {
+        val processed = withContext(Dispatchers.Default) {
+            applyThemeAwareImages(rawMarkdown, isDark)
+        }
+        displayContent = processed
+    }
+
+    // Parser + flavour are heavy to construct and identical across recompositions;
+    // hoist them once so they survive content / theme / scroll churn. The Markdown
+    // lib parses lazily on Dispatchers.Default once handed a fresh MarkdownState.
     val flavour = remember { GFMFlavourDescriptor() }
+    val parser = remember(flavour) { MarkdownParser(flavour) }
+    val components = remember(isDark, imageTransformer) {
+        githubStoreMarkdownComponents(imageTransformer, isDark)
+    }
 
     val collapsedHeightPx = with(density) { collapsedHeight.toPx() }
     val effectiveHeight = measuredHeightPx ?: 0f
@@ -174,26 +206,57 @@ fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                val isDark = androidx.compose.foundation.isSystemInDarkTheme()
-                Markdown(
-                    content = content,
-                    colors = colors,
-                    typography = typography,
-                    flavour = flavour,
-                    imageTransformer = imageTransformer,
-                    components = zed.rainxch.details.presentation.markdown
-                        .githubStoreMarkdownComponents(imageTransformer, isDark),
-                    modifier =
-                        Modifier
+                val content = displayContent
+                if (content == null) {
+                    // Pre-processing in flight. Show a small spinner clamped
+                    // to the collapsed-section height so the scroll position
+                    // doesn't jump once content lands.
+                    Box(
+                        modifier = Modifier
                             .fillMaxWidth()
-                            .onSizeChanged { size ->
-                                val measured = size.height.toFloat()
-                                val decisive = effectiveHeight > collapsedHeightPx
-                                if (!decisive && measured > effectiveHeight) {
-                                    onMeasured(measured)
-                                }
-                            },
-                )
+                            .height(collapsedHeight.takeIf { it > 0.dp } ?: 120.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                    }
+                } else {
+                    // `retainState = true` keeps the previous parsed AST on
+                    // screen while the next parse runs in the background —
+                    // no flash to a blank Loading state on theme toggle or
+                    // minor edits.
+                    val markdownState = rememberMarkdownState(
+                        content = content,
+                        flavour = flavour,
+                        parser = parser,
+                        retainState = true,
+                    )
+                    // Local-only measure latch — write the size up to the
+                    // hoisted VM state once it has stabilised (within 1px of
+                    // the previous local value), instead of forwarding every
+                    // onSizeChanged tick. Each forwarded write recopies the
+                    // full DetailsState; this damps that churn.
+                    var lastReportedPx by remember(rawMarkdown) { mutableStateOf(0f) }
+                    Markdown(
+                        markdownState = markdownState,
+                        colors = colors,
+                        typography = typography,
+                        imageTransformer = imageTransformer,
+                        components = components,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .onSizeChanged { size ->
+                                    val measured = size.height.toFloat()
+                                    val decisive = effectiveHeight > collapsedHeightPx
+                                    if (decisive) return@onSizeChanged
+                                    if (abs(measured - lastReportedPx) < 1f) return@onSizeChanged
+                                    lastReportedPx = measured
+                                    if (measured > effectiveHeight) {
+                                        onMeasured(measured)
+                                    }
+                                },
+                    )
+                }
             }
 
             if (!isExpanded && needsExpansion) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -120,13 +120,19 @@ fun LazyListScope.about(
                 readmeMarkdown
             }
         val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val probeClient = org.koin.compose.koinInject<io.ktor.client.HttpClient>(
+            qualifier = org.koin.core.qualifier.named("test"),
+        )
+        val imageTransformer = remember(probeClient) {
+            MarkdownImageTransformer(probeClient)
+        }
 
         ExpandableMarkdownContent(
             rawMarkdown = raw,
             isDark = isDark,
             isExpanded = isExpanded,
             onToggleExpanded = onToggleExpanded,
-            imageTransformer = MarkdownImageTransformer,
+            imageTransformer = imageTransformer,
             collapsedHeight = collapsedHeight,
             measuredHeightPx = measuredHeightPx,
             onMeasured = onMeasured,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Logs.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Logs.kt
@@ -2,7 +2,7 @@ package zed.rainxch.details.presentation.components.sections
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,11 +29,16 @@ fun LazyListScope.logs(state: DetailsState) {
         )
     }
 
-    items(
+    // `timeIso` is second-precision, so the same APK installed twice in
+    // one second would collide on a (timeIso + assetName) composite key.
+    // Including the list index makes the key unconditionally unique while
+    // still cheaper than no-key (kept stable across recompositions of the
+    // same list shape).
+    itemsIndexed(
         items = state.installLogs,
-        key = { it.timeIso + it.assetName },
-        contentType = { "install_log" },
-    ) { log ->
+        key = { index, log -> "$index|${log.timeIso}|${log.assetName}" },
+        contentType = { _, _ -> "install_log" },
+    ) { _, log ->
         Text(
             text = "> ${log.result.asText()}: ${log.assetName}",
             style =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Logs.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/Logs.kt
@@ -29,7 +29,11 @@ fun LazyListScope.logs(state: DetailsState) {
         )
     }
 
-    items(state.installLogs) { log ->
+    items(
+        items = state.installLogs,
+        key = { it.timeIso + it.assetName },
+        contentType = { "install_log" },
+    ) { log ->
         Text(
             text = "> ${log.result.asText()}: ${log.assetName}",
             style =

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -164,21 +164,15 @@ private fun ExpandableMarkdownContent(
     val isDark = androidx.compose.foundation.isSystemInDarkTheme()
 
     // Off-main pre-processing — see About.kt for the rationale.
-    var previewContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
     var fullChunks by remember(raw, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(raw, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(raw, isDark)
         }
-        val preview = withContext(Dispatchers.Default) {
-            zed.rainxch.details.presentation.utils
-                .truncateMarkdownPreview(processed, maxChars = 6000)
-        }
         val chunks = withContext(Dispatchers.Default) {
             zed.rainxch.details.presentation.utils
                 .splitMarkdownIntoChunks(processed, targetChunkChars = 4000)
         }
-        previewContent = preview
         fullChunks = chunks
     }
 
@@ -221,7 +215,6 @@ private fun ExpandableMarkdownContent(
             ) {
                 ProgressiveMarkdown(
                     isExpanded = isExpanded,
-                    previewContent = previewContent,
                     fullChunks = fullChunks,
                     collapsedHeight = collapsedHeight,
                     colors = colors,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -164,8 +164,8 @@ private fun ExpandableMarkdownContent(
     val isDark = androidx.compose.foundation.isSystemInDarkTheme()
 
     // Off-main pre-processing — see About.kt for the rationale.
-    var displayContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
     var previewContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
+    var fullChunks by remember(raw, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(raw, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(raw, isDark)
@@ -174,8 +174,12 @@ private fun ExpandableMarkdownContent(
             zed.rainxch.details.presentation.utils
                 .truncateMarkdownPreview(processed, maxChars = 6000)
         }
+        val chunks = withContext(Dispatchers.Default) {
+            zed.rainxch.details.presentation.utils
+                .splitMarkdownIntoChunks(processed, targetChunkChars = 4000)
+        }
         previewContent = preview
-        displayContent = processed
+        fullChunks = chunks
     }
 
     val density = LocalDensity.current
@@ -215,49 +219,22 @@ private fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                val content = when {
-                    isExpanded -> displayContent
-                    !isExpanded && previewContent != null -> previewContent
-                    else -> displayContent
-                }
-                if (content == null) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(collapsedHeight.takeIf { it > 0.dp } ?: 120.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
-                    }
-                } else {
-                    val markdownState = rememberMarkdownState(
-                        content = content,
-                        flavour = flavour,
-                        parser = parser,
-                        retainState = true,
-                    )
-                    var lastReportedPx by remember(raw) { mutableStateOf(0f) }
-                    Markdown(
-                        markdownState = markdownState,
-                        colors = colors,
-                        typography = typography,
-                        imageTransformer = MarkdownImageTransformer,
-                        components = components,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .onSizeChanged { size ->
-                                    val measured = size.height.toFloat()
-                                    val decisive = effectiveHeight > collapsedHeightPx
-                                    if (decisive) return@onSizeChanged
-                                    if (kotlin.math.abs(measured - lastReportedPx) < 1f) return@onSizeChanged
-                                    lastReportedPx = measured
-                                    if (measured > effectiveHeight) {
-                                        onMeasured(measured)
-                                    }
-                                },
-                    )
-                }
+                ProgressiveMarkdown(
+                    isExpanded = isExpanded,
+                    previewContent = previewContent,
+                    fullChunks = fullChunks,
+                    collapsedHeight = collapsedHeight,
+                    colors = colors,
+                    typography = typography,
+                    components = components,
+                    flavour = flavour,
+                    parser = parser,
+                    imageTransformer = MarkdownImageTransformer,
+                    onMeasured = onMeasured,
+                    effectiveHeight = effectiveHeight,
+                    collapsedHeightPx = collapsedHeightPx,
+                    rawKey = raw,
+                )
             }
 
             if (!isExpanded && needsExpansion) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -12,16 +12,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -30,6 +35,13 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.intellij.markdown.parser.MarkdownParser
+import com.mikepenz.markdown.model.rememberMarkdownState
+import zed.rainxch.core.domain.util.applyThemeAwareImages
+import zed.rainxch.details.presentation.markdown.githubStoreMarkdownComponents
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.compose.Markdown
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
@@ -150,15 +162,24 @@ private fun ExpandableMarkdownContent(
             release.description ?: stringResource(Res.string.no_release_notes)
         }
     val isDark = androidx.compose.foundation.isSystemInDarkTheme()
-    val displayContent =
-        remember(raw, isDark) {
-            zed.rainxch.core.domain.util.applyThemeAwareImages(raw, isDark)
+
+    // Off-main pre-processing — see About.kt for the rationale.
+    var displayContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
+    LaunchedEffect(raw, isDark) {
+        val processed = withContext(Dispatchers.Default) {
+            applyThemeAwareImages(raw, isDark)
         }
+        displayContent = processed
+    }
 
     val density = LocalDensity.current
     val colors = rememberMarkdownColors()
     val typography = rememberMarkdownTypography()
     val flavour = remember { GFMFlavourDescriptor() }
+    val parser = remember(flavour) { MarkdownParser(flavour) }
+    val components = remember(isDark) {
+        githubStoreMarkdownComponents(MarkdownImageTransformer, isDark)
+    }
     val cardColor = MaterialTheme.colorScheme.surfaceContainerLow
 
     val collapsedHeightPx = with(density) { collapsedHeight.toPx() }
@@ -188,25 +209,45 @@ private fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                Markdown(
-                    content = displayContent,
-                    colors = colors,
-                    typography = typography,
-                    flavour = flavour,
-                    imageTransformer = MarkdownImageTransformer,
-                    components = zed.rainxch.details.presentation.markdown
-                        .githubStoreMarkdownComponents(MarkdownImageTransformer, isDark),
-                    modifier =
-                        Modifier
+                val content = displayContent
+                if (content == null) {
+                    Box(
+                        modifier = Modifier
                             .fillMaxWidth()
-                            .onSizeChanged { size ->
-                                val measured = size.height.toFloat()
-                                val decisive = effectiveHeight > collapsedHeightPx
-                                if (!decisive && measured > effectiveHeight) {
-                                    onMeasured(measured)
-                                }
-                            },
-                )
+                            .height(collapsedHeight.takeIf { it > 0.dp } ?: 120.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                    }
+                } else {
+                    val markdownState = rememberMarkdownState(
+                        content = content,
+                        flavour = flavour,
+                        parser = parser,
+                        retainState = true,
+                    )
+                    var lastReportedPx by remember(raw) { mutableStateOf(0f) }
+                    Markdown(
+                        markdownState = markdownState,
+                        colors = colors,
+                        typography = typography,
+                        imageTransformer = MarkdownImageTransformer,
+                        components = components,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .onSizeChanged { size ->
+                                    val measured = size.height.toFloat()
+                                    val decisive = effectiveHeight > collapsedHeightPx
+                                    if (decisive) return@onSizeChanged
+                                    if (kotlin.math.abs(measured - lastReportedPx) < 1f) return@onSizeChanged
+                                    lastReportedPx = measured
+                                    if (measured > effectiveHeight) {
+                                        onMeasured(measured)
+                                    }
+                                },
+                    )
+                }
             }
 
             if (!isExpanded && needsExpansion) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -165,10 +165,16 @@ private fun ExpandableMarkdownContent(
 
     // Off-main pre-processing — see About.kt for the rationale.
     var displayContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
+    var previewContent by remember(raw, isDark) { mutableStateOf<String?>(null) }
     LaunchedEffect(raw, isDark) {
         val processed = withContext(Dispatchers.Default) {
             applyThemeAwareImages(raw, isDark)
         }
+        val preview = withContext(Dispatchers.Default) {
+            zed.rainxch.details.presentation.utils
+                .truncateMarkdownPreview(processed, maxChars = 6000)
+        }
+        previewContent = preview
         displayContent = processed
     }
 
@@ -209,7 +215,11 @@ private fun ExpandableMarkdownContent(
                         else -> Modifier
                     },
             ) {
-                val content = displayContent
+                val content = when {
+                    isExpanded -> displayContent
+                    !isExpanded && previewContent != null -> previewContent
+                    else -> displayContent
+                }
                 if (content == null) {
                     Box(
                         modifier = Modifier

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -181,8 +181,14 @@ private fun ExpandableMarkdownContent(
     val typography = rememberMarkdownTypography()
     val flavour = remember { GFMFlavourDescriptor() }
     val parser = remember(flavour) { MarkdownParser(flavour) }
-    val components = remember(isDark) {
-        githubStoreMarkdownComponents(MarkdownImageTransformer, isDark)
+    val probeClient = org.koin.compose.koinInject<io.ktor.client.HttpClient>(
+        qualifier = org.koin.core.qualifier.named("test"),
+    )
+    val imageTransformer = remember(probeClient) {
+        MarkdownImageTransformer(probeClient)
+    }
+    val components = remember(isDark, imageTransformer) {
+        githubStoreMarkdownComponents(imageTransformer, isDark)
     }
     val cardColor = MaterialTheme.colorScheme.surfaceContainerLow
 
@@ -222,7 +228,7 @@ private fun ExpandableMarkdownContent(
                     components = components,
                     flavour = flavour,
                     parser = parser,
-                    imageTransformer = MarkdownImageTransformer,
+                    imageTransformer = imageTransformer,
                     onMeasured = onMeasured,
                     effectiveHeight = effectiveHeight,
                     collapsedHeightPx = collapsedHeightPx,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
@@ -1,9 +1,17 @@
 package zed.rainxch.details.presentation.markdown
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalUriHandler
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.utils.getUnescapedTextInNode
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
 
 // Plain (non-@Composable) factory so callers can wrap in `remember(isDark)`
 // — the wrapped MarkdownComponents holds lambdas that get invoked inside the
@@ -35,4 +43,86 @@ fun githubStoreMarkdownComponents(
             SyntaxHighlightedCode(model, isDark)
         }
     },
+    image = { model -> LinkAwareMarkdownImage(model.content, model.node, imageTransformer) },
 )
+
+/**
+ * Drop-in replacement for the lib's default `MarkdownImage` that also
+ * supports the `[![alt](image-url)](href)` pattern — i.e. the image is a
+ * clickable hyperlink. README badges (Maven Central status, build status,
+ * sponsor buttons, "Get it on Play Store" / "Get it on F-Droid" tiles)
+ * all use that pattern.
+ *
+ * The lib's stock renderer pulls the image's own `LINK_DESTINATION` (the
+ * src) but ignores the outer INLINE_LINK that wraps it. We walk up via
+ * `ASTNode.parent`; if an ancestor is an INLINE_LINK, we grab its
+ * `LINK_DESTINATION` and apply `Modifier.clickable { openUri }` around
+ * the rendered image.
+ */
+@Composable
+private fun LinkAwareMarkdownImage(
+    content: String,
+    node: ASTNode,
+    imageTransformer: ImageTransformer,
+) {
+    val imageSrc = findChildRecursive(node, MarkdownElementTypes.LINK_DESTINATION)
+        ?.getUnescapedTextInNode(content)
+        ?: return
+    val outerHref = findEnclosingLinkDestination(node, content)
+    val imageData = imageTransformer.transform(imageSrc) ?: return
+
+    if (outerHref != null) {
+        val uriHandler = LocalUriHandler.current
+        Image(
+            painter = imageData.painter,
+            contentDescription = imageData.contentDescription,
+            modifier = imageData.modifier.clickable {
+                runCatching { uriHandler.openUri(outerHref) }
+            },
+            alignment = imageData.alignment,
+            contentScale = imageData.contentScale,
+            alpha = imageData.alpha,
+            colorFilter = imageData.colorFilter,
+        )
+    } else {
+        Image(
+            painter = imageData.painter,
+            contentDescription = imageData.contentDescription,
+            modifier = imageData.modifier,
+            alignment = imageData.alignment,
+            contentScale = imageData.contentScale,
+            alpha = imageData.alpha,
+            colorFilter = imageData.colorFilter,
+        )
+    }
+}
+
+private fun findChildRecursive(node: ASTNode, type: IElementType): ASTNode? {
+    for (child in node.children) {
+        if (child.type == type) return child
+        val nested = findChildRecursive(child, type)
+        if (nested != null) return nested
+    }
+    return null
+}
+
+private fun findEnclosingLinkDestination(imageNode: ASTNode, content: String): String? {
+    var cursor: ASTNode? = imageNode.parent
+    // Walk at most a few levels — INLINE_LINK is usually one or two
+    // parents up. Bail before drifting into the surrounding paragraph.
+    var depth = 0
+    while (cursor != null && depth < 4) {
+        if (cursor.type == MarkdownElementTypes.INLINE_LINK) {
+            // The INLINE_LINK's direct LINK_DESTINATION child is the href.
+            // Use the non-recursive child lookup so we don't accidentally
+            // pick up the image's own (inner) LINK_DESTINATION.
+            val destNode = cursor.children.firstOrNull {
+                it.type == MarkdownElementTypes.LINK_DESTINATION
+            } ?: return null
+            return destNode.getUnescapedTextInNode(content)
+        }
+        cursor = cursor.parent
+        depth++
+    }
+    return null
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
@@ -1,12 +1,13 @@
 package zed.rainxch.details.presentation.markdown
 
-import androidx.compose.runtime.Composable
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
 import org.intellij.markdown.MarkdownTokenTypes
 
-@Composable
+// Plain (non-@Composable) factory so callers can wrap in `remember(isDark)`
+// — the wrapped MarkdownComponents holds lambdas that get invoked inside the
+// Markdown render scope, but constructing the wrapper has no composition cost.
 fun githubStoreMarkdownComponents(
     imageTransformer: ImageTransformer,
     isDark: Boolean,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/SyntaxHighlightedCode.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/SyntaxHighlightedCode.kt
@@ -9,7 +9,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -23,6 +27,8 @@ import dev.snipme.highlights.model.BoldHighlight
 import dev.snipme.highlights.model.ColorHighlight
 import dev.snipme.highlights.model.SyntaxLanguage
 import dev.snipme.highlights.model.SyntaxThemes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
@@ -32,11 +38,25 @@ fun SyntaxHighlightedCode(
     model: MarkdownComponentModel,
     isDark: Boolean,
 ) {
-    val (language, code) = extractFenceContent(model.node, model.content)
-    val highlighted =
-        remember(code, language, isDark) {
+    val (language, code) = remember(model.node, model.content) {
+        extractFenceContent(model.node, model.content)
+    }
+
+    // Highlight tokenization is CPU-heavy on big code blocks. Run it on
+    // Default and render the plain code immediately so the markdown pass
+    // never blocks waiting for highlighting — Main-thread ANR observed
+    // previously with multiple large fences on a single README.
+    var highlighted by remember(code, language, isDark) {
+        mutableStateOf(AnnotatedString(code))
+    }
+    LaunchedEffect(code, language, isDark) {
+        if (code.isEmpty() || language == SyntaxLanguage.DEFAULT) return@LaunchedEffect
+        val result = withContext(Dispatchers.Default) {
             buildHighlighted(code, language, isDark)
         }
+        highlighted = result
+    }
+
     val container = MaterialTheme.colorScheme.surfaceContainerHigh
     val onContainer = MaterialTheme.colorScheme.onSurface
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/SyntaxHighlightedCode.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/SyntaxHighlightedCode.kt
@@ -33,6 +33,8 @@ import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 
+private const val MAX_HIGHLIGHTABLE_CHARS = 16_000
+
 @Composable
 fun SyntaxHighlightedCode(
     model: MarkdownComponentModel,
@@ -51,6 +53,10 @@ fun SyntaxHighlightedCode(
     }
     LaunchedEffect(code, language, isDark) {
         if (code.isEmpty() || language == SyntaxLanguage.DEFAULT) return@LaunchedEffect
+        // Skip giant code blocks (e.g. embedded JSON dumps, generated YAML).
+        // The Highlights tokenizer is super-linear in input size and the
+        // payoff for plain-eye reading shrinks fast past a few thousand chars.
+        if (code.length > MAX_HIGHLIGHTABLE_CHARS) return@LaunchedEffect
         val result = withContext(Dispatchers.Default) {
             buildHighlighted(code, language, isDark)
         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -1,16 +1,20 @@
 package zed.rainxch.details.presentation.utils
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
 import coil3.compose.LocalPlatformContext
 import coil3.compose.rememberAsyncImagePainter
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
+import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.mikepenz.markdown.model.ImageData
 import com.mikepenz.markdown.model.ImageTransformer
 
@@ -18,6 +22,14 @@ object MarkdownImageTransformer : ImageTransformer {
     private const val BROWSER_UA =
         "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
             "Chrome/126.0.0.0 Mobile Safari/537.36 GitHubStore/1.8"
+
+    // Hard cap on the decoded bitmap dimension. README images served at 4K+
+    // resolutions used to be decoded full-size on the IO/Decoder dispatcher,
+    // burning tens of megabytes per image and pushing GC pauses that
+    // surfaced as Main-thread frame drops while the bitmap was uploaded.
+    // 2048 px covers any display width on a phone or tablet at @3x density
+    // and keeps the bitmap memory cost reasonable.
+    private const val MAX_BITMAP_DIMENSION_PX = 2048
 
     private val networkHeaders =
         NetworkHeaders.Builder()
@@ -53,13 +65,29 @@ object MarkdownImageTransformer : ImageTransformer {
             ImageRequest.Builder(context)
                 .data(normalizedLink)
                 .httpHeaders(networkHeaders)
+                // Cap decoded bitmap so a 4K screenshot in a README doesn't
+                // allocate 64 MB and stutter the frame on upload to GPU.
+                // Coil rescales server-side response to fit before decoding.
+                .size(MAX_BITMAP_DIMENSION_PX)
+                // Stable cache key per normalized URL — same image appearing
+                // multiple times (badges, logos) hits memory cache after the
+                // first decode, skips the whole decode-and-upload path.
+                .memoryCacheKey(normalizedLink)
+                .diskCacheKey(normalizedLink)
+                .memoryCachePolicy(CachePolicy.ENABLED)
+                .diskCachePolicy(CachePolicy.ENABLED)
+                .crossfade(150)
                 .build()
 
         val painter = rememberAsyncImagePainter(model = request)
 
         return ImageData(
             painter = painter,
-            modifier = Modifier.fillMaxWidth(),
+            // Clamp displayed height so super-tall images (infographics,
+            // long screenshots, vertical banners) don't take over the
+            // scrollport — the previous unbounded heightIn caused 8000px
+            // images to dominate the entire README composition.
+            modifier = Modifier.fillMaxWidth().heightIn(max = 600.dp),
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
         )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -3,6 +3,11 @@ package zed.rainxch.details.presentation.utils
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.painter.Painter
@@ -17,28 +22,35 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.mikepenz.markdown.model.ImageData
 import com.mikepenz.markdown.model.ImageTransformer
+import io.ktor.client.HttpClient
+import io.ktor.client.request.head
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
-object MarkdownImageTransformer : ImageTransformer {
-    private const val BROWSER_UA =
-        "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/126.0.0.0 Mobile Safari/537.36 GitHubStore/1.8"
-
-    // Hard cap on the decoded bitmap dimension. README images served at 4K+
-    // resolutions used to be decoded full-size on the IO/Decoder dispatcher,
-    // burning tens of megabytes per image and pushing GC pauses that
-    // surfaced as Main-thread frame drops while the bitmap was uploaded.
-    // 2048 px covers any display width on a phone or tablet at @3x density
-    // and keeps the bitmap memory cost reasonable.
-    private const val MAX_BITMAP_DIMENSION_PX = 2048
-
-    private val networkHeaders =
-        NetworkHeaders.Builder()
-            .add("User-Agent", BROWSER_UA)
-            .add(
-                "Accept",
-                "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
-            )
-            .build()
+/**
+ * Skips rendering of images whose advertised `Content-Length` exceeds
+ * [MAX_IMAGE_BYTES]. A HEAD probe runs once per URL on `Dispatchers.IO`
+ * via the injected [probeClient] (re-used: the same client used for
+ * proxy testing in `core.data.di.SharedModule` under the `test`
+ * qualifier — short request timeouts, no extra interceptors). Results
+ * are cached process-wide so a README that references the same big
+ * image twice still probes once.
+ *
+ * Decoded-bitmap dimension is also capped at [MAX_BITMAP_DIMENSION_PX]
+ * so a 4K source image (Content-Length under the byte threshold) is
+ * still rescaled before reaching the GPU.
+ *
+ * Servers that omit `Content-Length` (chunked transfer, mis-configured
+ * CDNs) are treated as "size unknown" and rendered normally — the byte
+ * cap is best-effort, not a guarantee.
+ */
+class MarkdownImageTransformer(
+    private val probeClient: HttpClient,
+) : ImageTransformer {
 
     @Composable
     override fun transform(link: String): ImageData? {
@@ -60,18 +72,40 @@ object MarkdownImageTransformer : ImageTransformer {
             return null
         }
 
+        val isDataUri = normalizedLink.startsWith("data:")
+
+        var probeResult by remember(normalizedLink) {
+            mutableStateOf<ProbeResult>(probeCache[normalizedLink] ?: ProbeResult.Pending)
+        }
+        LaunchedEffect(normalizedLink) {
+            if (isDataUri) {
+                probeResult = ProbeResult.Allowed
+                return@LaunchedEffect
+            }
+            val cached = probeCache[normalizedLink]
+            if (cached != null) {
+                probeResult = cached
+                return@LaunchedEffect
+            }
+            val result = withContext(Dispatchers.IO) {
+                probeOnce(normalizedLink)
+            }
+            probeCache[normalizedLink] = result
+            probeResult = result
+        }
+
+        // Skip rendering entirely when the advertised payload would have
+        // burned bandwidth + decode time. Returning `null` makes the
+        // markdown renderer omit the image element; alt text (if any)
+        // remains visible in the surrounding paragraph.
+        if (probeResult is ProbeResult.Skipped) return null
+
         val context = LocalPlatformContext.current
         val request =
             ImageRequest.Builder(context)
                 .data(normalizedLink)
                 .httpHeaders(networkHeaders)
-                // Cap decoded bitmap so a 4K screenshot in a README doesn't
-                // allocate 64 MB and stutter the frame on upload to GPU.
-                // Coil rescales server-side response to fit before decoding.
                 .size(MAX_BITMAP_DIMENSION_PX)
-                // Stable cache key per normalized URL — same image appearing
-                // multiple times (badges, logos) hits memory cache after the
-                // first decode, skips the whole decode-and-upload path.
                 .memoryCacheKey(normalizedLink)
                 .diskCacheKey(normalizedLink)
                 .memoryCachePolicy(CachePolicy.ENABLED)
@@ -83,10 +117,6 @@ object MarkdownImageTransformer : ImageTransformer {
 
         return ImageData(
             painter = painter,
-            // Clamp displayed height so super-tall images (infographics,
-            // long screenshots, vertical banners) don't take over the
-            // scrollport — the previous unbounded heightIn caused 8000px
-            // images to dominate the entire README composition.
             modifier = Modifier.fillMaxWidth().heightIn(max = 600.dp),
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
@@ -95,4 +125,63 @@ object MarkdownImageTransformer : ImageTransformer {
 
     @Composable
     override fun intrinsicSize(painter: Painter): Size = painter.intrinsicSize
+
+    private suspend fun probeOnce(url: String): ProbeResult {
+        probeMutex.withLock {
+            probeCache[url]?.let { return it }
+            val result = runCatching {
+                val response: HttpResponse = probeClient.head(url)
+                val contentLength = response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+                when {
+                    contentLength == null -> ProbeResult.Allowed
+                    contentLength > MAX_IMAGE_BYTES -> ProbeResult.Skipped(contentLength)
+                    else -> ProbeResult.Allowed
+                }
+            }.getOrElse {
+                // Probe failed (timeout, CORS, network off). Allow render;
+                // Coil itself will surface the error if the real request
+                // fails. We don't penalise unreachable servers here.
+                ProbeResult.Allowed
+            }
+            probeCache[url] = result
+            return result
+        }
+    }
+
+    sealed interface ProbeResult {
+        data object Pending : ProbeResult
+        data object Allowed : ProbeResult
+        data class Skipped(val contentLength: Long) : ProbeResult
+    }
+
+    companion object {
+        private const val BROWSER_UA =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/126.0.0.0 Mobile Safari/537.36 GitHubStore/1.8"
+
+        // Hard cap on the decoded bitmap dimension (see class kdoc).
+        const val MAX_BITMAP_DIMENSION_PX = 2048
+
+        // Hard cap on the advertised payload size. Above this we skip the
+        // image entirely. 5 MB covers ~98% of repo READMEs in the wild;
+        // anything above is almost always a generated mega-screenshot or
+        // an uncompressed source export that would be unreadable inline
+        // anyway.
+        const val MAX_IMAGE_BYTES = 5L * 1024 * 1024
+
+        private val networkHeaders =
+            NetworkHeaders.Builder()
+                .add("User-Agent", BROWSER_UA)
+                .add(
+                    "Accept",
+                    "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+                )
+                .build()
+
+        // Process-wide probe cache. README rerenders, theme toggles, and
+        // recompositions all share the same map so the HEAD round-trip
+        // only happens once per URL per app session.
+        private val probeCache = mutableMapOf<String, ProbeResult>()
+        private val probeMutex = Mutex()
+    }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownTruncate.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownTruncate.kt
@@ -1,0 +1,27 @@
+package zed.rainxch.details.presentation.utils
+
+/**
+ * Returns a markdown substring suitable for rendering as a collapsed
+ * "preview" without the cost of composing the full tree. Truncates at a
+ * sensible boundary (double newline, then single newline, then `maxChars`)
+ * so headings and code fences aren't sliced mid-block.
+ *
+ * Always callable from any thread — no Compose APIs touched.
+ */
+fun truncateMarkdownPreview(content: String, maxChars: Int): String {
+    if (content.length <= maxChars) return content
+    val window = content.substring(0, maxChars)
+
+    // Prefer cutting at paragraph break (blank line) inside the last 25%
+    // of the window so the preview ends on a natural section boundary.
+    val searchFrom = (maxChars * 0.75).toInt().coerceAtLeast(0)
+    val paragraphBreak = window.lastIndexOf("\n\n", maxChars).takeIf { it >= searchFrom }
+    if (paragraphBreak != null && paragraphBreak > 0) {
+        return window.substring(0, paragraphBreak).trimEnd() + "\n"
+    }
+    val newline = window.lastIndexOf('\n', maxChars).takeIf { it >= searchFrom }
+    if (newline != null && newline > 0) {
+        return window.substring(0, newline).trimEnd() + "\n"
+    }
+    return window.trimEnd() + "…"
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownTruncate.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownTruncate.kt
@@ -25,3 +25,51 @@ fun truncateMarkdownPreview(content: String, maxChars: Int): String {
     }
     return window.trimEnd() + "…"
 }
+
+/**
+ * Splits a markdown document into roughly equal chunks at top-level block
+ * boundaries (double newlines), each ≤ `targetChunkChars`. Each chunk is a
+ * self-contained snippet the markdown parser can handle in isolation; we
+ * render them as separate `Markdown(...)` composables so the expensive
+ * AST-to-Compose pass happens once per chunk rather than once for the
+ * entire document.
+ *
+ * Code fences are kept whole (we never slice between ```...```), even if
+ * that makes one chunk larger than `targetChunkChars`. Without that
+ * guard the parser would emit half-open fence nodes and the renderer
+ * would print raw backticks.
+ *
+ * Always callable from any thread — no Compose APIs touched.
+ */
+fun splitMarkdownIntoChunks(content: String, targetChunkChars: Int): List<String> {
+    if (content.length <= targetChunkChars) return listOf(content)
+    val chunks = mutableListOf<String>()
+    val current = StringBuilder()
+    var inFence = false
+    val lines = content.split('\n')
+    fun flush() {
+        if (current.isNotEmpty()) {
+            chunks += current.toString()
+            current.clear()
+        }
+    }
+    for (line in lines) {
+        val trimmed = line.trimStart()
+        // Toggle fence flag on lines starting with ``` (markdown fence
+        // opener / closer). `~~~` is the alternate syntax used by some
+        // forges; same toggle rules apply.
+        if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+            inFence = !inFence
+        }
+        if (current.isNotEmpty()) current.append('\n')
+        current.append(line)
+        if (!inFence &&
+            current.length >= targetChunkChars &&
+            line.isBlank()
+        ) {
+            flush()
+        }
+    }
+    flush()
+    return chunks
+}


### PR DESCRIPTION
## Summary
Hard fixes for the README/release-notes lag + ANR observed on a Galaxy S25. All heavy work moved off Main.

### 1. `BoxWithConstraints` → `Box` + `onSizeChanged`
Details previously nested `BoxWithConstraints` inside `Scaffold`. Both subcompose during the measure pass — nesting multiplies the cost on rotation, IME show, or any parent size change. The `BoxWithConstraints` was only consuming `maxHeight` to derive `collapsedSectionHeight = maxHeight * 0.7f`. Single-shot size read → `Modifier.onSizeChanged`. Cites: [recomposition/avoiding-subcomposition-pitfalls](https://github.com/skydoves/compose-performance-skills/blob/main/recomposition/avoiding-subcomposition-pitfalls/SKILL.md).

### 2. `items(state.installLogs)` keyed + contentType
Lazy item cache could not reuse composables across insertions / scroll. Cites: [lists/optimizing-lazy-layouts](https://github.com/skydoves/compose-performance-skills/blob/main/lists/optimizing-lazy-layouts/SKILL.md).

### 3. Async markdown pre-process + loader + measure debounce
`applyThemeAwareImages(raw, isDark)` (regex-heavy) ran inside `remember { ... }` — on the composition thread. Moved to `LaunchedEffect + withContext(Dispatchers.Default)`, with a `CircularProgressIndicator` clamped to `collapsedHeight` while running.

Switched from `Markdown(content = ...)` to `Markdown(markdownState = rememberMarkdownState(..., retainState = true))`. `retainState = true` keeps the previously-parsed AST on screen while the next parse runs on Default — no flash to blank Loading on theme toggle.

Hoisted `MarkdownParser`, `GFMFlavourDescriptor`, and `githubStoreMarkdownComponents(isDark, transformer)` into `remember(...)`. Dropped the unnecessary `@Composable` annotation on the components factory so callers can memoize.

Debounced the `onSizeChanged → onMeasured` callback. Each forwarded write recopies the full `DetailsState`; the old code fired on every layout tick during the initial measure cascade — the "flicker after scroll completes" and "flicker on expand".

### 4. Syntax highlighting moved to `Dispatchers.Default` + 16KB cutoff (the ANR fix)
`SyntaxHighlightedCode.buildHighlighted(...)` was tokenizing the entire code block via the `Highlights` library inside `remember { ... }` — every code fence parsed on Main during composition. For a README with N fences, that is N synchronous tokenizations on the UI thread. A `Background concurrent mark compact GC freed 49MB` event with ANR followed exactly this pattern.

Fix: render plain code text immediately; tokenize in a `LaunchedEffect + withContext(Dispatchers.Default)`; swap the styled `AnnotatedString` in once ready. Code blocks larger than 16 000 chars (embedded JSON dumps, generated YAML) are not highlighted at all — the tokenizer is super-linear, the readability payoff drops fast.

### 5. Preview truncation when collapsed
The Markdown library composes every element on Main once given an AST. Even with parsing async, a kubernetes/kubernetes-sized README produces hundreds of `MarkdownText`/`MarkdownHeader`/`MarkdownCodeFence` composables on first frame.

Fix: compute a truncated preview (first ~6000 chars at a paragraph boundary) on `Dispatchers.Default` alongside the full content. Render the preview when `!isExpanded`; render the full tree only when the user taps "Read more". First-frame composition cost falls by an order of magnitude on big READMEs.

## Test plan
- [ ] Open a repo with a huge README (kubernetes/kubernetes, openssl/openssl). First paint shows spinner briefly, then a short preview — no ANR.
- [ ] Scroll over the About section, stop scrolling — no flicker.
- [ ] Tap "Read more" — full markdown lands (may take a beat for parse + compose on really big READMEs, but UI stays responsive).
- [ ] Toggle theme — old README stays visible during reparse.
- [ ] Compile both targets — ✓ verified.

## Follow-ups (separate PRs)
- Stabilize hot `List<T>` fields in `DetailsState` via `kotlinx.collections.immutable.ImmutableList`.
- Slice `DetailsState` into focused sub-states (header / releases / readme / logs).
- Wire Compose Compiler reports + Macrobenchmark to make future perf work measurable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More reliable layout measurement reducing layout-update churn and improving scrolling stability.
  * Markdown rendering and syntax highlighting moved off the main thread; renderer state retained to avoid blanking.
  * Markdown rendering now streams large content incrementally to the UI for smoother expansion.
* **Bug Fixes**
  * Install logs use stable item keys to prevent rendering glitches.
* **New Features**
  * Sections show a constrained loading spinner and a safe truncated preview while content is prepared.
  * Images capped in height and served with improved caching to avoid oversized visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->