### PR TITLE
fix(translate): preserve fenced code blocks across translation

### DIFF
--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -59,12 +59,10 @@ class TranslationRepositoryImpl(
             }
         }
 
-        // Strip out fenced code blocks before chunking + translation. Code
-        // is not prose; sending it through a translator at best corrupts
-        // identifiers, at worst rewrites strings and breaks examples.
-        // Each fence is swapped for a marker the translator passes through
-        // verbatim; we splice the originals back after the joined output.
-        val protection = extractCodeFences(text)
+        // Mask out machine-readable spans (code fences, HTML tags,
+        // markdown URLs, bare URLs) so the translator doesn't mangle
+        // them. See `protectFromTranslation` kdoc for the full list.
+        val protection = protectFromTranslation(text)
 
         val translator = resolveTranslator()
         val chunks = chunkText(protection.maskedText, translator.maxChunkSize)
@@ -87,7 +85,7 @@ class TranslationRepositoryImpl(
 
         val result =
             TranslationResult(
-                translatedText = restoreCodeFences(joined, protection.fences),
+                translatedText = restoreProtectedSpans(joined, protection.spans),
                 detectedSourceLanguage = detectedLang,
             )
 
@@ -101,39 +99,85 @@ class TranslationRepositoryImpl(
         return result
     }
 
-    private fun extractCodeFences(text: String): FenceProtection {
-        val fences = mutableListOf<String>()
-        // Greedy-non-greedy `[\s\S]*?` instead of `.*?` because the
-        // fence body crosses newlines. `MULTILINE` is not needed since
-        // the regex does not use `^`/`$` anchors — kept for clarity.
-        val regex = Regex("```[\\s\\S]*?```", RegexOption.MULTILINE)
-        val masked = regex.replace(text) { match ->
-            val idx = fences.size
-            fences += match.value
-            // Unicode math brackets + ALL_CAPS underscore token —
-            // empirically preserved verbatim by Google + Youdao
-            // translators across the 33 supported targets.
-            "⟦CF_${idx}_END⟧"
+    /**
+     * Strips machine-readable spans (code fences, HTML tags, markdown
+     * link/image URLs) that translators will otherwise mangle. Each span
+     * is replaced with an opaque marker the translator passes through
+     * verbatim, then restored after the joined translation comes back.
+     *
+     * Why bigger than just fenced code: real READMEs commonly stack
+     * `[![alt](badge.svg)](https://store/...)` badge rows and raw
+     * `<img>` tags. Translators tokenize on `(` and `<`, then insert
+     * whitespace into URLs (observed on `https://appgallery.cloud.
+     * huawei.com/...`) or translate alt text into the href slot. Both
+     * corrupt the rendered markdown.
+     */
+    private fun protectFromTranslation(text: String): TranslationProtection {
+        val spans = mutableListOf<String>()
+        var masked = text
+
+        // 1. Fenced code blocks first — these are the most disruptive
+        //    spans and matching them before everything else means later
+        //    passes won't accidentally re-mask their inner content.
+        masked = Regex("```[\\s\\S]*?```", RegexOption.MULTILINE).replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
         }
-        return FenceProtection(masked, fences)
+        // 2. HTML tags including their bodies (`<a>...</a>`, `<img …/>`,
+        //    `<picture>...</picture>`). Translators rewrite `href` and
+        //    `src` attributes; preserve the whole element.
+        masked = Regex("<[^/!][a-zA-Z0-9]*[^>]*?/>").replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
+        }
+        masked = Regex(
+            "<(a|img|picture|source|video|audio|svg)\\b[^>]*>[\\s\\S]*?</\\1>",
+            RegexOption.IGNORE_CASE,
+        ).replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
+        }
+        masked = Regex("<img\\b[^>]*>", RegexOption.IGNORE_CASE).replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
+        }
+        // 3. Markdown link / image URLs: the `](url)` tail. Keep the
+        //    `[label]` part untouched so prose-style link text still
+        //    translates (e.g. `[the docs]` → `[la documentación]`).
+        masked = Regex("\\]\\(([^)]+)\\)").replace(masked) { match ->
+            val url = match.groupValues[1]
+            "](" + replaceWithMarker(spans, url) + ")"
+        }
+        // 4. Bare URLs in plain text. Without this, translators
+        //    sometimes split long URLs across whitespace.
+        masked = Regex("https?://[^\\s<>\")]+").replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
+        }
+
+        return TranslationProtection(masked, spans)
     }
 
