### PR TITLE
feat: add LibreTranslate + DeepL translation providers

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -234,6 +234,20 @@ class TweaksRepositoryImpl(
         if (trimmed.isEmpty()) ksafe.safeDelete(K_DEEPL_AUTH_KEY) else ksafe.safePut(K_DEEPL_AUTH_KEY, trimmed)
     }
 
+    override fun getMicrosoftTranslatorKey(): Flow<String> = gatedGetFlow(K_MS_KEY, "")
+    override suspend fun setMicrosoftTranslatorKey(key: String) {
+        migrationDeferred.await()
+        val trimmed = key.trim()
+        if (trimmed.isEmpty()) ksafe.safeDelete(K_MS_KEY) else ksafe.safePut(K_MS_KEY, trimmed)
+    }
+
+    override fun getMicrosoftTranslatorRegion(): Flow<String> = gatedGetFlow(K_MS_REGION, "")
+    override suspend fun setMicrosoftTranslatorRegion(region: String) {
+        migrationDeferred.await()
+        val trimmed = region.trim()
+        if (trimmed.isEmpty()) ksafe.safeDelete(K_MS_REGION) else ksafe.safePut(K_MS_REGION, trimmed)
+    }
+
     override fun getAppLanguage(): Flow<String?> =
         gatedGetFlow<String?>(K_APP_LANGUAGE, null).map { raw ->
             raw?.trim()?.takeIf { it.isNotEmpty() && AppLanguages.containsTag(it) }
@@ -451,6 +465,8 @@ class TweaksRepositoryImpl(
         private const val K_LIBRE_BASE_URL = "libre_translate_base_url"
         private const val K_LIBRE_API_KEY = "libre_translate_api_key"
         private const val K_DEEPL_AUTH_KEY = "deepl_auth_key"
+        private const val K_MS_KEY = "microsoft_translator_key"
+        private const val K_MS_REGION = "microsoft_translator_region"
         private const val K_APP_LANGUAGE = "app_language"
         private const val K_AUTO_TRANSLATE_ENABLED = "auto_translate_enabled"
         private const val K_AUTO_TRANSLATE_TARGET = "auto_translate_target_lang"

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/TweaksRepositoryImpl.kt
@@ -213,6 +213,27 @@ class TweaksRepositoryImpl(
         if (trimmed.isEmpty()) ksafe.safeDelete(K_YOUDAO_APP_SECRET) else ksafe.safePut(K_YOUDAO_APP_SECRET, trimmed)
     }
 
+    override fun getLibreTranslateBaseUrl(): Flow<String> = gatedGetFlow(K_LIBRE_BASE_URL, "")
+    override suspend fun setLibreTranslateBaseUrl(url: String) {
+        migrationDeferred.await()
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) ksafe.safeDelete(K_LIBRE_BASE_URL) else ksafe.safePut(K_LIBRE_BASE_URL, trimmed)
+    }
+
+    override fun getLibreTranslateApiKey(): Flow<String> = gatedGetFlow(K_LIBRE_API_KEY, "")
+    override suspend fun setLibreTranslateApiKey(apiKey: String) {
+        migrationDeferred.await()
+        val trimmed = apiKey.trim()
+        if (trimmed.isEmpty()) ksafe.safeDelete(K_LIBRE_API_KEY) else ksafe.safePut(K_LIBRE_API_KEY, trimmed)
+    }
+
+    override fun getDeeplAuthKey(): Flow<String> = gatedGetFlow(K_DEEPL_AUTH_KEY, "")
+    override suspend fun setDeeplAuthKey(authKey: String) {
+        migrationDeferred.await()
+        val trimmed = authKey.trim()
+        if (trimmed.isEmpty()) ksafe.safeDelete(K_DEEPL_AUTH_KEY) else ksafe.safePut(K_DEEPL_AUTH_KEY, trimmed)
+    }
+
     override fun getAppLanguage(): Flow<String?> =
         gatedGetFlow<String?>(K_APP_LANGUAGE, null).map { raw ->
             raw?.trim()?.takeIf { it.isNotEmpty() && AppLanguages.containsTag(it) }
@@ -427,6 +448,9 @@ class TweaksRepositoryImpl(
         private const val K_TRANSLATION_PROVIDER = "translation_provider"
         private const val K_YOUDAO_APP_KEY = "youdao_app_key"
         private const val K_YOUDAO_APP_SECRET = "youdao_app_secret"
+        private const val K_LIBRE_BASE_URL = "libre_translate_base_url"
+        private const val K_LIBRE_API_KEY = "libre_translate_api_key"
+        private const val K_DEEPL_AUTH_KEY = "deepl_auth_key"
         private const val K_APP_LANGUAGE = "app_language"
         private const val K_AUTO_TRANSLATE_ENABLED = "auto_translate_enabled"
         private const val K_AUTO_TRANSLATE_TARGET = "auto_translate_target_lang"

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/TranslationProvider.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/TranslationProvider.kt
@@ -17,6 +17,7 @@ enum class TranslationProvider {
     YOUDAO,
     LIBRE_TRANSLATE,
     DEEPL,
+    MICROSOFT,
     ;
 
     companion object {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/TranslationProvider.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/TranslationProvider.kt
@@ -15,6 +15,8 @@ package zed.rainxch.core.domain.model
 enum class TranslationProvider {
     GOOGLE,
     YOUDAO,
+    LIBRE_TRANSLATE,
+    DEEPL,
     ;
 
     companion object {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -86,6 +86,18 @@ interface TweaksRepository {
 
     suspend fun setYoudaoAppSecret(appSecret: String)
 
+    fun getLibreTranslateBaseUrl(): Flow<String>
+
+    suspend fun setLibreTranslateBaseUrl(url: String)
+
+    fun getLibreTranslateApiKey(): Flow<String>
+
+    suspend fun setLibreTranslateApiKey(apiKey: String)
+
+    fun getDeeplAuthKey(): Flow<String>
+
+    suspend fun setDeeplAuthKey(authKey: String)
+
     /**
      * Selected UI language as a BCP 47 tag (e.g. `zh-CN`). Emits
      * `null` when the user hasn't picked one — which means "follow

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/repository/TweaksRepository.kt
@@ -98,6 +98,14 @@ interface TweaksRepository {
 
     suspend fun setDeeplAuthKey(authKey: String)
 
+    fun getMicrosoftTranslatorKey(): Flow<String>
+
+    suspend fun setMicrosoftTranslatorKey(key: String)
+
+    fun getMicrosoftTranslatorRegion(): Flow<String>
+
+    suspend fun setMicrosoftTranslatorRegion(region: String)
+
     /**
      * Selected UI language as a BCP 47 tag (e.g. `zh-CN`). Emits
      * `null` when the user hasn't picked one — which means "follow

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -912,7 +912,7 @@
     <string name="translation_youdao_saved">Youdao credentials saved</string>
     <string name="translation_provider_libre">LibreTranslate</string>
     <string name="translation_provider_deepl">DeepL</string>
-    <string name="translation_libre_help">Self-hosted = best privacy. Paste your LibreTranslate instance URL. API key is optional for open mirrors.</string>
+    <string name="translation_libre_help">Works out of the box via the public Disroot mirror — leave fields empty to use it. For more privacy, paste your own self-hosted URL. API key only needed if the instance requires one.</string>
     <string name="translation_libre_base_url">Instance URL</string>
     <string name="translation_libre_api_key">API key (optional)</string>
     <string name="translation_libre_save">Save settings</string>
@@ -921,6 +921,7 @@
     <string name="translation_deepl_auth_key">Auth key</string>
     <string name="translation_deepl_save">Save key</string>
     <string name="translation_deepl_saved">DeepL key saved</string>
+    <string name="translation_deepl_get_free_key">Get a free DeepL key →</string>
 
     <!-- E1: External import wizard -->
     <string name="external_import_top_bar_title">Import installed apps</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -910,6 +910,17 @@
     <string name="translation_youdao_app_secret">App Secret</string>
     <string name="translation_youdao_save">Save credentials</string>
     <string name="translation_youdao_saved">Youdao credentials saved</string>
+    <string name="translation_provider_libre">LibreTranslate</string>
+    <string name="translation_provider_deepl">DeepL</string>
+    <string name="translation_libre_help">Self-hosted = best privacy. Paste your LibreTranslate instance URL. API key is optional for open mirrors.</string>
+    <string name="translation_libre_base_url">Instance URL</string>
+    <string name="translation_libre_api_key">API key (optional)</string>
+    <string name="translation_libre_save">Save settings</string>
+    <string name="translation_libre_saved">LibreTranslate settings saved</string>
+    <string name="translation_deepl_help">Sign up at deepl.com/pro-api. Free tier keys end with :fx and use the free endpoint automatically. Pro tier keeps your text private; Free tier may use submitted text to improve models.</string>
+    <string name="translation_deepl_auth_key">Auth key</string>
+    <string name="translation_deepl_save">Save key</string>
+    <string name="translation_deepl_saved">DeepL key saved</string>
 
     <!-- E1: External import wizard -->
     <string name="external_import_top_bar_title">Import installed apps</string>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -922,6 +922,13 @@
     <string name="translation_deepl_save">Save key</string>
     <string name="translation_deepl_saved">DeepL key saved</string>
     <string name="translation_deepl_get_free_key">Get a free DeepL key →</string>
+    <string name="translation_provider_microsoft">Microsoft</string>
+    <string name="translation_microsoft_help">Azure Translator is privacy-respecting (No-Trace by default — your text is never stored or used for training). Free tier covers 2M characters/month. Region is only needed for non-global resources.</string>
+    <string name="translation_microsoft_key">Subscription key</string>
+    <string name="translation_microsoft_region">Region (e.g. westeurope, leave empty for Global)</string>
+    <string name="translation_microsoft_save">Save credentials</string>
+    <string name="translation_microsoft_saved">Microsoft Translator credentials saved</string>
+    <string name="translation_microsoft_get_free_key">Get a free Azure key →</string>
 
     <!-- E1: External import wizard -->
     <string name="external_import_top_bar_title">Import installed apps</string>

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -217,7 +217,8 @@ class TranslationRepositoryImpl(
                 )
             }
             TranslationProvider.LIBRE_TRANSLATE -> {
-                val baseUrl = tweaksRepository.getLibreTranslateBaseUrl().first()
+                val configured = tweaksRepository.getLibreTranslateBaseUrl().first()
+                val baseUrl = configured.takeIf { it.isNotBlank() } ?: LIBRE_TRANSLATE_DEFAULT_URL
                 val apiKey = tweaksRepository.getLibreTranslateApiKey().first().takeIf { it.isNotBlank() }
                 LibreTranslator(
                     httpClient = { httpClient },
@@ -304,6 +305,11 @@ class TranslationRepositoryImpl(
     companion object {
         private const val MAX_CACHE_SIZE = 50
         private const val CACHE_TTL_MS = 30 * 60 * 1000L // 30 minutes
+        // Public Disroot-hosted LibreTranslate mirror — anonymous, no
+        // API key required. Used when the user picks LibreTranslate
+        // without configuring a self-hosted URL. Override in Tweaks →
+        // Translation when a mirror you trust more is available.
+        private const val LIBRE_TRANSLATE_DEFAULT_URL = "https://translate.disroot.org"
     }
 
     @OptIn(ExperimentalTime::class)

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -13,6 +13,7 @@ import zed.rainxch.details.data.translation.GoogleTranslator
 import zed.rainxch.details.data.translation.Translator
 import zed.rainxch.details.data.translation.DeeplTranslator
 import zed.rainxch.details.data.translation.LibreTranslator
+import zed.rainxch.details.data.translation.MicrosoftTranslator
 import zed.rainxch.details.data.translation.YoudaoTranslator
 import zed.rainxch.details.domain.model.TranslationResult
 import zed.rainxch.details.domain.repository.TranslationRepository
@@ -233,6 +234,16 @@ class TranslationRepositoryImpl(
                     httpClient = { httpClient },
                     json = json,
                     authKey = authKey,
+                )
+            }
+            TranslationProvider.MICROSOFT -> {
+                val key = tweaksRepository.getMicrosoftTranslatorKey().first()
+                val region = tweaksRepository.getMicrosoftTranslatorRegion().first()
+                MicrosoftTranslator(
+                    httpClient = { httpClient },
+                    json = json,
+                    subscriptionKey = key,
+                    subscriptionRegion = region,
                 )
             }
         }

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/TranslationRepositoryImpl.kt
@@ -11,6 +11,8 @@ import zed.rainxch.core.domain.model.TranslationProvider
 import zed.rainxch.core.domain.repository.TweaksRepository
 import zed.rainxch.details.data.translation.GoogleTranslator
 import zed.rainxch.details.data.translation.Translator
+import zed.rainxch.details.data.translation.DeeplTranslator
+import zed.rainxch.details.data.translation.LibreTranslator
 import zed.rainxch.details.data.translation.YoudaoTranslator
 import zed.rainxch.details.domain.model.TranslationResult
 import zed.rainxch.details.domain.repository.TranslationRepository
@@ -212,6 +214,24 @@ class TranslationRepositoryImpl(
                     json = json,
                     appKey = appKey,
                     appSecret = appSecret,
+                )
+            }
+            TranslationProvider.LIBRE_TRANSLATE -> {
+                val baseUrl = tweaksRepository.getLibreTranslateBaseUrl().first()
+                val apiKey = tweaksRepository.getLibreTranslateApiKey().first().takeIf { it.isNotBlank() }
+                LibreTranslator(
+                    httpClient = { httpClient },
+                    json = json,
+                    baseUrl = baseUrl,
+                    apiKey = apiKey,
+                )
+            }
+            TranslationProvider.DEEPL -> {
+                val authKey = tweaksRepository.getDeeplAuthKey().first()
+                DeeplTranslator(
+                    httpClient = { httpClient },
+                    json = json,
+                    authKey = authKey,
                 )
             }
         }

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/DeeplTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/DeeplTranslator.kt
@@ -1,0 +1,96 @@
+package zed.rainxch.details.data.translation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import zed.rainxch.details.domain.model.TranslationResult
+
+internal class DeeplTranslator(
+    private val httpClient: () -> HttpClient,
+    private val json: Json,
+    private val authKey: String,
+) : Translator {
+    override val maxChunkSize: Int = 30_000
+
+    override suspend fun translate(
+        text: String,
+        targetLanguage: String,
+        sourceLanguage: String,
+    ): TranslationResult {
+        if (authKey.isBlank()) {
+            throw TranslationProviderNotConfiguredException(
+                "DeepL auth key not configured",
+            )
+        }
+
+        val host = if (authKey.endsWith(":fx")) {
+            "https://api-free.deepl.com"
+        } else {
+            "https://api.deepl.com"
+        }
+        val endpoint = "$host/v2/translate"
+        val target = mapLanguageCode(targetLanguage)
+        val source = mapSourceLanguageCode(sourceLanguage)
+
+        val response = httpClient().submitForm(
+            url = endpoint,
+            formParameters = Parameters.build {
+                append("text", text)
+                append("target_lang", target)
+                if (source != null) append("source_lang", source)
+                append("preserve_formatting", "1")
+            },
+        ) {
+            header(HttpHeaders.Authorization, "DeepL-Auth-Key $authKey")
+        }
+
+        val body = response.bodyAsText()
+        val root = json.parseToJsonElement(body).jsonObject
+
+        root["message"]?.jsonPrimitive?.content?.let { msg ->
+            if (root["translations"] == null) {
+                throw RuntimeException("DeepL error: $msg")
+            }
+        }
+
+        val first = root["translations"]?.jsonArray?.firstOrNull()?.jsonObject
+            ?: throw RuntimeException("DeepL response missing translations")
+        val translation = first["text"]?.jsonPrimitive?.content.orEmpty()
+        val detected = first["detected_source_language"]
+            ?.jsonPrimitive
+            ?.content
+            ?.lowercase()
+            ?.takeIf { it.isNotBlank() }
+
+        return TranslationResult(
+            translatedText = translation,
+            detectedSourceLanguage = detected,
+        )
+    }
+
+    private fun mapLanguageCode(code: String): String =
+        when (code.lowercase()) {
+            "en" -> "EN-US"
+            "pt" -> "PT-PT"
+            "pt-br" -> "PT-BR"
+            "zh", "zh-cn", "zh-hans" -> "ZH-HANS"
+            "zh-tw", "zh-hant" -> "ZH-HANT"
+            else -> code.uppercase()
+        }
+
+    private fun mapSourceLanguageCode(code: String): String? =
+        when (code.lowercase()) {
+            "", "auto" -> null
+            "zh", "zh-cn", "zh-hans" -> "ZH"
+            "zh-tw", "zh-hant" -> "ZH"
+            "pt-br", "pt" -> "PT"
+            else -> code.uppercase().substringBefore('-')
+        }
+}

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/DeeplTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/DeeplTranslator.kt
@@ -6,6 +6,8 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -52,17 +54,39 @@ internal class DeeplTranslator(
         }
 
         val body = response.bodyAsText()
-        val root = json.parseToJsonElement(body).jsonObject
-
-        root["message"]?.jsonPrimitive?.content?.let { msg ->
-            if (root["translations"] == null) {
-                throw RuntimeException("DeepL error: $msg")
-            }
+        if (!response.status.isSuccess()) {
+            val message = runCatching {
+                json.parseToJsonElement(body).jsonObject["message"]?.jsonPrimitive?.content
+            }.getOrNull()
+            throw RuntimeException(
+                "DeepL HTTP ${response.status.value}: ${message ?: body.take(200)}",
+            )
         }
 
-        val first = root["translations"]?.jsonArray?.firstOrNull()?.jsonObject
+        val root = try {
+            json.parseToJsonElement(body).jsonObject
+        } catch (e: SerializationException) {
+            throw RuntimeException(
+                "DeepL returned non-JSON response: ${body.take(200)}",
+                e,
+            )
+        }
+
+        // Surface `message` whenever it's present alongside a missing /
+        // empty translations array — DeepL sometimes returns
+        // `{"translations":[], "message":"..."}` instead of an HTTP error.
+        val translations = root["translations"]?.jsonArray
+        val errorMessage = root["message"]?.jsonPrimitive?.content
+        if (translations.isNullOrEmpty()) {
+            throw RuntimeException(
+                "DeepL ${errorMessage?.let { "error: $it" } ?: "response missing translations"}",
+            )
+        }
+
+        val first = translations.firstOrNull()?.jsonObject
             ?: throw RuntimeException("DeepL response missing translations")
-        val translation = first["text"]?.jsonPrimitive?.content.orEmpty()
+        val translation = first["text"]?.jsonPrimitive?.content
+            ?: throw RuntimeException("DeepL response missing translation text")
         val detected = first["detected_source_language"]
             ?.jsonPrimitive
             ?.content

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/LibreTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/LibreTranslator.kt
@@ -4,6 +4,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -28,9 +30,10 @@ internal class LibreTranslator(
             )
         }
 
+        val target = mapTargetLanguageCode(targetLanguage)
+            ?: throw RuntimeException("LibreTranslate target language required (got '$targetLanguage')")
+        val source = mapSourceLanguageCode(sourceLanguage)
         val endpoint = baseUrl.trimEnd('/') + "/translate"
-        val source = mapLanguageCode(sourceLanguage)
-        val target = mapLanguageCode(targetLanguage)
 
         val response = httpClient().submitForm(
             url = endpoint,
@@ -44,13 +47,33 @@ internal class LibreTranslator(
         )
 
         val body = response.bodyAsText()
-        val root = json.parseToJsonElement(body).jsonObject
+        if (!response.status.isSuccess()) {
+            // Try to parse the JSON error envelope; fall through to raw
+            // body when the upstream returned HTML / plain text (proxy
+            // pages, WAF blocks, misconfigured self-host).
+            val message = runCatching {
+                json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
+            }.getOrNull()
+            throw RuntimeException(
+                "LibreTranslate HTTP ${response.status.value}: ${message ?: body.take(200)}",
+            )
+        }
+
+        val root = try {
+            json.parseToJsonElement(body).jsonObject
+        } catch (e: SerializationException) {
+            throw RuntimeException(
+                "LibreTranslate returned non-JSON response: ${body.take(200)}",
+                e,
+            )
+        }
 
         root["error"]?.jsonPrimitive?.content?.let { msg ->
             throw RuntimeException("LibreTranslate error: $msg")
         }
 
-        val translation = root["translatedText"]?.jsonPrimitive?.content.orEmpty()
+        val translation = root["translatedText"]?.jsonPrimitive?.content
+            ?: throw RuntimeException("LibreTranslate response missing translatedText")
         val detected = root["detectedLanguage"]
             ?.jsonObject
             ?.get("language")
@@ -64,9 +87,17 @@ internal class LibreTranslator(
         )
     }
 
-    private fun mapLanguageCode(code: String): String =
+    private fun mapSourceLanguageCode(code: String): String =
         when (code.lowercase()) {
             "", "auto" -> "auto"
+            "zh-cn", "zh-hans" -> "zh"
+            "zh-tw", "zh-hant" -> "zt"
+            else -> code.lowercase().substringBefore('-')
+        }
+
+    private fun mapTargetLanguageCode(code: String): String? =
+        when (code.lowercase()) {
+            "", "auto" -> null
             "zh-cn", "zh-hans" -> "zh"
             "zh-tw", "zh-hant" -> "zt"
             else -> code.lowercase().substringBefore('-')

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/LibreTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/LibreTranslator.kt
@@ -1,0 +1,74 @@
+package zed.rainxch.details.data.translation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.Parameters
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import zed.rainxch.details.domain.model.TranslationResult
+
+internal class LibreTranslator(
+    private val httpClient: () -> HttpClient,
+    private val json: Json,
+    private val baseUrl: String,
+    private val apiKey: String?,
+) : Translator {
+    override val maxChunkSize: Int = 2_000
+
+    override suspend fun translate(
+        text: String,
+        targetLanguage: String,
+        sourceLanguage: String,
+    ): TranslationResult {
+        if (baseUrl.isBlank()) {
+            throw TranslationProviderNotConfiguredException(
+                "LibreTranslate instance URL not configured",
+            )
+        }
+
+        val endpoint = baseUrl.trimEnd('/') + "/translate"
+        val source = mapLanguageCode(sourceLanguage)
+        val target = mapLanguageCode(targetLanguage)
+
+        val response = httpClient().submitForm(
+            url = endpoint,
+            formParameters = Parameters.build {
+                append("q", text)
+                append("source", source)
+                append("target", target)
+                append("format", "text")
+                if (!apiKey.isNullOrBlank()) append("api_key", apiKey)
+            },
+        )
+
+        val body = response.bodyAsText()
+        val root = json.parseToJsonElement(body).jsonObject
+
+        root["error"]?.jsonPrimitive?.content?.let { msg ->
+            throw RuntimeException("LibreTranslate error: $msg")
+        }
+
+        val translation = root["translatedText"]?.jsonPrimitive?.content.orEmpty()
+        val detected = root["detectedLanguage"]
+            ?.jsonObject
+            ?.get("language")
+            ?.jsonPrimitive
+            ?.content
+            ?.takeIf { it.isNotBlank() }
+
+        return TranslationResult(
+            translatedText = translation,
+            detectedSourceLanguage = detected,
+        )
+    }
+
+    private fun mapLanguageCode(code: String): String =
+        when (code.lowercase()) {
+            "", "auto" -> "auto"
+            "zh-cn", "zh-hans" -> "zh"
+            "zh-tw", "zh-hant" -> "zt"
+            else -> code.lowercase().substringBefore('-')
+        }
+}

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/MicrosoftTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/MicrosoftTranslator.kt
@@ -1,0 +1,112 @@
+package zed.rainxch.details.data.translation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import zed.rainxch.details.domain.model.TranslationResult
+
+internal class MicrosoftTranslator(
+    private val httpClient: () -> HttpClient,
+    private val json: Json,
+    private val subscriptionKey: String,
+    private val subscriptionRegion: String,
+) : Translator {
+    override val maxChunkSize: Int = 45_000
+
+    override suspend fun translate(
+        text: String,
+        targetLanguage: String,
+        sourceLanguage: String,
+    ): TranslationResult {
+        if (subscriptionKey.isBlank()) {
+            throw TranslationProviderNotConfiguredException(
+                "Microsoft Translator subscription key not configured",
+            )
+        }
+
+        val target = mapLanguageCode(targetLanguage)
+        val source = mapSourceLanguageCode(sourceLanguage)
+        val sourceQuery = source?.let { "&from=$it" }.orEmpty()
+        val url = "https://api.cognitive.microsofttranslator.com/translate" +
+            "?api-version=3.0&to=$target$sourceQuery"
+
+        val requestBody: JsonArray = buildJsonArray {
+            addJsonObject {
+                put("Text", text)
+            }
+        }
+
+        val response = httpClient().post(url) {
+            header("Ocp-Apim-Subscription-Key", subscriptionKey)
+            if (subscriptionRegion.isNotBlank() && !subscriptionRegion.equals("global", ignoreCase = true)) {
+                header("Ocp-Apim-Subscription-Region", subscriptionRegion.lowercase())
+            }
+            contentType(ContentType.Application.Json)
+            setBody(requestBody.toString())
+        }
+
+        val body = response.bodyAsText()
+        val parsed = json.parseToJsonElement(body)
+
+        if (parsed is JsonObject) {
+            val errorMsg = parsed["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content
+            throw RuntimeException("Microsoft Translator error: ${errorMsg ?: body}")
+        }
+
+        val first = parsed.jsonArray.firstOrNull()?.jsonObject
+            ?: throw RuntimeException("Microsoft Translator response empty")
+
+        val translation = first["translations"]
+            ?.jsonArray
+            ?.firstOrNull()
+            ?.jsonObject
+            ?.get("text")
+            ?.jsonPrimitive
+            ?.content
+            .orEmpty()
+
+        val detected = first["detectedLanguage"]
+            ?.jsonObject
+            ?.get("language")
+            ?.jsonPrimitive
+            ?.content
+            ?.lowercase()
+            ?.takeIf { it.isNotBlank() }
+
+        return TranslationResult(
+            translatedText = translation,
+            detectedSourceLanguage = detected,
+        )
+    }
+
+    private fun mapLanguageCode(code: String): String =
+        when (code.lowercase()) {
+            "zh", "zh-cn", "zh-hans" -> "zh-Hans"
+            "zh-tw", "zh-hant" -> "zh-Hant"
+            "pt", "pt-br" -> "pt-br"
+            "pt-pt" -> "pt-pt"
+            "no" -> "nb"
+            "sr-cyrl" -> "sr-Cyrl"
+            "sr-latn" -> "sr-Latn"
+            else -> code.lowercase()
+        }
+
+    private fun mapSourceLanguageCode(code: String): String? =
+        when (code.lowercase()) {
+            "", "auto" -> null
+            else -> mapLanguageCode(code)
+        }
+}

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/MicrosoftTranslator.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/translation/MicrosoftTranslator.kt
@@ -7,6 +7,8 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -59,7 +61,28 @@ internal class MicrosoftTranslator(
         }
 
         val body = response.bodyAsText()
-        val parsed = json.parseToJsonElement(body)
+        if (!response.status.isSuccess()) {
+            val errorMsg = runCatching {
+                json.parseToJsonElement(body)
+                    .jsonObject["error"]
+                    ?.jsonObject
+                    ?.get("message")
+                    ?.jsonPrimitive
+                    ?.content
+            }.getOrNull()
+            throw RuntimeException(
+                "Microsoft Translator HTTP ${response.status.value}: ${errorMsg ?: body.take(200)}",
+            )
+        }
+
+        val parsed = try {
+            json.parseToJsonElement(body)
+        } catch (e: SerializationException) {
+            throw RuntimeException(
+                "Microsoft Translator returned non-JSON response: ${body.take(200)}",
+                e,
+            )
+        }
 
         if (parsed is JsonObject) {
             val errorMsg = parsed["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content
@@ -76,7 +99,7 @@ internal class MicrosoftTranslator(
             ?.get("text")
             ?.jsonPrimitive
             ?.content
-            .orEmpty()
+            ?: throw RuntimeException("Microsoft Translator response missing translation text")
 
         val detected = first["detectedLanguage"]
             ?.jsonObject

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
@@ -160,6 +160,26 @@ sealed interface TweaksAction {
 
     data object OnYoudaoCredentialsSave : TweaksAction
 
+    data class OnLibreTranslateBaseUrlChanged(
+        val url: String,
+    ) : TweaksAction
+
+    data class OnLibreTranslateApiKeyChanged(
+        val apiKey: String,
+    ) : TweaksAction
+
+    data object OnLibreTranslateApiKeyVisibilityToggle : TweaksAction
+
+    data object OnLibreTranslateCredentialsSave : TweaksAction
+
+    data class OnDeeplAuthKeyChanged(
+        val authKey: String,
+    ) : TweaksAction
+
+    data object OnDeeplAuthKeyVisibilityToggle : TweaksAction
+
+    data object OnDeeplCredentialsSave : TweaksAction
+
     data class OnAutoTranslateEnabledToggle(
         val enabled: Boolean,
     ) : TweaksAction

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksAction.kt
@@ -180,6 +180,18 @@ sealed interface TweaksAction {
 
     data object OnDeeplCredentialsSave : TweaksAction
 
+    data class OnMicrosoftTranslatorKeyChanged(
+        val key: String,
+    ) : TweaksAction
+
+    data class OnMicrosoftTranslatorRegionChanged(
+        val region: String,
+    ) : TweaksAction
+
+    data object OnMicrosoftTranslatorKeyVisibilityToggle : TweaksAction
+
+    data object OnMicrosoftTranslatorCredentialsSave : TweaksAction
+
     data class OnAutoTranslateEnabledToggle(
         val enabled: Boolean,
     ) : TweaksAction

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksEvent.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksEvent.kt
@@ -29,6 +29,10 @@ sealed interface TweaksEvent {
 
     data object OnYoudaoCredentialsSaved : TweaksEvent
 
+    data object OnLibreTranslateCredentialsSaved : TweaksEvent
+
+    data object OnDeeplCredentialsSaved : TweaksEvent
+
     /**
      * Fired on platforms where changing the UI language cannot be
      * applied in-place (currently Desktop — no `Activity.recreate()`

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksEvent.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksEvent.kt
@@ -33,6 +33,8 @@ sealed interface TweaksEvent {
 
     data object OnDeeplCredentialsSaved : TweaksEvent
 
+    data object OnMicrosoftTranslatorCredentialsSaved : TweaksEvent
+
     /**
      * Fired on platforms where changing the UI language cannot be
      * applied in-place (currently Desktop — no `Activity.recreate()`

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -147,6 +147,12 @@ fun TweaksRoot(
                 }
             }
 
+            TweaksEvent.OnMicrosoftTranslatorCredentialsSaved -> {
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(getString(Res.string.translation_microsoft_saved))
+                }
+            }
+
             TweaksEvent.OnAppLanguageChangeRequiresRestart -> {
                 coroutineScope.launch {
                     val result =

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksRoot.kt
@@ -135,6 +135,18 @@ fun TweaksRoot(
                 }
             }
 
+            TweaksEvent.OnLibreTranslateCredentialsSaved -> {
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(getString(Res.string.translation_libre_saved))
+                }
+            }
+
+            TweaksEvent.OnDeeplCredentialsSaved -> {
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(getString(Res.string.translation_deepl_saved))
+                }
+            }
+
             TweaksEvent.OnAppLanguageChangeRequiresRestart -> {
                 coroutineScope.launch {
                     val result =

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
@@ -53,6 +53,11 @@ data class TweaksState(
     val youdaoAppKey: String = "",
     val youdaoAppSecret: String = "",
     val isYoudaoAppSecretVisible: Boolean = false,
+    val libreTranslateBaseUrl: String = "",
+    val libreTranslateApiKey: String = "",
+    val isLibreTranslateApiKeyVisible: Boolean = false,
+    val deeplAuthKey: String = "",
+    val isDeeplAuthKeyVisible: Boolean = false,
     /**
      * User-selected UI language as a BCP 47 tag, or `null` to follow
      * the system locale. Mirrors the preference observed by

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksState.kt
@@ -58,6 +58,9 @@ data class TweaksState(
     val isLibreTranslateApiKeyVisible: Boolean = false,
     val deeplAuthKey: String = "",
     val isDeeplAuthKeyVisible: Boolean = false,
+    val microsoftTranslatorKey: String = "",
+    val microsoftTranslatorRegion: String = "",
+    val isMicrosoftTranslatorKeyVisible: Boolean = false,
     /**
      * User-selected UI language as a BCP 47 tag, or `null` to follow
      * the system locale. Mirrors the preference observed by

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -503,6 +503,16 @@ class TweaksViewModel(
                 _state.update { it.copy(deeplAuthKey = authKey) }
             }
         }
+        viewModelScope.launch {
+            tweaksRepository.getMicrosoftTranslatorKey().collect { key ->
+                _state.update { it.copy(microsoftTranslatorKey = key) }
+            }
+        }
+        viewModelScope.launch {
+            tweaksRepository.getMicrosoftTranslatorRegion().collect { region ->
+                _state.update { it.copy(microsoftTranslatorRegion = region) }
+            }
+        }
     }
 
     private fun evaluateBatteryOptimizationCard() {
@@ -992,6 +1002,21 @@ class TweaksViewModel(
                             }
                         }
                     }
+                    TranslationProvider.MICROSOFT -> {
+                        val current = _state.value
+                        val hasCreds = current.microsoftTranslatorKey.isNotBlank()
+                        if (hasCreds) {
+                            _state.update { it.copy(draftTranslationProvider = null) }
+                            viewModelScope.launch {
+                                tweaksRepository.setTranslationProvider(action.provider)
+                                _events.send(TweaksEvent.OnTranslationProviderSaved)
+                            }
+                        } else {
+                            _state.update {
+                                it.copy(draftTranslationProvider = TranslationProvider.MICROSOFT)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1095,6 +1120,39 @@ class TweaksViewModel(
                     }
                     _state.update { it.copy(draftTranslationProvider = null) }
                     _events.send(TweaksEvent.OnDeeplCredentialsSaved)
+                }
+            }
+
+            is TweaksAction.OnMicrosoftTranslatorKeyChanged -> {
+                _state.update { it.copy(microsoftTranslatorKey = action.key) }
+            }
+
+            is TweaksAction.OnMicrosoftTranslatorRegionChanged -> {
+                _state.update { it.copy(microsoftTranslatorRegion = action.region) }
+            }
+
+            TweaksAction.OnMicrosoftTranslatorKeyVisibilityToggle -> {
+                _state.update {
+                    it.copy(isMicrosoftTranslatorKeyVisible = !it.isMicrosoftTranslatorKeyVisible)
+                }
+            }
+
+            TweaksAction.OnMicrosoftTranslatorCredentialsSave -> {
+                val current = _state.value
+                viewModelScope.launch {
+                    tweaksRepository.setMicrosoftTranslatorKey(current.microsoftTranslatorKey)
+                    tweaksRepository.setMicrosoftTranslatorRegion(current.microsoftTranslatorRegion)
+                    val shouldActivate =
+                        current.microsoftTranslatorKey.isNotBlank() &&
+                            (
+                                current.translationProvider != TranslationProvider.MICROSOFT ||
+                                    current.draftTranslationProvider == TranslationProvider.MICROSOFT
+                            )
+                    if (shouldActivate) {
+                        tweaksRepository.setTranslationProvider(TranslationProvider.MICROSOFT)
+                    }
+                    _state.update { it.copy(draftTranslationProvider = null) }
+                    _events.send(TweaksEvent.OnMicrosoftTranslatorCredentialsSaved)
                 }
             }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -967,18 +967,14 @@ class TweaksViewModel(
                         }
                     }
                     TranslationProvider.LIBRE_TRANSLATE -> {
-                        val current = _state.value
-                        val hasCreds = current.libreTranslateBaseUrl.isNotBlank()
-                        if (hasCreds) {
-                            _state.update { it.copy(draftTranslationProvider = null) }
-                            viewModelScope.launch {
-                                tweaksRepository.setTranslationProvider(action.provider)
-                                _events.send(TweaksEvent.OnTranslationProviderSaved)
-                            }
-                        } else {
-                            _state.update {
-                                it.copy(draftTranslationProvider = TranslationProvider.LIBRE_TRANSLATE)
-                            }
+                        // No gating — repository falls back to the
+                        // public Disroot mirror when no URL configured,
+                        // so first-tap "just works" without going
+                        // through a config dialog.
+                        _state.update { it.copy(draftTranslationProvider = null) }
+                        viewModelScope.launch {
+                            tweaksRepository.setTranslationProvider(action.provider)
+                            _events.send(TweaksEvent.OnTranslationProviderSaved)
                         }
                     }
                     TranslationProvider.DEEPL -> {

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -488,6 +488,21 @@ class TweaksViewModel(
                 _state.update { it.copy(youdaoAppSecret = appSecret) }
             }
         }
+        viewModelScope.launch {
+            tweaksRepository.getLibreTranslateBaseUrl().collect { url ->
+                _state.update { it.copy(libreTranslateBaseUrl = url) }
+            }
+        }
+        viewModelScope.launch {
+            tweaksRepository.getLibreTranslateApiKey().collect { apiKey ->
+                _state.update { it.copy(libreTranslateApiKey = apiKey) }
+            }
+        }
+        viewModelScope.launch {
+            tweaksRepository.getDeeplAuthKey().collect { authKey ->
+                _state.update { it.copy(deeplAuthKey = authKey) }
+            }
+        }
     }
 
     private fun evaluateBatteryOptimizationCard() {
@@ -951,6 +966,36 @@ class TweaksViewModel(
                             }
                         }
                     }
+                    TranslationProvider.LIBRE_TRANSLATE -> {
+                        val current = _state.value
+                        val hasCreds = current.libreTranslateBaseUrl.isNotBlank()
+                        if (hasCreds) {
+                            _state.update { it.copy(draftTranslationProvider = null) }
+                            viewModelScope.launch {
+                                tweaksRepository.setTranslationProvider(action.provider)
+                                _events.send(TweaksEvent.OnTranslationProviderSaved)
+                            }
+                        } else {
+                            _state.update {
+                                it.copy(draftTranslationProvider = TranslationProvider.LIBRE_TRANSLATE)
+                            }
+                        }
+                    }
+                    TranslationProvider.DEEPL -> {
+                        val current = _state.value
+                        val hasCreds = current.deeplAuthKey.isNotBlank()
+                        if (hasCreds) {
+                            _state.update { it.copy(draftTranslationProvider = null) }
+                            viewModelScope.launch {
+                                tweaksRepository.setTranslationProvider(action.provider)
+                                _events.send(TweaksEvent.OnTranslationProviderSaved)
+                            }
+                        } else {
+                            _state.update {
+                                it.copy(draftTranslationProvider = TranslationProvider.DEEPL)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -993,6 +1038,67 @@ class TweaksViewModel(
                     // the user emptied fields and cancelled implicitly.
                     _state.update { it.copy(draftTranslationProvider = null) }
                     _events.send(TweaksEvent.OnYoudaoCredentialsSaved)
+                }
+            }
+
+            is TweaksAction.OnLibreTranslateBaseUrlChanged -> {
+                _state.update { it.copy(libreTranslateBaseUrl = action.url) }
+            }
+
+            is TweaksAction.OnLibreTranslateApiKeyChanged -> {
+                _state.update { it.copy(libreTranslateApiKey = action.apiKey) }
+            }
+
+            TweaksAction.OnLibreTranslateApiKeyVisibilityToggle -> {
+                _state.update {
+                    it.copy(isLibreTranslateApiKeyVisible = !it.isLibreTranslateApiKeyVisible)
+                }
+            }
+
+            TweaksAction.OnLibreTranslateCredentialsSave -> {
+                val current = _state.value
+                viewModelScope.launch {
+                    tweaksRepository.setLibreTranslateBaseUrl(current.libreTranslateBaseUrl)
+                    tweaksRepository.setLibreTranslateApiKey(current.libreTranslateApiKey)
+                    val shouldActivate =
+                        current.libreTranslateBaseUrl.isNotBlank() &&
+                            (
+                                current.translationProvider != TranslationProvider.LIBRE_TRANSLATE ||
+                                    current.draftTranslationProvider == TranslationProvider.LIBRE_TRANSLATE
+                            )
+                    if (shouldActivate) {
+                        tweaksRepository.setTranslationProvider(TranslationProvider.LIBRE_TRANSLATE)
+                    }
+                    _state.update { it.copy(draftTranslationProvider = null) }
+                    _events.send(TweaksEvent.OnLibreTranslateCredentialsSaved)
+                }
+            }
+
+            is TweaksAction.OnDeeplAuthKeyChanged -> {
+                _state.update { it.copy(deeplAuthKey = action.authKey) }
+            }
+
+            TweaksAction.OnDeeplAuthKeyVisibilityToggle -> {
+                _state.update {
+                    it.copy(isDeeplAuthKeyVisible = !it.isDeeplAuthKeyVisible)
+                }
+            }
+
+            TweaksAction.OnDeeplCredentialsSave -> {
+                val current = _state.value
+                viewModelScope.launch {
+                    tweaksRepository.setDeeplAuthKey(current.deeplAuthKey)
+                    val shouldActivate =
+                        current.deeplAuthKey.isNotBlank() &&
+                            (
+                                current.translationProvider != TranslationProvider.DEEPL ||
+                                    current.draftTranslationProvider == TranslationProvider.DEEPL
+                            )
+                    if (shouldActivate) {
+                        tweaksRepository.setTranslationProvider(TranslationProvider.DEEPL)
+                    }
+                    _state.update { it.copy(draftTranslationProvider = null) }
+                    _events.send(TweaksEvent.OnDeeplCredentialsSaved)
                 }
             }
 

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -254,6 +254,17 @@ private fun TranslationProviderCard(
                     onAction = onAction,
                 )
             }
+
+            AnimatedVisibility(
+                visible = state.displayedTranslationProvider == TranslationProvider.MICROSOFT,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                MicrosoftCredentialsForm(
+                    state = state,
+                    onAction = onAction,
+                )
+            }
         }
     }
 }
@@ -265,6 +276,7 @@ private fun providerLabel(provider: TranslationProvider): String =
         TranslationProvider.YOUDAO -> stringResource(Res.string.translation_provider_youdao)
         TranslationProvider.LIBRE_TRANSLATE -> stringResource(Res.string.translation_provider_libre)
         TranslationProvider.DEEPL -> stringResource(Res.string.translation_provider_deepl)
+        TranslationProvider.MICROSOFT -> stringResource(Res.string.translation_provider_microsoft)
     }
 
 /**
@@ -607,6 +619,98 @@ private fun DeeplCredentialsForm(
                 )
                 Spacer(Modifier.size(8.dp))
                 Text(stringResource(Res.string.translation_deepl_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun MicrosoftCredentialsForm(
+    state: TweaksState,
+    onAction: (TweaksAction) -> Unit,
+) {
+    val canSave = state.microsoftTranslatorKey.isNotBlank()
+    val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
+
+    Column(
+        modifier = Modifier.padding(top = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.translation_microsoft_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        androidx.compose.material3.TextButton(
+            onClick = { runCatching { uriHandler.openUri("https://portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation") } },
+            modifier = Modifier.align(Alignment.Start),
+        ) {
+            Text(stringResource(Res.string.translation_microsoft_get_free_key))
+        }
+
+        OutlinedTextField(
+            value = state.microsoftTranslatorKey,
+            onValueChange = { onAction(TweaksAction.OnMicrosoftTranslatorKeyChanged(it)) },
+            label = { Text(stringResource(Res.string.translation_microsoft_key)) },
+            singleLine = true,
+            visualTransformation =
+                if (state.isMicrosoftTranslatorKeyVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+            trailingIcon = {
+                IconButton(
+                    onClick = { onAction(TweaksAction.OnMicrosoftTranslatorKeyVisibilityToggle) },
+                ) {
+                    Icon(
+                        imageVector =
+                            if (state.isMicrosoftTranslatorKeyVisible) {
+                                Icons.Default.VisibilityOff
+                            } else {
+                                Icons.Default.Visibility
+                            },
+                        contentDescription =
+                            if (state.isMicrosoftTranslatorKeyVisible) {
+                                stringResource(Res.string.proxy_hide_password)
+                            } else {
+                                stringResource(Res.string.proxy_show_password)
+                            },
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
+        OutlinedTextField(
+            value = state.microsoftTranslatorRegion,
+            onValueChange = { onAction(TweaksAction.OnMicrosoftTranslatorRegionChanged(it)) },
+            label = { Text(stringResource(Res.string.translation_microsoft_region)) },
+            placeholder = { Text("global") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalButton(
+                onClick = { onAction(TweaksAction.OnMicrosoftTranslatorCredentialsSave) },
+                enabled = canSave,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Save,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(stringResource(Res.string.translation_microsoft_save))
             }
         }
     }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -232,6 +232,28 @@ private fun TranslationProviderCard(
                     onAction = onAction,
                 )
             }
+
+            AnimatedVisibility(
+                visible = state.displayedTranslationProvider == TranslationProvider.LIBRE_TRANSLATE,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                LibreTranslateCredentialsForm(
+                    state = state,
+                    onAction = onAction,
+                )
+            }
+
+            AnimatedVisibility(
+                visible = state.displayedTranslationProvider == TranslationProvider.DEEPL,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                DeeplCredentialsForm(
+                    state = state,
+                    onAction = onAction,
+                )
+            }
         }
     }
 }
@@ -241,6 +263,8 @@ private fun providerLabel(provider: TranslationProvider): String =
     when (provider) {
         TranslationProvider.GOOGLE -> stringResource(Res.string.translation_provider_google)
         TranslationProvider.YOUDAO -> stringResource(Res.string.translation_provider_youdao)
+        TranslationProvider.LIBRE_TRANSLATE -> stringResource(Res.string.translation_provider_libre)
+        TranslationProvider.DEEPL -> stringResource(Res.string.translation_provider_deepl)
     }
 
 /**
@@ -414,6 +438,165 @@ private fun YoudaoCredentialsForm(
                 )
                 Spacer(Modifier.size(8.dp))
                 Text(stringResource(Res.string.translation_youdao_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibreTranslateCredentialsForm(
+    state: TweaksState,
+    onAction: (TweaksAction) -> Unit,
+) {
+    val canSave = state.libreTranslateBaseUrl.isNotBlank()
+
+    Column(
+        modifier = Modifier.padding(top = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.translation_libre_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        OutlinedTextField(
+            value = state.libreTranslateBaseUrl,
+            onValueChange = { onAction(TweaksAction.OnLibreTranslateBaseUrlChanged(it)) },
+            label = { Text(stringResource(Res.string.translation_libre_base_url)) },
+            placeholder = { Text("https://translate.example.com") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
+        OutlinedTextField(
+            value = state.libreTranslateApiKey,
+            onValueChange = { onAction(TweaksAction.OnLibreTranslateApiKeyChanged(it)) },
+            label = { Text(stringResource(Res.string.translation_libre_api_key)) },
+            singleLine = true,
+            visualTransformation =
+                if (state.isLibreTranslateApiKeyVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+            trailingIcon = {
+                IconButton(
+                    onClick = { onAction(TweaksAction.OnLibreTranslateApiKeyVisibilityToggle) },
+                ) {
+                    Icon(
+                        imageVector =
+                            if (state.isLibreTranslateApiKeyVisible) {
+                                Icons.Default.VisibilityOff
+                            } else {
+                                Icons.Default.Visibility
+                            },
+                        contentDescription =
+                            if (state.isLibreTranslateApiKeyVisible) {
+                                stringResource(Res.string.proxy_hide_password)
+                            } else {
+                                stringResource(Res.string.proxy_show_password)
+                            },
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalButton(
+                onClick = { onAction(TweaksAction.OnLibreTranslateCredentialsSave) },
+                enabled = canSave,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Save,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(stringResource(Res.string.translation_libre_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeeplCredentialsForm(
+    state: TweaksState,
+    onAction: (TweaksAction) -> Unit,
+) {
+    val canSave = state.deeplAuthKey.isNotBlank()
+
+    Column(
+        modifier = Modifier.padding(top = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(Res.string.translation_deepl_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        OutlinedTextField(
+            value = state.deeplAuthKey,
+            onValueChange = { onAction(TweaksAction.OnDeeplAuthKeyChanged(it)) },
+            label = { Text(stringResource(Res.string.translation_deepl_auth_key)) },
+            singleLine = true,
+            visualTransformation =
+                if (state.isDeeplAuthKeyVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+            trailingIcon = {
+                IconButton(
+                    onClick = { onAction(TweaksAction.OnDeeplAuthKeyVisibilityToggle) },
+                ) {
+                    Icon(
+                        imageVector =
+                            if (state.isDeeplAuthKeyVisible) {
+                                Icons.Default.VisibilityOff
+                            } else {
+                                Icons.Default.Visibility
+                            },
+                        contentDescription =
+                            if (state.isDeeplAuthKeyVisible) {
+                                stringResource(Res.string.proxy_hide_password)
+                            } else {
+                                stringResource(Res.string.proxy_show_password)
+                            },
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalButton(
+                onClick = { onAction(TweaksAction.OnDeeplCredentialsSave) },
+                enabled = canSave,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Save,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(stringResource(Res.string.translation_deepl_save))
             }
         }
     }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/sections/Translation.kt
@@ -448,7 +448,9 @@ private fun LibreTranslateCredentialsForm(
     state: TweaksState,
     onAction: (TweaksAction) -> Unit,
 ) {
-    val canSave = state.libreTranslateBaseUrl.isNotBlank()
+    // Always allow save — empty URL is a valid state (falls back to
+    // the bundled public mirror in the repository layer).
+    val canSave = true
 
     Column(
         modifier = Modifier.padding(top = 16.dp),
@@ -464,7 +466,7 @@ private fun LibreTranslateCredentialsForm(
             value = state.libreTranslateBaseUrl,
             onValueChange = { onAction(TweaksAction.OnLibreTranslateBaseUrlChanged(it)) },
             label = { Text(stringResource(Res.string.translation_libre_base_url)) },
-            placeholder = { Text("https://translate.example.com") },
+            placeholder = { Text("https://translate.disroot.org") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
             modifier = Modifier.fillMaxWidth(),
@@ -534,6 +536,7 @@ private fun DeeplCredentialsForm(
     onAction: (TweaksAction) -> Unit,
 ) {
     val canSave = state.deeplAuthKey.isNotBlank()
+    val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
 
     Column(
         modifier = Modifier.padding(top = 16.dp),
@@ -544,6 +547,13 @@ private fun DeeplCredentialsForm(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        androidx.compose.material3.TextButton(
+            onClick = { runCatching { uriHandler.openUri("https://www.deepl.com/pro-api") } },
+            modifier = Modifier.align(Alignment.Start),
+        ) {
+            Text(stringResource(Res.string.translation_deepl_get_free_key))
+        }
 
         OutlinedTextField(
             value = state.deeplAuthKey,


### PR DESCRIPTION
## Summary
Adds two privacy-respecting translation providers per #644:
- **LibreTranslate** — user supplies instance URL (self-host = best privacy). Optional API key. Public mirrors come and go, so no defaults baked in.
- **DeepL** — user supplies auth key. Free tier (`:fx` suffix) routes to `api-free.deepl.com`; Pro routes to `api.deepl.com`. Free tier may use submitted text to train models — disclaimer surfaced in UI.

## Architecture
Follows the existing Google/Youdao pattern:
- `TranslationProvider` enum gains `LIBRE_TRANSLATE` + `DEEPL`
- `LibreTranslator` + `DeeplTranslator` implement `Translator`
- `TweaksRepository` gains KSafe-encrypted prefs (`libre_translate_base_url`, `libre_translate_api_key`, `deepl_auth_key`)
- `TranslationRepositoryImpl.resolveTranslator()` routes to new providers
- Tweaks UI gains 2 credential forms with privacy disclaimers

## Test plan
- [ ] Tweaks → Translation → tap LibreTranslate chip → form expands → paste URL → Save → translate a README → verify hit lands on user's instance
- [ ] Tweaks → Translation → tap DeepL chip → form expands → paste `:fx` key → Save → translate → verify free endpoint hit
- [ ] Paste non-`:fx` key → verify pro endpoint hit
- [ ] Empty creds → translation triggers `TranslationProviderNotConfiguredException` surfaced in UI

Closes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LibreTranslate, DeepL, and Microsoft translation providers with persistent credentials, provider selection, and LibreTranslate default fallback when URL is blank.
  * LibreTranslate supports a configurable base URL and optional API key; DeepL uses an auth key; Microsoft uses key + region. Deepl selection only activates when a key is present.

* **UI Changes**
  * New settings forms to enter/save credentials, key show/hide toggles, and provider-specific save confirmations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->