### PR TITLE
fix: dark title bar on Windows 11

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,7 +99,7 @@ kotlin {
                 implementation(libs.koin.compose.viewmodel)
 
                 implementation(libs.slf4j.simple)
-                implementation("net.java.dev.jna:jna-platform:5.14.0")
+                implementation(libs.jna.platform)
             }
         }
     }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,6 +99,7 @@ kotlin {
                 implementation(libs.koin.compose.viewmodel)
 
                 implementation(libs.slf4j.simple)
+                implementation("net.java.dev.jna:jna-platform:5.14.0")
             }
         }
     }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -33,7 +33,9 @@ import zed.rainxch.githubstore.core.presentation.res.menubar_help_feedback
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_licenses
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_menu
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_privacy
+import zed.rainxch.githubstore.desktop.applyMacosWindowAppearance
 import zed.rainxch.githubstore.desktop.applyWindowsImmersiveDarkMode
+import zed.rainxch.githubstore.desktop.installMacosSystemAppearance
 import java.awt.Desktop
 import java.net.URI
 import kotlin.system.exitProcess
@@ -43,6 +45,7 @@ private const val PRIVACY_POLICY_URL = "https://github-store.org/privacy"
 private const val LANGUAGE_PREF_READ_TIMEOUT_MS = 2000L
 
 fun main(args: Array<String>) {
+    installMacosSystemAppearance()
     CrashReporter.install()
 
     A11yCrashGuard.install()
@@ -123,6 +126,7 @@ fun main(args: Array<String>) {
             val isOsDark = isSystemInDarkTheme()
             LaunchedEffect(window, isOsDark) {
                 applyWindowsImmersiveDarkMode(window, isOsDark)
+                applyMacosWindowAppearance(window, isOsDark)
             }
             MenuBar {
                 Menu(text = stringResource(Res.string.menubar_help_menu)) {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.githubstore
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,6 +33,7 @@ import zed.rainxch.githubstore.core.presentation.res.menubar_help_feedback
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_licenses
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_menu
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_privacy
+import zed.rainxch.githubstore.desktop.applyWindowsImmersiveDarkMode
 import java.awt.Desktop
 import java.net.URI
 import kotlin.system.exitProcess
@@ -118,6 +120,10 @@ fun main(args: Array<String>) {
                 }
             },
         ) {
+            val isOsDark = isSystemInDarkTheme()
+            LaunchedEffect(window, isOsDark) {
+                applyWindowsImmersiveDarkMode(window, isOsDark)
+            }
             MenuBar {
                 Menu(text = stringResource(Res.string.menubar_help_menu)) {
                     Item(

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
@@ -25,13 +25,32 @@ private const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20
 private const val DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1 = 19
 private const val S_OK = 0
 
+private val osName: String
+    get() = System.getProperty("os.name").orEmpty().lowercase()
+
 private val isWindows: Boolean
-    get() =
-        System
-            .getProperty("os.name")
-            .orEmpty()
-            .lowercase()
-            .startsWith("windows")
+    get() = osName.startsWith("windows")
+
+private val isMac: Boolean
+    get() = osName.contains("mac")
+
+fun installMacosSystemAppearance() {
+    if (!isMac) return
+    if (System.getProperty("apple.awt.application.appearance") == null) {
+        System.setProperty("apple.awt.application.appearance", "system")
+    }
+}
+
+fun applyMacosWindowAppearance(
+    window: Window,
+    isDark: Boolean,
+) {
+    if (!isMac) return
+    val frame = window as? javax.swing.JFrame ?: return
+    val key = "apple.awt.windowAppearance"
+    val value = if (isDark) "NSAppearanceNameDarkAqua" else "NSAppearanceNameAqua"
+    runCatching { frame.rootPane.putClientProperty(key, value) }
+}
 
 fun applyWindowsImmersiveDarkMode(
     window: Window,

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
@@ -23,6 +23,7 @@ private interface DwmApi : StdCallLibrary {
 
 private const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20
 private const val DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1 = 19
+private const val S_OK = 0
 
 private val isWindows: Boolean
     get() =
@@ -43,10 +44,13 @@ fun applyWindowsImmersiveDarkMode(
             WinDef.HWND(com.sun.jna.Pointer(Native.getWindowID(window)))
         }.getOrNull() ?: return
     val flag = WinDef.BOOLByReference(WinDef.BOOL(isDark))
-    runCatching { dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, flag, 4) }
-        .onFailure {
-            runCatching {
-                dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1, flag, 4)
-            }
+    val hr =
+        runCatching {
+            dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, flag, 4)
+        }.getOrElse { -1 }
+    if (hr != S_OK) {
+        runCatching {
+            dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1, flag, 4)
         }
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
@@ -1,0 +1,52 @@
+package zed.rainxch.githubstore.desktop
+
+import com.sun.jna.Native
+import com.sun.jna.platform.win32.WinDef
+import com.sun.jna.win32.StdCallLibrary
+import java.awt.Window
+
+private interface DwmApi : StdCallLibrary {
+    fun DwmSetWindowAttribute(
+        hwnd: WinDef.HWND,
+        attribute: Int,
+        value: WinDef.BOOLByReference,
+        size: Int,
+    ): Int
+
+    companion object {
+        val INSTANCE: DwmApi? =
+            runCatching {
+                Native.load("dwmapi", DwmApi::class.java)
+            }.getOrNull()
+    }
+}
+
+private const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+private const val DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1 = 19
+
+private val isWindows: Boolean
+    get() =
+        System
+            .getProperty("os.name")
+            .orEmpty()
+            .lowercase()
+            .startsWith("windows")
+
+fun applyWindowsImmersiveDarkMode(
+    window: Window,
+    isDark: Boolean,
+) {
+    if (!isWindows) return
+    val dwm = DwmApi.INSTANCE ?: return
+    val hwnd =
+        runCatching {
+            WinDef.HWND(com.sun.jna.Pointer(Native.getWindowID(window)))
+        }.getOrNull() ?: return
+    val flag = WinDef.BOOLByReference(WinDef.BOOL(isDark))
+    runCatching { dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, flag, 4) }
+        .onFailure {
+            runCatching {
+                dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1, flag, 4)
+            }
+        }
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -18,7 +18,8 @@
       "bullets": [
         "Discovery cards now show every platform a repo ships installers for, not just the one whose endpoint listed it.",
         "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column.",
-        "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file."
+        "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file.",
+        "Windows 11 title bar now matches system dark mode instead of staying glaringly white."
       ]
     }
   ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ koin = "4.1.1"
 ktor = "3.4.0"
 room = "2.8.4"
 slf4jSimple = "2.0.17"
+jna = "5.14.0"
 sqlite = "2.6.2"
 datastore = "1.2.0"
 ksafe = "2.0.0"
@@ -111,6 +112,7 @@ ksafe = { module = "eu.anifantakis:ksafe", version.ref = "ksafe" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" }
+jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 
 # Image loading


### PR DESCRIPTION
## Summary
- Fixes #663 — Windows 11 system dark mode kept the white title bar.
- Calls `DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, …)` via JNA when the OS is dark; falls back to attribute `19` on pre-20H1 builds.
- Re-applies on dark-mode change.

## Test plan
- [ ] Win11 system dark → launch app → title bar dark.
- [ ] Toggle Windows light/dark while running → title bar follows.
- [ ] macOS / Linux unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app now detects OS theme and applies a matching dark/light appearance to window chrome on Windows and macOS.
  * macOS system/window appearance is initialized at startup for a native look.

* **Bug Fixes**
  * Fixed Windows 11 title bar remaining bright in dark theme—window chrome now respects system dark mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->