-    private fun restoreCodeFences(translated: String, fences: List<String>): String {
-        if (fences.isEmpty()) return translated
+    private fun replaceWithMarker(spans: MutableList<String>, value: String): String {
+        val idx = spans.size
+        spans += value
+        // Unicode math brackets + ALL_CAPS underscore token — empirically
+        // preserved verbatim by Google + Youdao translators across the 33
+        // supported targets.
+        return "⟦TR_${idx}_END⟧"
+    }
+
+    private fun restoreProtectedSpans(translated: String, spans: List<String>): String {
+        if (spans.isEmpty()) return translated
         var result = translated
-        fences.forEachIndexed { i, original ->
-            // Tolerate translator inserting whitespace around the marker
-            // (Youdao occasionally pads with NBSP). Falls back to leaving
-            // any unmatched marker in place rather than corrupting prose.
-            val pattern = Regex("⟦\\s*CF_\\s*${i}\\s*_END\\s*⟧")
+        spans.forEachIndexed { i, original ->
+            // Tolerate translator inserting whitespace around the marker.
+            // Falls back to leaving any unmatched marker in place rather
+            // than corrupting prose.
+            val pattern = Regex("⟦\\s*TR_\\s*${i}\\s*_END\\s*⟧")
             result = pattern.replaceFirst(result, Regex.escapeReplacement(original))
         }
         return result
     }
 
-    private data class FenceProtection(
+    private data class TranslationProtection(
         val maskedText: String,
-        val fences: List<String>,
+        val spans: List<String>,
     )
 
     override fun getDeviceLanguageCode(): String = localizationManager.getPrimaryLanguageCode()

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -59,8 +59,15 @@ class TranslationRepositoryImpl(
             }
         }
 
+        // Strip out fenced code blocks before chunking + translation. Code
+        // is not prose; sending it through a translator at best corrupts
+        // identifiers, at worst rewrites strings and breaks examples.
+        // Each fence is swapped for a marker the translator passes through
+        // verbatim; we splice the originals back after the joined output.
+        val protection = extractCodeFences(text)
+
         val translator = resolveTranslator()
-        val chunks = chunkText(text, translator.maxChunkSize)
+        val chunks = chunkText(protection.maskedText, translator.maxChunkSize)
         val translatedParts = mutableListOf<Pair<String, String>>()
         var detectedLang: String? = null
 
@@ -72,13 +79,15 @@ class TranslationRepositoryImpl(
             }
         }
 
+        val joined =
+            translatedParts
+                .dropLast(1)
+                .joinToString("") { (text, delim) -> text + delim } +
+                translatedParts.lastOrNull()?.first.orEmpty()
+
         val result =
             TranslationResult(
-                translatedText =
-                    translatedParts
-                        .dropLast(1)
-                        .joinToString("") { (text, delim) -> text + delim } +
-                        translatedParts.lastOrNull()?.first.orEmpty(),
+                translatedText = restoreCodeFences(joined, protection.fences),
                 detectedSourceLanguage = detectedLang,
             )
 
@@ -91,6 +100,41 @@ class TranslationRepositoryImpl(
         }
         return result
     }
+
+    private fun extractCodeFences(text: String): FenceProtection {
+        val fences = mutableListOf<String>()
+        // Greedy-non-greedy `[\s\S]*?` instead of `.*?` because the
+        // fence body crosses newlines. `MULTILINE` is not needed since
+        // the regex does not use `^`/`$` anchors — kept for clarity.
+        val regex = Regex("```[\\s\\S]*?```", RegexOption.MULTILINE)
+        val masked = regex.replace(text) { match ->
+            val idx = fences.size
+            fences += match.value
+            // Unicode math brackets + ALL_CAPS underscore token —
+            // empirically preserved verbatim by Google + Youdao
+            // translators across the 33 supported targets.
+            "⟦CF_${idx}_END⟧"
+        }
+        return FenceProtection(masked, fences)
+    }
+
+    private fun restoreCodeFences(translated: String, fences: List<String>): String {
+        if (fences.isEmpty()) return translated
+        var result = translated
+        fences.forEachIndexed { i, original ->
+            // Tolerate translator inserting whitespace around the marker
+            // (Youdao occasionally pads with NBSP). Falls back to leaving
+            // any unmatched marker in place rather than corrupting prose.
+            val pattern = Regex("⟦\\s*CF_\\s*${i}\\s*_END\\s*⟧")
+            result = pattern.replaceFirst(result, Regex.escapeReplacement(original))
+        }
+        return result
+    }
+
+    private data class FenceProtection(
+        val maskedText: String,
+        val fences: List<String>,
+    )
 
     override fun getDeviceLanguageCode(): String = localizationManager.getPrimaryLanguageCode()
 

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -149,6 +149,18 @@ class TranslationRepositoryImpl(
         masked = Regex("https?://[^\\s<>\")]+").replace(masked) { match ->
             replaceWithMarker(spans, match.value)
         }
+        // 5. GFM alert callout markers: `[!NOTE]`, `[!TIP]`,
+        //    `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`. The renderer
+        //    pattern-matches these literally to pick the alert kind /
+        //    icon / tint; translation rewrites `[!IMPORTANT]` into
+        //    e.g. `[!Vajno]` (ru) and the renderer falls back to a
+        //    plain blockquote, losing the formatting entirely.
+        masked = Regex(
+            "\\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]",
+            RegexOption.IGNORE_CASE,
+        ).replace(masked) { match ->
+            replaceWithMarker(spans, match.value)
+        }
 
         return TranslationProtection(masked, spans)
     }


### PR DESCRIPTION
## Summary
Stop translating content inside ` ``` ` fenced code blocks. Translators rewrite identifiers, mangle string literals, and break example commands.

## How
- Before chunking + sending to the translator, `extractCodeFences` walks the body and replaces every `` ```…``` `` block with a marker `⟦CF_<n>_END⟧`. Markers chosen empirically — Unicode math brackets + ALL_CAPS underscore token survive Google + Youdao verbatim across the 33 supported targets.
- After all chunks return, `restoreCodeFences` splices the original fence bodies back at each marker. Tolerates whitespace padding (Youdao occasionally inserts NBSP).
- Cache key still uses the original `text`, so cache hit/miss behavior is unchanged.
- Unfenced inline code (single backticks) is intentionally untouched — short snippets in prose translate fine.

## Test plan
- [ ] Open a repo with a code-heavy README (e.g. kotlinx.coroutines), enable auto-translate to Chinese, expand About. Code fences stay verbatim; prose around them is translated.
- [ ] Same on a What's New section that pastes shell commands in fences — commands intact.
- [ ] Compile both targets — ✓ verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation now masks machine-readable spans (fenced code, HTML fragments, and URLs) before chunking to prevent accidental modification.
  * Chunked translation operates on masked text, then restores the original spans in the final output.
  * Ensures large texts and multi-chunk workflows preserve protected content integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->