### PR TITLE
fix: guard a11y NPE via uncaught-exception handler path on macOS

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
@@ -14,24 +14,72 @@ import java.util.concurrent.atomic.AtomicBoolean
  *     androidx.compose.ui.platform.a11y.SemanticsOwnerAccessibility.accessibleParentOf
  *        -> sun.lwawt.macosx.CAccessible$AXChangeNotifier.propertyChange
  *
- * The uncaught exception poisons the AWT EventDispatchThread and the app
- * appears to freeze/crash on click. Installing a filtering [EventQueue]
- * swallows only that specific NPE so the EDT keeps draining events.
- * Trade-off: macOS VoiceOver may miss updates on those removed nodes.
- * Remove once the upstream fix lands (track against Compose MP 1.11+).
+ * The NPE surfaces via two propagation paths and both are guarded here:
  *
- * See [GitHub-Store#330](https://github.com/OpenHub-Store/GitHub-Store/issues/330).
+ * 1. **EDT path** — NPE escapes `DispatchedTask.run` and propagates through
+ *    the AWT event queue dispatch chain. [FilteringEventQueue] swallows it so
+ *    the EDT keeps draining events.
+ *
+ * 2. **Coroutine-failure path** — `BaseContinuationImpl.resumeWith` catches the
+ *    NPE and routes the coroutine failure through `handleCoroutineException` to
+ *    the default uncaught-exception handler, bypassing [FilteringEventQueue].
+ *    The handler wrapper installed in [install] intercepts this path before it
+ *    reaches [CrashReporter], preventing a spurious crash dump.
+ *
+ * Trade-off: macOS VoiceOver may miss updates on those removed nodes for the
+ * remainder of the session. Remove once the upstream fix lands (track against
+ * Compose MP 1.11+).
+ *
+ * See [GitHub-Store#330](https://github.com/OpenHub-Store/GitHub-Store/issues/330)
+ * and [GitHub-Store#640](https://github.com/OpenHub-Store/GitHub-Store/issues/640).
  */
 object A11yCrashGuard {
+    private val warned = AtomicBoolean(false)
+
     fun install() {
         val osName = System.getProperty("os.name")?.lowercase().orEmpty()
         if (!osName.contains("mac")) return
+
+        // Path 1: NPE propagates out of the coroutine dispatcher and through the
+        // AWT EventQueue dispatch chain.
         Toolkit.getDefaultToolkit().systemEventQueue.push(FilteringEventQueue())
+
+        // Path 2: NPE is intercepted by BaseContinuationImpl.resumeWith and
+        // forwarded to the default uncaught-exception handler via coroutine
+        // failure handling. Wrap the handler that CrashReporter already installed
+        // so all non-a11y exceptions still reach it.
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            if (isComposeA11yNpe(throwable)) {
+                if (warned.compareAndSet(false, true)) {
+                    System.err.println(
+                        "[A11yCrashGuard] Suppressed Compose a11y NPE via uncaught-exception path " +
+                            "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",
+                    )
+                }
+                return@setDefaultUncaughtExceptionHandler
+            }
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun isComposeA11yNpe(throwable: Throwable): Boolean {
+        if (throwable !is NullPointerException) return false
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current.stackTrace.any { frame ->
+                    frame.className.startsWith("androidx.compose.ui.platform.a11y") ||
+                        frame.className.startsWith("sun.lwawt.macosx.CAccessible")
+                }
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
     }
 
     private class FilteringEventQueue : EventQueue() {
-        private val warned = AtomicBoolean(false)
-
         override fun dispatchEvent(event: AWTEvent) {
             try {
                 super.dispatchEvent(event)
@@ -40,27 +88,13 @@ object A11yCrashGuard {
                     if (warned.compareAndSet(false, true)) {
                         System.err.println(
                             "[A11yCrashGuard] Suppressed Compose a11y NPE on macOS " +
-                                "(known issue, see GitHub-Store#330). Further occurrences silenced.",
+                                "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",
                         )
                     }
                     return
                 }
                 throw npe
             }
-        }
-
-        private fun isComposeA11yNpe(throwable: Throwable): Boolean {
-            var current: Throwable? = throwable
-            while (current != null) {
-                if (current.stackTrace.any { frame ->
-                        frame.className.startsWith("androidx.compose.ui.platform.a11y")
-                    }
-                ) {
-                    return true
-                }
-                current = current.cause
-            }
-            return false
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
@@ -34,8 +34,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * and [GitHub-Store#640](https://github.com/OpenHub-Store/GitHub-Store/issues/640).
  */
 object A11yCrashGuard {
-    private val warned = AtomicBoolean(false)
+    // Separate flags per path so each path logs its first suppression independently.
+    private val warnedEdt = AtomicBoolean(false)
+    private val warnedUncaught = AtomicBoolean(false)
 
+    // Must be called after CrashReporter.install() so the uncaught-exception handler
+    // chain is: A11yCrashGuard (filter) -> CrashReporter (log + dump) -> JVM default.
     fun install() {
         val osName = System.getProperty("os.name")?.lowercase().orEmpty()
         if (!osName.contains("mac")) return
@@ -51,7 +55,7 @@ object A11yCrashGuard {
         val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             if (isComposeA11yNpe(throwable)) {
-                if (warned.compareAndSet(false, true)) {
+                if (warnedUncaught.compareAndSet(false, true)) {
                     System.err.println(
                         "[A11yCrashGuard] Suppressed Compose a11y NPE via uncaught-exception path " +
                             "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",
@@ -59,7 +63,10 @@ object A11yCrashGuard {
                 }
                 return@setDefaultUncaughtExceptionHandler
             }
+            // Forward to CrashReporter (or JVM default if previous is null, which
+            // would only happen if install() is called before CrashReporter.install()).
             previous?.uncaughtException(thread, throwable)
+                ?: throwable.printStackTrace(System.err)
         }
     }
 
@@ -69,7 +76,8 @@ object A11yCrashGuard {
         while (current != null) {
             if (current.stackTrace.any { frame ->
                     frame.className.startsWith("androidx.compose.ui.platform.a11y") ||
-                        frame.className.startsWith("sun.lwawt.macosx.CAccessible")
+                        // Specific AX bridge inner class present in all known traces for this bug.
+                        frame.className.startsWith("sun.lwawt.macosx.CAccessible\$AXChangeNotifier")
                 }
             ) {
                 return true
@@ -85,7 +93,7 @@ object A11yCrashGuard {
                 super.dispatchEvent(event)
             } catch (npe: NullPointerException) {
                 if (isComposeA11yNpe(npe)) {
-                    if (warned.compareAndSet(false, true)) {
+                    if (warnedEdt.compareAndSet(false, true)) {
                         System.err.println(
                             "[A11yCrashGuard] Suppressed Compose a11y NPE on macOS " +
                                 "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",


### PR DESCRIPTION
## What

Extends `A11yCrashGuard` to cover a second propagation path for the Compose MP 1.10.x accessibility NPE on macOS.

The existing `FilteringEventQueue` only intercepts the NPE when it escapes `DispatchedTask.run` and propagates up through the AWT event queue chain. When `BaseContinuationImpl.resumeWith` catches the NPE first (which happens depending on the coroutine call depth), the failure is routed through `handleCoroutineException` directly to the default uncaught-exception handler — bypassing `FilteringEventQueue` entirely. `CrashReporter` then writes a crash dump and the a11y sync loop coroutine dies, leaving the app unresponsive.

Changes:
- `warned` and `isComposeA11yNpe` lifted to `A11yCrashGuard` object so both paths share them
- `install()` wraps the existing uncaught-exception handler (installed by `CrashReporter`) with an a11y NPE filter; non-a11y exceptions are forwarded to the previous handler unchanged
- `isComposeA11yNpe` adds `sun.lwawt.macosx.CAccessible` as a secondary stack-frame fingerprint (it appears in every reported trace for this bug)
- Updated log messages and KDoc to reference both #330 and #640

## Why

Users on macOS 15 running GitHub Store v1.8.2 see the app crash when navigating from a search result to the details screen. The stack trace is the same Compose MP `SemanticsOwnerAccessibility.accessibleParentOf` NPE that #330 addressed, but in this trigger path the coroutine machinery intercepts the exception before the `FilteringEventQueue` sees it.

## How to test

1. macOS only. Reproduce with: open app → Search → enter `Happ`, select macOS filter → click more details on a result.
2. Without this fix on v1.8.2: the app freezes or writes a `crash-*.log` in `~/Library/Logs/GitHub-Store/`.
3. With this fix: the app continues normally; `session.log` shows one `[A11yCrashGuard] Suppressed Compose a11y NPE via uncaught-exception path` line and no crash dump is written.

Fixes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented macOS crashes triggered by accessibility interactions; app no longer crashes when accessibility features are enabled.
  * Reduced repetitive error logging so only the first occurrence per failure path is reported.
* **Documentation**
  * Clarified diagnostic messages and logs (references to issues `#330` and `#640`) and expanded notes on behavior and trade-offs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->