### PR TITLE
fix(details): unblock Android touch scroll (gutter scrollable was double-handling)

### DIFF
--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -537,6 +537,15 @@ fun DetailsScreen(
                     .scrollable(
                         state = listState,
                         orientation = Orientation.Vertical,
+                        // LazyColumn's internal scrollable uses
+                        // reverseDirection=true (vertical, default
+                        // layout direction). Matching that here makes
+                        // the wheel-direction sign convention agree
+                        // — otherwise wheel-up at the top jumps to
+                        // the bottom and vice versa, because parent
+                        // and child interpret the same pointer delta
+                        // with opposite signs.
+                        reverseDirection = true,
                         enabled = isDesktop,
                     )
                     .onSizeChanged { size ->

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -3,6 +3,8 @@ package zed.rainxch.details.presentation
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
+import zed.rainxch.core.domain.getPlatform
+import zed.rainxch.core.domain.model.Platform
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -521,12 +523,21 @@ fun DetailsScreen(
             }
             val pullEnabled = remember { isPullToRefreshSupported() }
 
+            // Gutter scroll forwarding is a desktop-only UX polish
+            // (mouse-wheel-in-side-margins → scrolls content column).
+            // On Android the outer scrollable fought the inner
+            // LazyColumn's own scroll handler — both pointing at the
+            // same `listState` doubled-up gesture handling and the
+            // touch scroll froze. Issue tracked under content-width
+            // PR follow-up. Keep enabled = isDesktop.
+            val isDesktop = remember { getPlatform() != Platform.ANDROID }
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .scrollable(
                         state = listState,
                         orientation = Orientation.Vertical,
+                        enabled = isDesktop,
                     )
                     .onSizeChanged { size ->
                         // Layout-phase write; cheaper than BoxWithConstraints


### PR DESCRIPTION
## Summary
PR #646 added \`Modifier.scrollable(state = listState, Orientation.Vertical)\` on the outer Box wrapping the LazyColumn to forward mouse-wheel events from the empty gutters (when Compact/Wide content widths are active).

On Android this caused touch scroll to feel jammed/weird: parent .scrollable and LazyColumn's own internal scrollable both pointed at the same \`listState\`, so touch gestures were double-handled.

Gate the outer scrollable to \`enabled = getPlatform() != ANDROID\` — mouse-wheel-in-gutter was always a desktop-only feature; Android touch already lands on the LazyColumn directly.

## Test plan
- [ ] Android: open Details on Poco F6 → scroll README/release-notes smoothly with finger
- [ ] Desktop: Compact width → mouse wheel in empty side gutters still scrolls content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling freeze on Android in the details view for smoother interactions.
  * Improved mouse-wheel forwarding on desktop to provide more reliable scrolling.

* **Documentation**
  * Clarified that the mouse-wheel forwarding behavior is desktop-only and noted prior Android gesture issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->