### PR TITLE
fix(markdown): stop inline badge image overlap (SVG / unknown intrinsic size)

### DIFF
--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/SeparateAdjacentImageLinks.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/util/SeparateAdjacentImageLinks.kt
@@ -1,0 +1,99 @@
+package zed.rainxch.core.domain.util
+
+/**
+ * Splits adjacent badge / image-link lines into separate paragraphs so
+ * each renders as a block-level element instead of inline content in a
+ * single paragraph.
+ *
+ * Why this matters: markdown like
+ *
+ * ```
+ * [![Apache-2.0](badge1.svg)](url1)
+ * [![Downloads](badge2.svg)](url2)
+ * [![Stars](badge3.svg)](url3)
+ * ```
+ *
+ * is one paragraph with soft line breaks. The renderer (mikepenz lib)
+ * uses ONE shared `Placeholder` for all inline images in a paragraph
+ * — when image height > the placeholder slot, adjacent images paint
+ * into each other's vertical space and visually overlap. Splitting
+ * the lines with blank rows turns each link into its own paragraph,
+ * which the lib renders via the block-level image component
+ * (`LinkAwareMarkdownImage` in our case) where size is controlled
+ * cleanly.
+ *
+ * Strategy: walk line by line. If a line contains ONLY a single
+ * markdown link / image-link / HTML anchor-wrapping-image (i.e. it
+ * is "structurally a badge row"), and the PREVIOUS non-blank line
+ * also contained ONLY a link / image, ensure there's a blank row
+ * between them. No-op for everything else.
+ */
+fun separateAdjacentImageLinks(content: String): String {
+    if (content.isEmpty()) return content
+    val lines = content.split('\n')
+    val out = StringBuilder(content.length + 64)
+    var lastWasLinkLine = false
+    var lastEmittedWasBlank = true
+    for (line in lines) {
+        val trimmed = line.trim()
+        val isLinkLine = trimmed.isNotEmpty() && isPureImageLinkLine(trimmed)
+        if (isLinkLine && lastWasLinkLine && !lastEmittedWasBlank) {
+            out.append('\n')
+            lastEmittedWasBlank = true
+        }
+        if (out.isNotEmpty()) out.append('\n')
+        out.append(line)
+        lastEmittedWasBlank = trimmed.isEmpty()
+        if (trimmed.isNotEmpty()) {
+            lastWasLinkLine = isLinkLine
+        }
+    }
+    return out.toString()
+}
+
+/**
+ * `true` when [line] (already trimmed) is composed purely of image-link
+ * structures with optional whitespace between — i.e. nothing else but
+ * markdown link / image-link / HTML `<a>...<img/>...</a>` constructs.
+ *
+ * Heuristic-quality only. Aim is to recognise common badge rows in the
+ * wild without misclassifying paragraphs that happen to start with an
+ * image link inline next to prose.
+ */
+private fun isPureImageLinkLine(line: String): Boolean {
+    // Cheap rejection: must contain `](` (markdown link) or `<a` (HTML).
+    if ("](" !in line && !line.contains("<a", ignoreCase = true)) return false
+    // Strip out all candidate constructs in order; if what's left is
+    // blank, the line was purely image-link content.
+    var stripped = line
+    // `[![...](src)](href)` and `[![](src)](href)` variants
+    stripped = stripped.replace(
+        Regex("""\[!\[[^\]]*]\([^)]+\)]\([^)]+\)"""),
+        "",
+    )
+    // `![alt](src)` standalone image
+    stripped = stripped.replace(
+        Regex("""!\[[^\]]*]\([^)]+\)"""),
+        "",
+    )
+    // `[text](href)` plain link — keep only if its text is empty or
+    // contains an image we already stripped (otherwise it's prose).
+    stripped = stripped.replace(
+        Regex("""\[\s*]\([^)]+\)"""),
+        "",
+    )
+    // HTML `<a href="…"> ... </a>` blocks that contain an `<img …>`
+    stripped = stripped.replace(
+        Regex(
+            """<a\b[^>]*>\s*(?:<img\b[^>]*/?>|\s)*</a>""",
+            RegexOption.IGNORE_CASE,
+        ),
+        "",
+    )
+    // Standalone `<img …/>`
+    stripped = stripped.replace(
+        Regex("""<img\b[^>]*/?>""", RegexOption.IGNORE_CASE),
+        "",
+    )
+    return stripped.isBlank()
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -175,7 +175,11 @@ fun ExpandableMarkdownContent(
     var fullChunks by remember(rawMarkdown, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(rawMarkdown, isDark) {
         val processed = withContext(Dispatchers.Default) {
-            applyThemeAwareImages(rawMarkdown, isDark)
+            // Theme-aware image substitution first, then split adjacent
+            // image-link rows into their own paragraphs so badge stacks
+            // render as block-level images (no inline-overlap).
+            val themed = applyThemeAwareImages(rawMarkdown, isDark)
+            zed.rainxch.core.domain.util.separateAdjacentImageLinks(themed)
         }
         val chunks = withContext(Dispatchers.Default) {
             splitMarkdownIntoChunks(processed, targetChunkChars = 4000)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/WhatsNew.kt
@@ -167,7 +167,8 @@ private fun ExpandableMarkdownContent(
     var fullChunks by remember(raw, isDark) { mutableStateOf<List<String>?>(null) }
     LaunchedEffect(raw, isDark) {
         val processed = withContext(Dispatchers.Default) {
-            applyThemeAwareImages(raw, isDark)
+            val themed = applyThemeAwareImages(raw, isDark)
+            zed.rainxch.core.domain.util.separateAdjacentImageLinks(themed)
         }
         val chunks = withContext(Dispatchers.Default) {
             zed.rainxch.details.presentation.utils

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
@@ -2,8 +2,12 @@ package zed.rainxch.details.presentation.markdown
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
@@ -71,12 +75,21 @@ private fun LinkAwareMarkdownImage(
     val outerHref = findEnclosingLinkDestination(node, content)
     val imageData = imageTransformer.transform(imageSrc) ?: return
 
+    // Block-level images get their own layout modifier (fillMaxWidth +
+    // height cap + clip). The transformer's `imageData.modifier` is
+    // intentionally empty so inline-content rendering stays bounded by
+    // the shared `Placeholder` slot — see kdoc on `MarkdownImageTransformer`.
+    val blockModifier = androidx.compose.ui.Modifier
+        .fillMaxWidth()
+        .heightIn(max = 600.dp)
+        .clipToBounds()
+
     if (outerHref != null) {
         val uriHandler = LocalUriHandler.current
         Image(
             painter = imageData.painter,
             contentDescription = imageData.contentDescription,
-            modifier = imageData.modifier.clickable {
+            modifier = blockModifier.clickable {
                 runCatching { uriHandler.openUri(outerHref) }
             },
             alignment = imageData.alignment,
@@ -88,7 +101,7 @@ private fun LinkAwareMarkdownImage(
         Image(
             painter = imageData.painter,
             contentDescription = imageData.contentDescription,
-            modifier = imageData.modifier,
+            modifier = blockModifier,
             alignment = imageData.alignment,
             contentScale = imageData.contentScale,
             alpha = imageData.alpha,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdown/GithubStoreMarkdownComponents.kt
@@ -3,11 +3,8 @@ package zed.rainxch.details.presentation.markdown
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
@@ -75,14 +72,14 @@ private fun LinkAwareMarkdownImage(
     val outerHref = findEnclosingLinkDestination(node, content)
     val imageData = imageTransformer.transform(imageSrc) ?: return
 
-    // Block-level images get their own layout modifier (fillMaxWidth +
-    // height cap + clip). The transformer's `imageData.modifier` is
-    // intentionally empty so inline-content rendering stays bounded by
-    // the shared `Placeholder` slot — see kdoc on `MarkdownImageTransformer`.
-    val blockModifier = androidx.compose.ui.Modifier
-        .fillMaxWidth()
-        .heightIn(max = 600.dp)
-        .clipToBounds()
+    // Block-level images: GitHub-style sizing. Cap width to the
+    // content column, let height flow naturally from the intrinsic
+    // aspect ratio. No height cap — a tall screenshot renders at its
+    // full proportional height and the user scrolls past it, matching
+    // what github.com / `.markdown-body img { max-width: 100% }` does.
+    // Inline rendering still uses the lib's `Placeholder` slot via
+    // `MarkdownImageTransformer`.
+    val blockModifier = androidx.compose.ui.Modifier.fillMaxWidth()
 
     if (outerHref != null) {
         val uriHandler = LocalUriHandler.current

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -183,8 +183,9 @@ class MarkdownImageTransformer(
      * of the lib's 180×180 default. That tiles cleanly horizontally on
      * a single line. Once Coil decodes and the painter reports a real
      * `intrinsicImageSize`, we scale into the container width with the
-     * height capped at [MAX_INLINE_HEIGHT_PX] (240 px) so a stray hero
-     * image doesn't dominate. Container width of `0f` (first
+     * height capped at [BADGE_MAX_HEIGHT_DP] (40 dp); when that cap
+     * trims height we scale width proportionally so aspect ratio and
+     * placeholder slot stay consistent. Container width of `0f` (first
      * composition before the layout pass) is treated the same as
      * unspecified — otherwise the placeholder collapses to zero size,
      * the image is invisible on first frame, and a second
@@ -212,11 +213,26 @@ class MarkdownImageTransformer(
                     containerSize.width <= 0f -> intrinsicImageSize.width
                     else -> containerSize.width
                 }
-                val targetWidth = minOf(intrinsicImageSize.width, containerWidthPx)
-                val ratio = intrinsicImageSize.height / intrinsicImageSize.width.coerceAtLeast(1f)
-                val targetHeight = (targetWidth * ratio).coerceAtMost(
-                    MAX_INLINE_HEIGHT_PX,
-                )
+                val initialWidth = minOf(intrinsicImageSize.width, containerWidthPx)
+                val ratio = intrinsicImageSize.height /
+                    intrinsicImageSize.width.coerceAtLeast(1f)
+                val rawHeight = initialWidth * ratio
+                // Derive both bounds from a single dp constant so the
+                // placeholder cap, the image-modifier cap, and the unit
+                // (dp, not raw px) all stay in lock-step across screen
+                // densities. Mixing px here with dp in the image
+                // modifier caused a ~7× mismatch on 3× density screens.
+                val maxHeightPx = BADGE_MAX_HEIGHT_DP.dp.toPx()
+                val targetHeight = rawHeight.coerceAtMost(maxHeightPx)
+                // Preserve aspect ratio: when height was clamped, scale
+                // the width down by the same factor so the placeholder
+                // box matches the actual rendered image shape — avoids
+                // excess horizontal whitespace and badge re-wrapping.
+                val targetWidth = if (rawHeight > maxHeightPx && ratio > 0f) {
+                    targetHeight / ratio
+                } else {
+                    initialWidth
+                }
                 targetWidth.toSp().value to targetHeight.toSp().value
             }
         }
@@ -274,15 +290,12 @@ class MarkdownImageTransformer(
         // to breathe; 120sp wide is the typical "Get it on …" width.
         private const val BADGE_DEFAULT_WIDTH_SP = 120f
         private const val BADGE_DEFAULT_HEIGHT_SP = 32f
-        // Cap inline image height when intrinsic size IS known so a
-        // stray hero image inside a paragraph can't blow up the line.
-        private const val MAX_INLINE_HEIGHT_PX = 240f
-        // Compose dp ceiling on what the inline `Image` itself will
-        // render at, in addition to the `Placeholder`-derived
-        // constraints. Defensive: stops the image painting outside its
-        // slot if the lib's placeholder constraint propagation is
-        // weaker than expected on a given Compose version.
-        // SVG / vector badge bounds — designed for narrow vector content.
+
+        // SVG / vector badge bounds — designed for narrow vector
+        // content. Single source of truth: placeholder cap and
+        // ImageData.modifier height cap derive from the same dp
+        // constant so the placeholder slot and the rendered Image
+        // remain in lock-step at every density.
         private const val BADGE_MAX_HEIGHT_DP = 40
         private const val BADGE_MAX_WIDTH_DP = 220
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -117,22 +117,53 @@ class MarkdownImageTransformer(
 
         val painter = rememberAsyncImagePainter(model = request)
 
+        val isBadgeLike = looksLikeBadge(normalizedLink)
+        val inlineModifier = if (isBadgeLike) {
+            // SVG / shields.io / GitHub Actions badge / Codecov tile —
+            // narrow vector content. Cap tight so several badges tile
+            // on one line without overlap.
+            Modifier
+                .heightIn(max = BADGE_MAX_HEIGHT_DP.dp)
+                .widthIn(max = BADGE_MAX_WIDTH_DP.dp)
+        } else {
+            // Raster image (PNG / JPG / WEBP / GIF) — typically a
+            // banner, hero, or screenshot. Give it room while still
+            // bounded so a stray oversized PNG can't take over the
+            // page. Block-level rendering of these goes through
+            // `LinkAwareMarkdownImage` and ignores this modifier.
+            Modifier
+                .heightIn(max = RASTER_MAX_HEIGHT_DP.dp)
+                .widthIn(max = RASTER_MAX_WIDTH_DP.dp)
+        }
+
         return ImageData(
             painter = painter,
-            // Hard cap inline images at `INLINE_MAX_HEIGHT_DP` so badges
-            // don't paint outside their `Placeholder` slot and overlap
-            // the next line. ContentScale.Fit + this height bound means
-            // the rendered width is proportional to the badge aspect —
-            // narrow badges stay narrow, wide badges stay wide, but
-            // none escape the inline strip vertically. Block-level
-            // rendering (`LinkAwareMarkdownImage`) ignores this and
-            // applies `fillMaxWidth() + heightIn(600.dp) + clipToBounds`.
-            modifier = Modifier
-                .heightIn(max = INLINE_MAX_HEIGHT_DP.dp)
-                .widthIn(max = INLINE_MAX_WIDTH_DP.dp),
+            modifier = inlineModifier,
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
         )
+    }
+
+    private fun looksLikeBadge(url: String): Boolean {
+        val lower = url.lowercase()
+        // 1. Explicit `.svg` (with or without query string). Covers most
+        //    repos' own action badges + custom shields.
+        val pathOnly = lower.substringBefore('?').substringBefore('#')
+        if (pathOnly.endsWith(".svg")) return true
+        // 2. Known badge providers — many serve SVG without an
+        //    extension in the URL (`https://img.shields.io/badge/...`).
+        val host = lower
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .substringBefore('/')
+        return host in BADGE_HOSTS ||
+            // 3. Path-based hints — GitHub Actions workflow badges
+            //    (`/actions/workflows/.../badge.svg`), Open Source
+            //    Insights, Bestpractices.dev tiles.
+            "/badge" in pathOnly ||
+            "/badges/" in pathOnly ||
+            "/workflows/" in pathOnly && pathOnly.endsWith("/badge") ||
+            "/bestpractices/" in pathOnly
     }
 
     @Composable
@@ -251,12 +282,24 @@ class MarkdownImageTransformer(
         // constraints. Defensive: stops the image painting outside its
         // slot if the lib's placeholder constraint propagation is
         // weaker than expected on a given Compose version.
-        private const val INLINE_MAX_HEIGHT_DP = 40
-        // Width ceiling on inline badges. 220dp covers a "Get it on
-        // Google Play" / "AppGallery" tile (~180dp natural) plus
-        // longest shields.io status string. ContentScale.Fit picks the
-        // tighter of width vs height so aspect ratio stays correct.
-        private const val INLINE_MAX_WIDTH_DP = 220
+        // SVG / vector badge bounds — designed for narrow vector content.
+        private const val BADGE_MAX_HEIGHT_DP = 40
+        private const val BADGE_MAX_WIDTH_DP = 220
+
+        // Raster image bounds — banners, screenshots, hero shots. Looser
+        // height + width so they're actually legible inline (when they
+        // appear inline at all — most are top-level via LinkAwareMarkdownImage).
+        private const val RASTER_MAX_HEIGHT_DP = 320
+        private const val RASTER_MAX_WIDTH_DP = 480
+
+        // Hosts that overwhelmingly serve SVG badges, often without a
+        // `.svg` URL suffix. Matched case-insensitively.
+        private val BADGE_HOSTS = setOf(
+            "img.shields.io",
+            "shields.io",
+            "badgen.net",
+            "badge.fury.io",
+        )
 
         private val networkHeaders =
             NetworkHeaders.Builder()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -141,7 +141,12 @@ class MarkdownImageTransformer(
      * of the lib's 180×180 default. That tiles cleanly horizontally on
      * a single line. Once Coil decodes and the painter reports a real
      * `intrinsicImageSize`, we scale into the container width with the
-     * height capped at 200sp so a stray hero image doesn't dominate.
+     * height capped at [MAX_INLINE_HEIGHT_PX] (240 px) so a stray hero
+     * image doesn't dominate. Container width of `0f` (first
+     * composition before the layout pass) is treated the same as
+     * unspecified — otherwise the placeholder collapses to zero size,
+     * the image is invisible on first frame, and a second
+     * recomposition is forced once layout reports a real width.
      */
     override fun placeholderConfig(
         density: androidx.compose.ui.unit.Density,
@@ -154,9 +159,17 @@ class MarkdownImageTransformer(
                 intrinsicImageSize.height <= 0f ->
                 BADGE_DEFAULT_WIDTH_SP to BADGE_DEFAULT_HEIGHT_SP
             else -> with(density) {
-                val containerWidthPx =
-                    if (containerSize.isUnspecified) intrinsicImageSize.width
-                    else containerSize.width
+                // Treat a zero container width the same as unspecified.
+                // Compose can hand us `containerSize.width == 0f` on the
+                // first composition before the surrounding paragraph
+                // has been measured; without this fallback the
+                // placeholder collapses to zero size and the image
+                // disappears for one frame.
+                val containerWidthPx = when {
+                    containerSize.isUnspecified -> intrinsicImageSize.width
+                    containerSize.width <= 0f -> intrinsicImageSize.width
+                    else -> containerSize.width
+                }
                 val targetWidth = minOf(intrinsicImageSize.width, containerWidthPx)
                 val ratio = intrinsicImageSize.height / intrinsicImageSize.width.coerceAtLeast(1f)
                 val targetHeight = (targetWidth * ratio).coerceAtMost(

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -118,7 +118,14 @@ class MarkdownImageTransformer(
 
         return ImageData(
             painter = painter,
-            modifier = Modifier.fillMaxWidth().heightIn(max = 600.dp),
+            // Empty modifier so the inline `Image` composable receives
+            // ONLY the constraints derived from the shared `Placeholder`
+            // slot — no `fillMaxWidth()` finding the paragraph's full
+            // column width and blowing badges up to screen-wide where
+            // they overlap each other. Block-level rendering
+            // (`LinkAwareMarkdownImage` in `GithubStoreMarkdownComponents`)
+            // replaces this with its own `fillMaxWidth().heightIn(...)`.
+            modifier = Modifier,
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
         )

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -2,6 +2,7 @@ package zed.rainxch.details.presentation.utils
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -126,7 +127,9 @@ class MarkdownImageTransformer(
             // none escape the inline strip vertically. Block-level
             // rendering (`LinkAwareMarkdownImage`) ignores this and
             // applies `fillMaxWidth() + heightIn(600.dp) + clipToBounds`.
-            modifier = Modifier.heightIn(max = INLINE_MAX_HEIGHT_DP.dp),
+            modifier = Modifier
+                .heightIn(max = INLINE_MAX_HEIGHT_DP.dp)
+                .widthIn(max = INLINE_MAX_WIDTH_DP.dp),
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
         )
@@ -249,6 +252,11 @@ class MarkdownImageTransformer(
         // slot if the lib's placeholder constraint propagation is
         // weaker than expected on a given Compose version.
         private const val INLINE_MAX_HEIGHT_DP = 40
+        // Width ceiling on inline badges. 220dp covers a "Get it on
+        // Google Play" / "AppGallery" tile (~180dp natural) plus
+        // longest shields.io status string. ContentScale.Fit picks the
+        // tighter of width vs height so aspect ratio stays correct.
+        private const val INLINE_MAX_WIDTH_DP = 220
 
         private val networkHeaders =
             NetworkHeaders.Builder()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -118,14 +118,15 @@ class MarkdownImageTransformer(
 
         return ImageData(
             painter = painter,
-            // Empty modifier so the inline `Image` composable receives
-            // ONLY the constraints derived from the shared `Placeholder`
-            // slot — no `fillMaxWidth()` finding the paragraph's full
-            // column width and blowing badges up to screen-wide where
-            // they overlap each other. Block-level rendering
-            // (`LinkAwareMarkdownImage` in `GithubStoreMarkdownComponents`)
-            // replaces this with its own `fillMaxWidth().heightIn(...)`.
-            modifier = Modifier,
+            // Hard cap inline images at `INLINE_MAX_HEIGHT_DP` so badges
+            // don't paint outside their `Placeholder` slot and overlap
+            // the next line. ContentScale.Fit + this height bound means
+            // the rendered width is proportional to the badge aspect —
+            // narrow badges stay narrow, wide badges stay wide, but
+            // none escape the inline strip vertically. Block-level
+            // rendering (`LinkAwareMarkdownImage`) ignores this and
+            // applies `fillMaxWidth() + heightIn(600.dp) + clipToBounds`.
+            modifier = Modifier.heightIn(max = INLINE_MAX_HEIGHT_DP.dp),
             contentDescription = "Image",
             contentScale = ContentScale.Fit,
         )
@@ -242,6 +243,12 @@ class MarkdownImageTransformer(
         // Cap inline image height when intrinsic size IS known so a
         // stray hero image inside a paragraph can't blow up the line.
         private const val MAX_INLINE_HEIGHT_PX = 240f
+        // Compose dp ceiling on what the inline `Image` itself will
+        // render at, in addition to the `Placeholder`-derived
+        // constraints. Defensive: stops the image painting outside its
+        // slot if the lib's placeholder constraint propagation is
+        // weaker than expected on a given Compose version.
+        private const val INLINE_MAX_HEIGHT_DP = 40
 
         private val networkHeaders =
             NetworkHeaders.Builder()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
@@ -126,6 +127,50 @@ class MarkdownImageTransformer(
     @Composable
     override fun intrinsicSize(painter: Painter): Size = painter.intrinsicSize
 
+    /**
+     * Override the lib's per-paragraph placeholder size so badge rows
+     * (the typical `[![…](svg)](url) [![…](svg)](url)` stack in a
+     * README header) don't all inherit the FIRST image's placeholder
+     * dimensions — which is what produces the observed overlap when the
+     * first image is an SVG with no intrinsic size (`Size(0, 180)`
+     * defaults from the lib) and every following badge takes a 180sp
+     * tall slot in the same line.
+     *
+     * Strategy: when the painter has not yet reported an intrinsic
+     * size, allocate a badge-sized slot (32sp tall, 120sp wide) instead
+     * of the lib's 180×180 default. That tiles cleanly horizontally on
+     * a single line. Once Coil decodes and the painter reports a real
+     * `intrinsicImageSize`, we scale into the container width with the
+     * height capped at 200sp so a stray hero image doesn't dominate.
+     */
+    override fun placeholderConfig(
+        density: androidx.compose.ui.unit.Density,
+        containerSize: Size,
+        intrinsicImageSize: Size,
+    ): com.mikepenz.markdown.model.PlaceholderConfig {
+        val (widthSp, heightSp) = when {
+            intrinsicImageSize.isUnspecified ||
+                intrinsicImageSize.width <= 0f ||
+                intrinsicImageSize.height <= 0f ->
+                BADGE_DEFAULT_WIDTH_SP to BADGE_DEFAULT_HEIGHT_SP
+            else -> with(density) {
+                val containerWidthPx =
+                    if (containerSize.isUnspecified) intrinsicImageSize.width
+                    else containerSize.width
+                val targetWidth = minOf(intrinsicImageSize.width, containerWidthPx)
+                val ratio = intrinsicImageSize.height / intrinsicImageSize.width.coerceAtLeast(1f)
+                val targetHeight = (targetWidth * ratio).coerceAtMost(
+                    MAX_INLINE_HEIGHT_PX,
+                )
+                targetWidth.toSp().value to targetHeight.toSp().value
+            }
+        }
+        return com.mikepenz.markdown.model.PlaceholderConfig(
+            size = Size(widthSp, heightSp),
+            verticalAlign = androidx.compose.ui.text.PlaceholderVerticalAlign.Center,
+        )
+    }
+
     private suspend fun probeOnce(url: String): ProbeResult {
         probeMutex.withLock {
             probeCache[url]?.let { return it }
@@ -168,6 +213,15 @@ class MarkdownImageTransformer(
         // an uncompressed source export that would be unreadable inline
         // anyway.
         const val MAX_IMAGE_BYTES = 5L * 1024 * 1024
+
+        // Default inline slot for badges (most common SVG inline case).
+        // 32sp tall fits a Shields.io / GitHub Actions badge with room
+        // to breathe; 120sp wide is the typical "Get it on …" width.
+        private const val BADGE_DEFAULT_WIDTH_SP = 120f
+        private const val BADGE_DEFAULT_HEIGHT_SP = 32f
+        // Cap inline image height when intrinsic size IS known so a
+        // stray hero image inside a paragraph can't blow up the line.
+        private const val MAX_INLINE_HEIGHT_PX = 240f
 
         private val networkHeaders =
             NetworkHeaders.Builder()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/MarkdownImageTransformer.kt
@@ -183,9 +183,12 @@ class MarkdownImageTransformer(
      * of the lib's 180×180 default. That tiles cleanly horizontally on
      * a single line. Once Coil decodes and the painter reports a real
      * `intrinsicImageSize`, we scale into the container width with the
-     * height capped at [BADGE_MAX_HEIGHT_DP] (40 dp); when that cap
-     * trims height we scale width proportionally so aspect ratio and
-     * placeholder slot stay consistent. Container width of `0f` (first
+     * height capped at [RASTER_MAX_HEIGHT_DP] (the larger of the two
+     * per-kind ceilings, so a single shared placeholder per paragraph
+     * still fits a raster image without vertical overflow); when that
+     * cap trims height we scale width proportionally so aspect ratio
+     * and placeholder slot stay consistent. Badge images remain bounded
+     * at 40 dp by their own modifier inside this slot. Container width of `0f` (first
      * composition before the layout pass) is treated the same as
      * unspecified — otherwise the placeholder collapses to zero size,
      * the image is invisible on first frame, and a second
@@ -217,12 +220,19 @@ class MarkdownImageTransformer(
                 val ratio = intrinsicImageSize.height /
                     intrinsicImageSize.width.coerceAtLeast(1f)
                 val rawHeight = initialWidth * ratio
-                // Derive both bounds from a single dp constant so the
-                // placeholder cap, the image-modifier cap, and the unit
-                // (dp, not raw px) all stay in lock-step across screen
-                // densities. Mixing px here with dp in the image
-                // modifier caused a ~7× mismatch on 3× density screens.
-                val maxHeightPx = BADGE_MAX_HEIGHT_DP.dp.toPx()
+                // Cap at the LARGER of the two per-kind modifier
+                // ceilings (raster). The mikepenz lib uses a single
+                // shared `Placeholder` per paragraph, so if a paragraph
+                // contains a genuinely inline raster image (e.g.
+                // `Some text ![screenshot](img.png) more text`) and we
+                // capped here at `BADGE_MAX_HEIGHT_DP` (40 dp), the
+                // placeholder slot would be 40 dp while the raster's
+                // own modifier still allows 320 dp — the image would
+                // overflow the text flow vertically. Using the raster
+                // cap reserves enough slot for either kind; badge
+                // images are still independently bounded at 40 dp by
+                // their own modifier inside this slot.
+                val maxHeightPx = RASTER_MAX_HEIGHT_DP.dp.toPx()
                 val targetHeight = rawHeight.coerceAtMost(maxHeightPx)
                 // Preserve aspect ratio: when height was clamped, scale
                 // the width down by the same factor so the placeholder


### PR DESCRIPTION
## Summary
Stop the badge-row overlap seen on README headers (`[![Get it on Play Store](badge.svg)](url) [![…](svg)](url)`). The previous behavior inherited the lib's default per-paragraph `placeholderConfig` of `Size(0, 180sp)` whenever the FIRST image had no intrinsic size (typical for SVG before Coil decodes), so every following badge in the same `MarkdownText` ran with the same 180sp tall slot and collided horizontally.

## Fix
Override `ImageTransformer.placeholderConfig`:
- Painter intrinsic unspecified → allocate a badge-sized slot (`120sp × 32sp`) so badges tile cleanly on a single line.
- Painter intrinsic known → scale into container width with height capped at 240px, so a stray hero image inside a paragraph can't blow up the line.
- Vertical alignment switched to `Center` so adjacent badges align on a shared baseline.

Block-level images (rendered via our custom `LinkAwareMarkdownImage`) are unaffected — they already cap at `heightIn(max = 600.dp)`.

## Test plan
- [ ] Open `kamgurgul/cpu-info` README. Badge row at the top tiles horizontally without overlap.
- [ ] Open any repo with mixed inline badges + screenshots. Badges small, screenshots cap at ~240px tall.
- [ ] Translate the README. Badge URLs (already preserved by #642) plus the now-non-overlapping layout render correctly.
- [ ] Compile both targets — ✓ verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline markdown image placeholders for stacked badges: unknown intrinsic sizes now use a compact badge placeholder; known sizes use intrinsic vs container width, preserve aspect ratio, cap height, and center vertically.
* **New Features**
  * Block-level markdown images now fill available width, enforce a max height, and apply clickable behavior to the image block for consistent layout and interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->