### PR TITLE
feat: remember desktop window size and position across launches

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -105,7 +107,11 @@ fun main(args: Array<String>) {
                 Triple(windowState.placement, windowState.position, windowState.size)
             }.distinctUntilChanged()
                 .debounce(500)
-                .collect { WindowStateStore.save(windowState) }
+                .collect {
+                    withContext(Dispatchers.IO) {
+                        WindowStateStore.save(windowState)
+                    }
+                }
         }
 
         LaunchedEffect(Unit) {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -1,6 +1,7 @@
 package zed.rainxch.githubstore
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -89,6 +90,14 @@ fun main(args: Array<String>) {
     application {
         var deepLinkUri by mutableStateOf(deepLinkArg)
         val windowState = remember { WindowStateStore.load() }
+
+        DisposableEffect(windowState) {
+            val hook = Thread { WindowStateStore.save(windowState) }
+            runCatching { Runtime.getRuntime().addShutdownHook(hook) }
+            onDispose {
+                runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+            }
+        }
 
         @OptIn(FlowPreview::class)
         LaunchedEffect(windowState) {

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
@@ -14,6 +16,9 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
@@ -33,6 +38,7 @@ import zed.rainxch.githubstore.core.presentation.res.menubar_help_feedback
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_licenses
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_menu
 import zed.rainxch.githubstore.core.presentation.res.menubar_help_privacy
+import zed.rainxch.githubstore.desktop.WindowStateStore
 import zed.rainxch.githubstore.desktop.applyMacosWindowAppearance
 import zed.rainxch.githubstore.desktop.applyWindowsImmersiveDarkMode
 import zed.rainxch.githubstore.desktop.installMacosSystemAppearance
@@ -82,6 +88,16 @@ fun main(args: Array<String>) {
 
     application {
         var deepLinkUri by mutableStateOf(deepLinkArg)
+        val windowState = remember { WindowStateStore.load() }
+
+        @OptIn(FlowPreview::class)
+        LaunchedEffect(windowState) {
+            snapshotFlow {
+                Triple(windowState.placement, windowState.position, windowState.size)
+            }.distinctUntilChanged()
+                .debounce(500)
+                .collect { WindowStateStore.save(windowState) }
+        }
 
         LaunchedEffect(Unit) {
             DesktopDeepLink.startInstanceListener { uri ->
@@ -107,7 +123,11 @@ fun main(args: Array<String>) {
         }
 
         Window(
-            onCloseRequest = ::exitApplication,
+            onCloseRequest = {
+                WindowStateStore.save(windowState)
+                exitApplication()
+            },
+            state = windowState,
             title = stringResource(Res.string.app_name),
             icon = painterResource(Res.drawable.app_icon),
             onKeyEvent = { keyEvent ->

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
@@ -3,6 +3,7 @@ package zed.rainxch.githubstore.desktop
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -95,6 +96,10 @@ object WindowStateStore {
     }
 
     fun save(state: WindowState) {
+        if (!state.size.isSpecified) return
+        val width = state.size.width.value
+        val height = state.size.height.value
+        if (width.isNaN() || height.isNaN()) return
         runCatching {
             val pos = state.position
             val (x, y) =
@@ -107,8 +112,8 @@ object WindowStateStore {
                 PersistedWindowState(
                     x = x,
                     y = y,
-                    width = state.size.width.value,
-                    height = state.size.height.value,
+                    width = width,
+                    height = height,
                     placement = state.placement.name,
                 )
             val parent = configFile.parentFile

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
+import java.awt.Toolkit
 import java.io.File
 
 @Serializable
@@ -135,10 +136,25 @@ object WindowStateStore {
             runCatching {
                 GraphicsEnvironment.getLocalGraphicsEnvironment()
             }.getOrNull() ?: return false
+        val toolkit = runCatching { Toolkit.getDefaultToolkit() }.getOrNull()
         return ge.screenDevices.any { device ->
             device.configurations.any { cfg ->
-                cfg.bounds.intersects(rect) &&
-                    cfg.bounds.contains(
+                val usable =
+                    runCatching {
+                        val insets = toolkit?.getScreenInsets(cfg)
+                        if (insets != null) {
+                            Rectangle(
+                                cfg.bounds.x + insets.left,
+                                cfg.bounds.y + insets.top,
+                                cfg.bounds.width - insets.left - insets.right,
+                                cfg.bounds.height - insets.top - insets.bottom,
+                            )
+                        } else {
+                            cfg.bounds
+                        }
+                    }.getOrDefault(cfg.bounds)
+                usable.intersects(rect) &&
+                    usable.contains(
                         rect.x + VISIBLE_TITLEBAR_X_INSET,
                         rect.y + VISIBLE_TITLEBAR_Y_INSET,
                     )

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowStateStore.kt
@@ -1,0 +1,148 @@
+package zed.rainxch.githubstore.desktop
+
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.io.File
+
+@Serializable
+private data class PersistedWindowState(
+    val x: Float? = null,
+    val y: Float? = null,
+    val width: Float,
+    val height: Float,
+    val placement: String,
+)
+
+object WindowStateStore {
+    private const val FILE_NAME = "window-state.json"
+    private const val MIN_WIDTH = 480f
+    private const val MIN_HEIGHT = 600f
+    private const val DEFAULT_WIDTH = 1280f
+    private const val DEFAULT_HEIGHT = 840f
+    private const val VISIBLE_TITLEBAR_X_INSET = 40
+    private const val VISIBLE_TITLEBAR_Y_INSET = 20
+
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+
+    private val configFile: File by lazy {
+        val home = File(System.getProperty("user.home"))
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val dir =
+            when {
+                "mac" in osName -> {
+                    File(home, "Library/Application Support/GitHub-Store")
+                }
+
+                "win" in osName -> {
+                    val appData = System.getenv("APPDATA")?.let(::File) ?: File(home, "AppData/Roaming")
+                    File(appData, "GitHub-Store")
+                }
+
+                else -> {
+                    val xdg =
+                        System
+                            .getenv("XDG_CONFIG_HOME")
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let(::File)
+                            ?: File(home, ".config")
+                    File(xdg, "GitHub-Store")
+                }
+            }
+        File(dir, FILE_NAME)
+    }
+
+    fun load(): WindowState {
+        val saved =
+            runCatching {
+                configFile
+                    .takeIf { it.isFile }
+                    ?.readText()
+                    ?.let { json.decodeFromString<PersistedWindowState>(it) }
+            }.getOrNull()
+        val width = (saved?.width ?: DEFAULT_WIDTH).coerceAtLeast(MIN_WIDTH)
+        val height = (saved?.height ?: DEFAULT_HEIGHT).coerceAtLeast(MIN_HEIGHT)
+        val placement = parsePlacement(saved?.placement)
+        val savedX = saved?.x
+        val savedY = saved?.y
+        val position =
+            if (
+                savedX != null &&
+                savedY != null &&
+                isTitleBarVisible(savedX, savedY, width, height)
+            ) {
+                WindowPosition(savedX.dp, savedY.dp)
+            } else {
+                WindowPosition.Aligned(Alignment.Center)
+            }
+        return WindowState(
+            placement = placement,
+            position = position,
+            size = DpSize(width.dp, height.dp),
+        )
+    }
+
+    fun save(state: WindowState) {
+        runCatching {
+            val pos = state.position
+            val (x, y) =
+                if (pos is WindowPosition.Absolute) {
+                    pos.x.value to pos.y.value
+                } else {
+                    null to null
+                }
+            val persisted =
+                PersistedWindowState(
+                    x = x,
+                    y = y,
+                    width = state.size.width.value,
+                    height = state.size.height.value,
+                    placement = state.placement.name,
+                )
+            val parent = configFile.parentFile
+            if (parent != null && !parent.isDirectory) parent.mkdirs()
+            configFile.writeText(json.encodeToString(persisted))
+        }
+    }
+
+    private fun parsePlacement(name: String?): WindowPlacement =
+        when (name) {
+            WindowPlacement.Maximized.name -> WindowPlacement.Maximized
+            WindowPlacement.Fullscreen.name -> WindowPlacement.Fullscreen
+            else -> WindowPlacement.Floating
+        }
+
+    private fun isTitleBarVisible(
+        x: Float,
+        y: Float,
+        width: Float,
+        height: Float,
+    ): Boolean {
+        if (width <= 0f || height <= 0f) return false
+        val rect = Rectangle(x.toInt(), y.toInt(), width.toInt(), height.toInt())
+        val ge =
+            runCatching {
+                GraphicsEnvironment.getLocalGraphicsEnvironment()
+            }.getOrNull() ?: return false
+        return ge.screenDevices.any { device ->
+            device.configurations.any { cfg ->
+                cfg.bounds.intersects(rect) &&
+                    cfg.bounds.contains(
+                        rect.x + VISIBLE_TITLEBAR_X_INSET,
+                        rect.y + VISIBLE_TITLEBAR_Y_INSET,
+                    )
+            }
+        }
+    }
+}

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -10,7 +10,8 @@
         "Design overhaul — new Geist typography, hero app header on Details, redesigned Home cards with platform glyphs, Apple-style menus, and a refreshed Library with an updates banner and a 'Ready to install' section.",
         "Tablet two-pane layout — Home, Search, and Library keep the list on the left and open the repo on the right; drag the divider to resize.",
         "Inner Details pages — About and What's New now slide in as dedicated screens with their own back action, and stay inside the right pane on tablet.",
-        "Real Apple and Tux icons for the macOS and Linux platform indicators across cards and lists."
+        "Real Apple and Tux icons for the macOS and Linux platform indicators across cards and lists.",
+        "Desktop remembers your last window size, position, and maximized state across launches; new windows open centered instead of in the top-left corner."
       ]
     },
     {


### PR DESCRIPTION
Closes #664.

Desktop windows now restore their last size, position, and maximized/fullscreen state instead of always opening as a square in the top-left. First launch (and any time saved coordinates fall off-screen) opens centered at 1280x840.

State is persisted to `window-state.json` under the platform config dir (`~/Library/Application Support/GitHub-Store/`, `%APPDATA%/GitHub-Store/`, `$XDG_CONFIG_HOME/GitHub-Store/`). Writes are debounced 500ms while dragging/resizing and also flushed on close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop windows now remember and restore their size, position, and maximized state across sessions.
  * New windows open centered on the screen instead of the top-left corner.
  * Native platform icons added for macOS and Linux indicators.
  * Window state is persisted reliably across restarts and shutdowns so layout is retained.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->