### PR TITLE
fix: mirror+direct race corrupts destination on download

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
@@ -38,21 +38,13 @@ class MultiSourceDownloaderImpl(
         suggestedFileName: String?,
     ): Flow<DownloadProgress> =
         channelFlow {
-            var mirrorEmitted = false
             try {
-                downloader.download(mirrorUrl, suggestedFileName).collect { progress ->
-                    mirrorEmitted = true
-                    send(progress)
-                }
+                downloader.download(mirrorUrl, suggestedFileName).collect { send(it) }
                 return@channelFlow
             } catch (e: CancellationException) {
                 throw e
             } catch (t: Throwable) {
-                if (mirrorEmitted) {
-                    Logger.w(t) { "Mirror download failed mid-stream, not retrying direct to avoid partial file." }
-                    throw t
-                }
-                Logger.w(t) { "Mirror download failed before progress, falling back to direct." }
+                Logger.w(t) { "Mirror download failed, falling back to direct." }
             }
             downloader
                 .download(directUrl, suggestedFileName, bypassMirror = true)

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
@@ -1,13 +1,12 @@
 package zed.rainxch.core.data.download
 
-import kotlinx.coroutines.CompletableDeferred
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
 import zed.rainxch.core.data.network.MirrorRewriter
 import zed.rainxch.core.data.network.ProxyManager
 import zed.rainxch.core.domain.model.DownloadProgress
@@ -30,52 +29,33 @@ class MultiSourceDownloaderImpl(
         val mirrorUrl =
             MirrorRewriter.applyTemplate(active.template, githubUrl)
                 ?: return downloader.download(githubUrl, suggestedFileName)
-        return raceDownloads(githubUrl, mirrorUrl, suggestedFileName)
+        return mirrorFirstWithFallback(mirrorUrl, githubUrl, suggestedFileName)
     }
 
-    private fun raceDownloads(
-        directUrl: String,
+    private fun mirrorFirstWithFallback(
         mirrorUrl: String,
+        directUrl: String,
         suggestedFileName: String?,
     ): Flow<DownloadProgress> =
         channelFlow {
-            val winnerSignal = CompletableDeferred<String>()
-
-            val directJob =
-                launch {
-                    try {
-                        downloader
-                            .download(directUrl, suggestedFileName, bypassMirror = true)
-                            .collect { progress ->
-                                if (winnerSignal.complete("direct") || winnerSignal.getCompleted() == "direct") {
-                                    send(progress)
-                                } else {
-                                    return@collect
-                                }
-                            }
-                    } catch (t: Throwable) {
-                        if (winnerSignal.isCompleted && winnerSignal.getCompleted() == "direct") throw t
-                    }
+            var mirrorEmitted = false
+            try {
+                downloader.download(mirrorUrl, suggestedFileName).collect { progress ->
+                    mirrorEmitted = true
+                    send(progress)
                 }
-
-            val mirrorJob =
-                launch {
-                    try {
-                        downloader
-                            .download(mirrorUrl, suggestedFileName)
-                            .collect { progress ->
-                                if (winnerSignal.complete("mirror") || winnerSignal.getCompleted() == "mirror") {
-                                    send(progress)
-                                } else {
-                                    return@collect
-                                }
-                            }
-                    } catch (t: Throwable) {
-                        if (winnerSignal.isCompleted && winnerSignal.getCompleted() == "mirror") throw t
-                    }
+                return@channelFlow
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                if (mirrorEmitted) {
+                    Logger.w(t) { "Mirror download failed mid-stream, not retrying direct to avoid partial file." }
+                    throw t
                 }
-
-            val winner = winnerSignal.await()
-            if (winner == "direct") mirrorJob.cancelAndJoin() else directJob.cancelAndJoin()
+                Logger.w(t) { "Mirror download failed before progress, falling back to direct." }
+            }
+            downloader
+                .download(directUrl, suggestedFileName, bypassMirror = true)
+                .collect { send(it) }
         }.flowOn(Dispatchers.IO)
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/MultiSourceDownloaderImpl.kt
@@ -46,8 +46,16 @@ class MultiSourceDownloaderImpl(
             } catch (t: Throwable) {
                 Logger.w(t) { "Mirror download failed, falling back to direct." }
             }
+            var firstDirectEmit = true
             downloader
                 .download(directUrl, suggestedFileName, bypassMirror = true)
-                .collect { send(it) }
+                .collect { progress ->
+                    if (firstDirectEmit) {
+                        firstDirectEmit = false
+                        send(progress.copy(restart = true))
+                    } else {
+                        send(progress)
+                    }
+                }
         }.flowOn(Dispatchers.IO)
 }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
@@ -37,12 +37,10 @@ class SlowDownloadDetectorImpl(
 
     override val suggestMirror: Flow<Unit> = _suggestMirror.asSharedFlow()
 
-    override fun reset() {
-        appScope.launch {
-            mutex.withLock {
-                samples.clear()
-                recentSlowEvents.clear()
-            }
+    override suspend fun reset() {
+        mutex.withLock {
+            samples.clear()
+            recentSlowEvents.clear()
         }
     }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
@@ -37,6 +37,15 @@ class SlowDownloadDetectorImpl(
 
     override val suggestMirror: Flow<Unit> = _suggestMirror.asSharedFlow()
 
+    override fun reset() {
+        appScope.launch {
+            mutex.withLock {
+                samples.clear()
+                recentSlowEvents.clear()
+            }
+        }
+    }
+
     override fun onProgress(progress: DownloadProgress) {
         appScope.launch {
             mutex.withLock {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/download/SlowDownloadDetectorImpl.kt
@@ -44,24 +44,22 @@ class SlowDownloadDetectorImpl(
         }
     }
 
-    override fun onProgress(progress: DownloadProgress) {
-        appScope.launch {
-            mutex.withLock {
-                val now = Clock.System.now().toEpochMilliseconds()
-                samples.addLast(now to progress.bytesDownloaded)
-                while (samples.isNotEmpty() && samples.first().first < now - sustainedMs) {
-                    samples.removeFirst()
-                }
-                if (samples.size >= 2) {
-                    val first = samples.first()
-                    val last = samples.last()
-                    val elapsedSec = (last.first - first.first).coerceAtLeast(1L) / 1000.0
-                    val deltaBytes = (last.second - first.second).coerceAtLeast(0L)
-                    val bytesPerSec = (deltaBytes / elapsedSec).toLong()
-                    val windowFull = (last.first - first.first) >= sustainedMs - 500
-                    if (windowFull && bytesPerSec < thresholdBytesPerSec) {
-                        recordSlowEvent(now)
-                    }
+    override suspend fun onProgress(progress: DownloadProgress) {
+        mutex.withLock {
+            val now = Clock.System.now().toEpochMilliseconds()
+            samples.addLast(now to progress.bytesDownloaded)
+            while (samples.isNotEmpty() && samples.first().first < now - sustainedMs) {
+                samples.removeFirst()
+            }
+            if (samples.size >= 2) {
+                val first = samples.first()
+                val last = samples.last()
+                val elapsedSec = (last.first - first.first).coerceAtLeast(1L) / 1000.0
+                val deltaBytes = (last.second - first.second).coerceAtLeast(0L)
+                val bytesPerSec = (deltaBytes / elapsedSec).toLong()
+                val windowFull = (last.first - first.first) >= sustainedMs - 500
+                if (windowFull && bytesPerSec < thresholdBytesPerSec) {
+                    recordSlowEvent(now)
                 }
             }
         }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
@@ -149,6 +149,9 @@ class DefaultDownloadOrchestrator(
         }
 
         multiSourceDownloader.download(spec.asset.downloadUrl, scopedName).collect { progress ->
+            if (progress.restart) {
+                slowDownloadDetector.reset()
+            }
             slowDownloadDetector.onProgress(progress)
             updateEntry(spec.packageName) {
                 it.copy(

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/DownloadProgress.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/DownloadProgress.kt
@@ -4,4 +4,5 @@ data class DownloadProgress(
     val bytesDownloaded: Long,
     val totalBytes: Long?,
     val percent: Int?,
+    val restart: Boolean = false,
 )

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
@@ -7,4 +7,6 @@ interface SlowDownloadDetector {
     val suggestMirror: Flow<Unit>
 
     fun onProgress(progress: DownloadProgress)
+
+    fun reset()
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
@@ -8,5 +8,5 @@ interface SlowDownloadDetector {
 
     fun onProgress(progress: DownloadProgress)
 
-    fun reset()
+    suspend fun reset()
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/network/SlowDownloadDetector.kt
@@ -6,7 +6,7 @@ import zed.rainxch.core.domain.model.DownloadProgress
 interface SlowDownloadDetector {
     val suggestMirror: Flow<Unit>
 
-    fun onProgress(progress: DownloadProgress)
+    suspend fun onProgress(progress: DownloadProgress)
 
     suspend fun reset()
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -17,7 +17,8 @@
       "type": "FIXED",
       "bullets": [
         "Discovery cards now show every platform a repo ships installers for, not just the one whose endpoint listed it.",
-        "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column."
+        "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column.",
+        "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Fixes #667 — checksum mismatch most updates.
- `MultiSourceDownloaderImpl.raceDownloads` raced both flows writing to the same `suggestedFileName` destination. Loser's `moveAtomic` could land after winner's → destination = partial loser bytes → SHA-256 mismatch.
- Replaced race with sequential mirror-first / direct-fallback.

## Test plan
- [ ] Update an app via GHS with no mirror active → succeeds, no mismatch.
- [ ] Enable a mirror (Tweaks → Sources → Mirror) and update an app → succeeds, no mismatch.
- [ ] Force mirror failure (point to invalid template) → falls back to direct, succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checksum mismatches caused by concurrent mirror and direct downloads writing the same file.
  * Mirror downloads are now attempted first; if a mirror fails, downloads automatically fall back to the direct source.

* **Improvements**
  * Progress reporting now indicates restart events.
  * Slow-download detection is cleared on restarts for more accurate tracking and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->