### PR TITLE
fix(db): destructive fallback on downgrade

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/local/db/initDatabase.kt
@@ -47,5 +47,6 @@ fun initDatabase(context: Context): AppDatabase {
             MIGRATION_15_16,
             MIGRATION_16_17,
             MIGRATION_17_18,
-        ).build()
+        ).fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
+        .build()
 }


### PR DESCRIPTION
## Summary
Survives users installing an older build after the v18 schema lands. Without this, Room throws `IllegalStateException: A migration from 18 to 17 was required` on first launch.

## Test plan
- [ ] Install v18 build, generate some installed-apps rows
- [ ] Install older v17 build → app launches, DB wiped + recovers via sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database stability when downgrading to an earlier app version. The database schema will now automatically rebuild instead of causing crashes or inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->