### PR TITLE
fix(vm): buffer ViewModel event Channels

### DIFF
--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/AppsViewModel.kt
@@ -135,7 +135,7 @@ class AppsViewModel(
         }
     }
 
-    private val _events = Channel<AppsEvent>()
+    private val _events = Channel<AppsEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private fun loadApps() {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/ExternalImportViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/import/ExternalImportViewModel.kt
@@ -91,7 +91,7 @@ class ExternalImportViewModel(
                 initialValue = ExternalImportState(),
             )
 
-    private val _events = Channel<ExternalImportEvent>()
+    private val _events = Channel<ExternalImportEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     fun onAction(action: ExternalImportAction) {

--- a/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/starred/StarredPickerViewModel.kt
+++ b/feature/apps/presentation/src/commonMain/kotlin/zed/rainxch/apps/presentation/starred/StarredPickerViewModel.kt
@@ -27,7 +27,7 @@ class StarredPickerViewModel(
     private val _state = MutableStateFlow(StarredPickerState())
     val state = _state.asStateFlow()
 
-    private val _events = Channel<StarredPickerEvent>()
+    private val _events = Channel<StarredPickerEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private var scanJob: Job? = null

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -157,7 +157,7 @@ class DetailsViewModel(
                 DetailsState(),
             )
 
-    private val _events = Channel<DetailsEvent>()
+    private val _events = Channel<DetailsEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private val rateLimited = AtomicBoolean(false)

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/HomeViewModel.kt
@@ -93,7 +93,7 @@ class HomeViewModel(
                 initialValue = HomeState(),
             )
 
-    private val _events = Channel<HomeEvent>()
+    private val _events = Channel<HomeEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private fun syncSystemState() {

--- a/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/zed/rainxch/profile/presentation/ProfileViewModel.kt
@@ -35,7 +35,7 @@ class ProfileViewModel(
                 initialValue = ProfileState(),
             )
 
-    private val _events = Channel<ProfileEvent>()
+    private val _events = Channel<ProfileEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private fun formatCacheSize(bytes: Long): String {

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/SearchViewModel.kt
@@ -195,7 +195,7 @@ class SearchViewModel(
         }
     }
 
-    private val _events = Channel<SearchEvent>()
+    private val _events = Channel<SearchEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private fun syncSystemState() {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -128,7 +128,7 @@ class TweaksViewModel(
                 initialValue = TweaksState(),
             )
 
-    private val _events = Channel<TweaksEvent>()
+    private val _events = Channel<TweaksEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private fun refreshCacheSize() {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/feedback/FeedbackViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/feedback/FeedbackViewModel.kt
@@ -31,7 +31,7 @@ class FeedbackViewModel(
     private val _state = MutableStateFlow(FeedbackState())
     val state = _state.asStateFlow()
 
-    private val _events = Channel<FeedbackEvent>()
+    private val _events = Channel<FeedbackEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/hidden/HiddenRepositoriesViewModel.kt
@@ -19,7 +19,7 @@ class HiddenRepositoriesViewModel(
     private val _state = MutableStateFlow(HiddenRepositoriesState())
     val state = _state.asStateFlow()
 
-    private val _events = Channel<HiddenRepositoriesEvent>()
+    private val _events = Channel<HiddenRepositoriesEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/mirror/MirrorPickerViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/mirror/MirrorPickerViewModel.kt
@@ -28,7 +28,7 @@ class MirrorPickerViewModel(
     private val _state = MutableStateFlow(MirrorPickerState())
     val state = _state.asStateFlow()
 
-    private val _events = Channel<MirrorPickerEvent>()
+    private val _events = Channel<MirrorPickerEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/skipped/SkippedUpdatesViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/skipped/SkippedUpdatesViewModel.kt
@@ -19,7 +19,7 @@ class SkippedUpdatesViewModel(
     private val _state = MutableStateFlow(SkippedUpdatesState())
     val state = _state.asStateFlow()
 
-    private val _events = Channel<SkippedUpdatesEvent>()
+    private val _events = Channel<SkippedUpdatesEvent>(capacity = Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {


### PR DESCRIPTION
## Symptom
Tap a None / System proxy chip in Tweaks — chip marks selected, no snackbar. Tap the same chip again — snackbar fires. Same lost-toast pattern reported on the HTTP / SOCKS Save button.

## Cause
Every screen VM declares its one-shot event hose as `private val _events = Channel<XEvent>()`. Defaults to `RENDEZVOUS` (capacity 0): `send` suspends until a receiver is sitting on `receive` at that exact instant. `ObserveAsEvents` collects via `repeatOnLifecycle(STARTED)` which cancels and restarts collection on lifecycle transitions; if the VM `send` lands between collector cancel and restart, the suspended send is satisfied late (when the collector reattaches) but the user's mental clock has already moved on — they see no toast for the action they just performed. The next tap fires a *new* send while the collector is now warm and lands the snackbar.

## Fix
Change every screen VM to `Channel<XEvent>(capacity = Channel.BUFFERED)`. Sender never suspends, receiver drains in order. No event loss, no race with lifecycle re-collect.

Twelve VMs touched, all via the same mechanical edit. No behavior change beyond the buffering.

## Test plan
- [ ] Tweaks: tap None proxy chip once → snackbar fires
- [ ] Tweaks: tap System chip once → snackbar fires
- [ ] Tweaks: fill HTTP host+port, tap Save once → snackbar fires
- [ ] No regressions in Details, Search, Apps, Profile, Home toasts
- [ ] Compile both targets — ✓ verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal event handling performance across multiple application components to enhance responsiveness and stability under load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->