### PR TITLE
build(flatpak): add CI build job, update metainfo, fix JVM heap for runners

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -508,10 +508,14 @@ jobs:
 
   build-flatpak:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build Flatpak bundle
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -506,9 +506,34 @@ jobs:
           retention-days: 30
           compression-level: 0
 
+  build-flatpak:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: GitHub-Store-x86_64.flatpak
+          manifest-path: packaging/flatpak/zed.rainxch.githubstore.yml
+          run-tests: false
+          upload-artifact: false
+          cache-key: flatpak-builder-${{ github.sha }}
+
+      - name: Upload Flatpak bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-flatpak
+          path: GitHub-Store-x86_64.flatpak
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+
   release:
     name: Draft release with all installers
-    needs: [sign-windows, build-macos, build-linux]
+    needs: [sign-windows, build-macos, build-linux, build-flatpak]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -572,6 +597,7 @@ jobs:
           linux_debian12_count=0
           linux_appimage_count=0
           linux_arch_count=0
+          linux_flatpak_count=0
 
           # Windows — names already unique (.exe, .msi). Files come from the
           # signed artifact, not the raw build output, so they carry the
@@ -625,11 +651,17 @@ jobs:
             stage "$f" "$(basename "$f")" && linux_arch_count=$((linux_arch_count + 1)) || true
           done < <(find artifacts/linux-arch -type f -name '*.pkg.tar.zst' 2>/dev/null)
 
+          # Linux Flatpak bundle (.flatpak)
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            stage "$f" "$(basename "$f")" && linux_flatpak_count=$((linux_flatpak_count + 1)) || true
+          done < <(find artifacts/linux-flatpak -type f -name '*.flatpak' 2>/dev/null)
+
           echo
           echo "Final staged files:"
           ls -la release-files/
           echo
-          echo "Per-group counts: windows=$windows_count macos-x64=$macos_x64_count macos-arm64=$macos_arm64_count linux-modern=$linux_modern_count linux-debian12=$linux_debian12_count linux-appimage=$linux_appimage_count linux-arch=$linux_arch_count"
+          echo "Per-group counts: windows=$windows_count macos-x64=$macos_x64_count macos-arm64=$macos_arm64_count linux-modern=$linux_modern_count linux-debian12=$linux_debian12_count linux-appimage=$linux_appimage_count linux-arch=$linux_arch_count linux-flatpak=$linux_flatpak_count"
 
           # Completeness guard: refuse to ship an incomplete release. Each
           # group must produce >= 1 staged file. Without this guard, a build
@@ -644,6 +676,7 @@ jobs:
           [ "$linux_debian12_count" -eq 0 ] && missing+=("Linux debian12-compat (.deb/.rpm)")
           [ "$linux_appimage_count" -eq 0 ] && missing+=("Linux AppImage (.AppImage/.zsync)")
           [ "$linux_arch_count" -eq 0 ] && missing+=("Linux Arch (.pkg.tar.zst)")
+          [ "$linux_flatpak_count" -eq 0 ] && missing+=("Linux Flatpak (.flatpak)")
 
           if [ ${#missing[@]} -gt 0 ]; then
             echo

--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -520,7 +520,7 @@ jobs:
           manifest-path: packaging/flatpak/zed.rainxch.githubstore.yml
           run-tests: false
           upload-artifact: false
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ hashFiles('packaging/flatpak/flatpak-sources.json', 'packaging/flatpak/zed.rainxch.githubstore.yml') }}
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@v4

--- a/packaging/flatpak/zed.rainxch.githubstore.metainfo.xml
+++ b/packaging/flatpak/zed.rainxch.githubstore.metainfo.xml
@@ -62,6 +62,35 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="1.8.2" date="2026-05-13">
+      <description>
+        <p>Multi-OS release picker: download APKs from desktop and .debs from phone;
+           cross-platform downloads open in your browser. Adds "Hide seen repositories"
+           to declutter discovery feeds, content-width preference for desktop, and
+           AppImage distribution for Linux.</p>
+      </description>
+    </release>
+    <release version="1.8.1" date="2026-05-06">
+      <description>
+        <p>APK inspection: view signatures, permissions, and metadata before installing.
+           Background update-check toggle to save battery. Migration tooling for
+           switching between installer types.</p>
+      </description>
+    </release>
+    <release version="1.8.0" date="2026-04-30">
+      <description>
+        <p>Switched to a dedicated backend for improved reliability and faster response
+           times in throttled regions. Adds external import (paste a GitHub URL to add
+           a repository) and mirror picker for China users.</p>
+      </description>
+    </release>
+    <release version="1.7.0" date="2026-03-28">
+      <description>
+        <p>Tweaks overhaul: installer attribution, font and theme customisation, and
+           per-app update channels. Link Apps feature: associate any installed app with
+           its GitHub repository for one-tap updates.</p>
+      </description>
+    </release>
     <release version="1.6.2" date="2026-03-18">
       <description>
         <p>Security improvements: package name and signing key validation on updates,

--- a/packaging/flatpak/zed.rainxch.githubstore.yml
+++ b/packaging/flatpak/zed.rainxch.githubstore.yml
@@ -106,7 +106,7 @@ modules:
       - ./gradlew :composeApp:packageUberJarForCurrentOS
           --no-daemon
           --no-configuration-cache
-          -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=2g"
+          -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=1g"
           -Dorg.gradle.parallel=false
       # Install the JAR
       - install -Dm644 "$(find composeApp/build/compose/jars/ -name '*.jar' -type f | head -1)"


### PR DESCRIPTION
## Summary

Closes #208.

The Flatpak packaging infrastructure (`packaging/flatpak/`) is already on `main`. This PR wires it into CI and fixes two issues that blocked a working build:

- **CI job** (`build-flatpak`): runs `flatpak/flatpak-github-actions/flatpak-builder@v6` on every push to `generate-installers`, produces `GitHub-Store-x86_64.flatpak`, and uploads it as the `linux-flatpak` artifact. The bundle is staged and included in the draft release alongside `.deb`, `.rpm`, AppImage, and Arch packages.
- **JVM heap reduction**: the Flatpak manifest had `-Xmx6g -XX:MaxMetaspaceSize=2g`. GitHub Actions `ubuntu-latest` runners have 7 GB total RAM, leaving no headroom for the OS and `flatpak-builder` itself. Reduced to `-Xmx4g -XX:MaxMetaspaceSize=1g`, matching the project's standard `GRADLE_OPTS`.
- **Metainfo releases**: `zed.rainxch.githubstore.metainfo.xml` previously only listed release 1.6.2. Added entries for 1.7.0, 1.8.0, 1.8.1, and 1.8.2 with dates and brief descriptions so the Flathub listing will show an accurate history once the app is submitted.

## Test plan

- [ ] Push to `generate-installers` branch and verify the `build-flatpak` job passes
- [ ] Confirm `GitHub-Store-x86_64.flatpak` appears in the draft release assets
- [ ] Run `flatpak-builder-lint manifest packaging/flatpak/zed.rainxch.githubstore.yml` locally (no errors expected)
- [ ] Run `appstreamcli validate packaging/flatpak/zed.rainxch.githubstore.metainfo.xml` to verify new release entries are valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux Flatpak installer now available for streamlined installation on Flatpak-compatible systems.

* **Chores**
  * Updated application release history and AppStream metadata.
  * Adjusted build environment memory settings to improve packaging reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->