### PR TITLE
fix: silent install via root now triggers Magisk prompt

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -39,6 +39,8 @@ kotlin {
 
                 implementation(libs.dhizuku.api)
 
+                implementation(libs.libsu.core)
+
                 implementation(libs.ktor.client.okhttp)
 
                 implementation(libs.androidx.work.runtime)

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -66,15 +66,15 @@ class RootServiceManager(
         val srcPath = shellQuote(apkFile.absolutePath)
         val tmpPathQuoted = shellQuote(tmpPath)
 
-        val copyRes = Shell.cmd("cp $srcPath $tmpPathQuoted && chmod 644 $tmpPathQuoted").exec()
-        if (!copyRes.isSuccess) {
-            Logger.e(TAG) {
-                "installPackage() — staging copy failed: exit=${copyRes.code} out='${copyRes.out.joinToString("\n")}' err='${copyRes.err.joinToString("\n")}'"
-            }
-            return@withContext STATUS_FAILURE
-        }
-
         try {
+            val copyRes = Shell.cmd("cp $srcPath $tmpPathQuoted && chmod 644 $tmpPathQuoted").exec()
+            if (!copyRes.isSuccess) {
+                Logger.e(TAG) {
+                    "installPackage() — staging copy failed: exit=${copyRes.code} out='${copyRes.out.joinToString("\n")}' err='${copyRes.err.joinToString("\n")}'"
+                }
+                return@withContext STATUS_FAILURE
+            }
+
             val command = buildString {
                 append("pm install ")
                 if (safeInstaller != null) append("-i ").append(safeInstaller).append(' ')
@@ -141,7 +141,6 @@ class RootServiceManager(
             try {
                 Shell.setDefaultBuilder(
                     Shell.Builder.create()
-                        .setFlags(Shell.FLAG_MOUNT_MASTER)
                         .setTimeout(SHELL_TIMEOUT_SECONDS),
                 )
             } catch (e: IllegalStateException) {

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -1,7 +1,7 @@
 package zed.rainxch.core.data.services.root
 
-import android.os.ParcelFileDescriptor
 import co.touchlab.kermit.Logger
+import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,10 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import zed.rainxch.core.data.services.root.model.RootStatus
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
-import java.util.concurrent.TimeUnit
 
 class RootServiceManager(
     private val scope: CoroutineScope,
@@ -22,36 +19,27 @@ class RootServiceManager(
     val status: StateFlow<RootStatus> = _status.asStateFlow()
 
     @Volatile
-    private var cachedSuPath: String? = null
+    private var configured = false
 
     fun initialize() {
-
-        scope.launch(Dispatchers.IO) {
-            refreshStatusBlocking()
-        }
+        configureDefaultShell()
+        scope.launch(Dispatchers.IO) { refreshStatusBlocking() }
     }
 
     fun refreshStatus() {
+        configureDefaultShell()
         scope.launch(Dispatchers.IO) { refreshStatusBlocking() }
     }
 
     fun requestPermission() {
+        configureDefaultShell()
         scope.launch(Dispatchers.IO) {
-            val su = cachedSuPath ?: locateSuBinary()?.path ?: run {
-                Logger.d(TAG) { "requestPermission() — no su binary on device, skipping" }
-                refreshStatusBlocking()
-                return@launch
-            }
+            Logger.d(TAG) { "requestPermission() — forcing main shell creation" }
             try {
-                Logger.d(TAG) { "requestPermission() — invoking '$su -c true' to surface root prompt" }
-                val proc = Runtime.getRuntime().exec(arrayOf(su, "-c", "true"))
-                proc.waitFor(PROMPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                if (proc.isAlive) {
-                    Logger.w(TAG) { "requestPermission() — prompt invocation still running after ${PROMPT_TIMEOUT_SECONDS}s, destroying" }
-                    proc.destroyForcibly()
-                }
+                val shell = Shell.getShell()
+                Logger.d(TAG) { "requestPermission() — shell rootStatus=${shell.status}" }
             } catch (e: Exception) {
-                Logger.w(TAG) { "requestPermission() failed: ${e.javaClass.simpleName}: ${e.message}" }
+                Logger.w(TAG) { "requestPermission() — getShell failed: ${e.javaClass.simpleName}: ${e.message}" }
             }
             refreshStatusBlocking()
         }
@@ -60,143 +48,72 @@ class RootServiceManager(
     suspend fun installPackage(
         apkFile: File,
         installerPackageName: String?,
-    ): Int? =
-        withContext(Dispatchers.IO) {
-            val su = cachedSuPath ?: locateSuBinary()?.path ?: run {
-                Logger.w(TAG) { "installPackage() — no su binary available" }
-                return@withContext null
+    ): Int? = withContext(Dispatchers.IO) {
+        configureDefaultShell()
+        if (!isRootGranted()) {
+            Logger.w(TAG) { "installPackage() — root not granted, aborting" }
+            return@withContext null
+        }
+        val safeInstaller = installerPackageName?.takeIf { it.isNotBlank() }
+        if (safeInstaller != null && !PACKAGE_NAME_PATTERN.matches(safeInstaller)) {
+            Logger.w(TAG) {
+                "installPackage() — rejecting non-conformant installerPackageName='$safeInstaller'"
             }
+            return@withContext STATUS_FAILURE
+        }
 
-            val safeInstaller = installerPackageName?.takeIf { it.isNotBlank() }
-            if (safeInstaller != null && !PACKAGE_NAME_PATTERN.matches(safeInstaller)) {
-                Logger.w(TAG) {
-                    "installPackage() — rejecting non-conformant installerPackageName='$safeInstaller'"
-                }
-                return@withContext STATUS_FAILURE
+        val tmpPath = "/data/local/tmp/ghs_${System.currentTimeMillis()}_${(0..Int.MAX_VALUE).random()}.apk"
+        val srcPath = shellQuote(apkFile.absolutePath)
+        val tmpPathQuoted = shellQuote(tmpPath)
+
+        val copyRes = Shell.cmd("cp $srcPath $tmpPathQuoted && chmod 644 $tmpPathQuoted").exec()
+        if (!copyRes.isSuccess) {
+            Logger.e(TAG) {
+                "installPackage() — staging copy failed: exit=${copyRes.code} out='${copyRes.out.joinToString("\n")}' err='${copyRes.err.joinToString("\n")}'"
             }
-            val pm = "/system/bin/pm"
+            return@withContext STATUS_FAILURE
+        }
 
+        try {
             val command = buildString {
-                append(pm).append(" install ")
+                append("pm install ")
                 if (safeInstaller != null) append("-i ").append(safeInstaller).append(' ')
-                append("-S ").append(apkFile.length()).append(' ')
-                append('-')
+                append("-r ")
+                append(tmpPathQuoted)
             }
-            Logger.d(TAG) { "installPackage() — executing via $su: $command" }
-            val proc = try {
-                Runtime.getRuntime().exec(arrayOf(su, "-c", command))
-            } catch (e: Exception) {
-                Logger.e(TAG) { "installPackage() — su exec failed: ${e.message}" }
-                return@withContext null
-            }
-
-            val stdoutBuf = StringBuilder()
-            val stderrBuf = StringBuilder()
-            val stdoutThread = Thread {
-                try {
-                    BufferedReader(InputStreamReader(proc.inputStream)).use { reader ->
-                        reader.forEachLine { stdoutBuf.append(it).append('\n') }
-                    }
-                } catch (_: Exception) {
-                }
-            }
-            val stderrThread = Thread {
-                try {
-                    BufferedReader(InputStreamReader(proc.errorStream)).use { reader ->
-                        reader.forEachLine { stderrBuf.append(it).append('\n') }
-                    }
-                } catch (_: Exception) {
-                }
-            }
-            stdoutThread.start()
-            stderrThread.start()
-
-            val pipeError = StringBuilder()
-            val pipeThread = Thread {
-                try {
-                    apkFile.inputStream().use { input ->
-                        proc.outputStream.use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                } catch (e: Exception) {
-                    pipeError.append(e.javaClass.simpleName).append(": ").append(e.message)
-                    Logger.e(TAG) { "installPackage() — stdin pipe failed: $pipeError" }
-                }
-            }
-            pipeThread.start()
-            pipeThread.join(INSTALL_TIMEOUT_SECONDS * 1000L)
-            if (pipeThread.isAlive) {
-                Logger.e(TAG) { "installPackage() — pipe thread still alive after ${INSTALL_TIMEOUT_SECONDS}s, destroying process" }
-                pipeThread.interrupt()
-                proc.destroyForcibly()
-                stdoutThread.join(READER_DRAIN_TIMEOUT_MS)
-                stderrThread.join(READER_DRAIN_TIMEOUT_MS)
-                return@withContext STATUS_FAILURE
-            }
-
-            val finished = proc.waitFor(INSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                Logger.e(TAG) { "installPackage() — pm process timed out, destroying" }
-                proc.destroyForcibly()
-                stdoutThread.join(READER_DRAIN_TIMEOUT_MS)
-                stderrThread.join(READER_DRAIN_TIMEOUT_MS)
-                return@withContext STATUS_FAILURE
-            }
-
-            stdoutThread.join(READER_DRAIN_TIMEOUT_MS)
-            stderrThread.join(READER_DRAIN_TIMEOUT_MS)
-
-            val stdout = stdoutBuf.toString().trim()
-            val stderr = stderrBuf.toString().trim()
-            val exit = proc.exitValue()
-            Logger.d(TAG) { "installPackage() — exit=$exit stdout='$stdout' stderr='$stderr'" }
-            if (exit == 0 && stdout.contains("Success")) {
+            Logger.d(TAG) { "installPackage() — executing: $command" }
+            val result = Shell.cmd(command).exec()
+            val stdout = result.out.joinToString("\n").trim()
+            val stderr = result.err.joinToString("\n").trim()
+            Logger.d(TAG) { "installPackage() — exit=${result.code} stdout='$stdout' stderr='$stderr'" }
+            if (result.isSuccess && stdout.contains("Success")) {
                 STATUS_SUCCESS
             } else {
                 Logger.w(TAG) { "installPackage() — pm reported failure: stdout='$stdout' stderr='$stderr'" }
                 STATUS_FAILURE
             }
+        } finally {
+            Shell.cmd("rm -f $tmpPathQuoted").submit()
         }
+    }
 
-    suspend fun uninstallPackage(packageName: String): Int? =
-        withContext(Dispatchers.IO) {
-            val su = cachedSuPath ?: locateSuBinary()?.path ?: return@withContext null
-            if (!PACKAGE_NAME_PATTERN.matches(packageName)) {
-                Logger.w(TAG) {
-                    "uninstallPackage() — rejecting non-conformant packageName='$packageName'"
-                }
-                return@withContext STATUS_FAILURE
-            }
-            val command = "/system/bin/pm uninstall $packageName"
-            try {
-                val proc = Runtime.getRuntime().exec(arrayOf(su, "-c", command))
-                val stdoutBuf = StringBuilder()
-                val stdoutThread = Thread {
-                    try {
-                        BufferedReader(InputStreamReader(proc.inputStream)).use { reader ->
-                            reader.forEachLine { stdoutBuf.append(it).append('\n') }
-                        }
-                    } catch (_: Exception) {
-                    }
-                }
-                stdoutThread.start()
-                val finished = proc.waitFor(UNINSTALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                if (!finished) {
-                    proc.destroyForcibly()
-                    stdoutThread.join(READER_DRAIN_TIMEOUT_MS)
-                    return@withContext STATUS_FAILURE
-                }
-                stdoutThread.join(READER_DRAIN_TIMEOUT_MS)
-                val stdout = stdoutBuf.toString().trim()
-                val exit = proc.exitValue()
-                Logger.d(TAG) { "uninstallPackage($packageName) — exit=$exit stdout='$stdout'" }
-                if (exit == 0 && stdout.contains("Success")) STATUS_SUCCESS else STATUS_FAILURE
-            } catch (e: Exception) {
-                Logger.e(TAG) { "uninstallPackage($packageName) — su exec failed: ${e.message}" }
-                STATUS_FAILURE
-            }
+    suspend fun uninstallPackage(packageName: String): Int? = withContext(Dispatchers.IO) {
+        configureDefaultShell()
+        if (!isRootGranted()) {
+            Logger.w(TAG) { "uninstallPackage() — root not granted, aborting" }
+            return@withContext null
         }
+        if (!PACKAGE_NAME_PATTERN.matches(packageName)) {
+            Logger.w(TAG) {
+                "uninstallPackage() — rejecting non-conformant packageName='$packageName'"
+            }
+            return@withContext STATUS_FAILURE
+        }
+        val result = Shell.cmd("pm uninstall $packageName").exec()
+        val stdout = result.out.joinToString("\n").trim()
+        Logger.d(TAG) { "uninstallPackage($packageName) — exit=${result.code} stdout='$stdout'" }
+        if (result.isSuccess && stdout.contains("Success")) STATUS_SUCCESS else STATUS_FAILURE
+    }
 
     private fun refreshStatusBlocking() {
         val computed = computeStatus()
@@ -207,93 +124,42 @@ class RootServiceManager(
     }
 
     private fun computeStatus(): RootStatus {
-        val probe = locateSuBinary()
-        if (probe == null) {
-            cachedSuPath = null
-            return RootStatus.NOT_AVAILABLE
-        }
-        cachedSuPath = probe.path
-        return when (probe.kind) {
-            ProbeResultKind.UID_ZERO -> RootStatus.READY
-            ProbeResultKind.NOT_ZERO -> RootStatus.PERMISSION_NEEDED
+        val granted = Shell.isAppGrantedRoot()
+        return when (granted) {
+            true -> RootStatus.READY
+            false -> RootStatus.PERMISSION_NEEDED
+            null -> RootStatus.NOT_AVAILABLE
         }
     }
 
-    private fun locateSuBinary(): SuProbe? {
+    private fun isRootGranted(): Boolean = Shell.isAppGrantedRoot() == true
 
-        var firstNotZero: SuProbe? = null
-        for (path in SU_PATHS) {
-            val result = probeSu(path) ?: continue
-            if (result == ProbeResultKind.UID_ZERO) {
-                return SuProbe(path = path, kind = result)
+    private fun configureDefaultShell() {
+        if (configured) return
+        synchronized(this) {
+            if (configured) return
+            try {
+                Shell.setDefaultBuilder(
+                    Shell.Builder.create()
+                        .setFlags(Shell.FLAG_MOUNT_MASTER)
+                        .setTimeout(SHELL_TIMEOUT_SECONDS),
+                )
+            } catch (e: IllegalStateException) {
+                Logger.d(TAG) { "configureDefaultShell() — main shell already constructed, skipping setDefaultBuilder" }
             }
-            if (firstNotZero == null) {
-                firstNotZero = SuProbe(path = path, kind = result)
-            }
+            configured = true
         }
-        return firstNotZero
     }
 
-    private fun probeSu(path: String): ProbeResultKind? =
-        try {
-            val proc = Runtime.getRuntime().exec(arrayOf(path, "-c", "id"))
-            val finished = proc.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            if (!finished) {
-                Logger.d(TAG) { "probeSu($path) timed out, treating as PERMISSION_NEEDED" }
-                proc.destroyForcibly()
-                ProbeResultKind.NOT_ZERO
-            } else {
-                val output =
-                    BufferedReader(InputStreamReader(proc.inputStream)).use {
-                        it.readText().trim()
-                    }
-                if (proc.exitValue() == 0 && output.contains("uid=0")) {
-                    ProbeResultKind.UID_ZERO
-                } else {
-                    ProbeResultKind.NOT_ZERO
-                }
-            }
-        } catch (_: java.io.IOException) {
-
-            null
-        } catch (e: Exception) {
-            Logger.w(TAG) { "probeSu($path) threw: ${e.javaClass.simpleName}: ${e.message}" }
-            null
-        }
-
-    private data class SuProbe(
-        val path: String,
-        val kind: ProbeResultKind,
-    )
-
-    private enum class ProbeResultKind {
-        UID_ZERO,
-        NOT_ZERO,
-    }
+    private fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 
     companion object {
         private const val TAG = "RootServiceManager"
         private const val STATUS_SUCCESS = 0
         private const val STATUS_FAILURE = -1
-        private const val INSTALL_TIMEOUT_SECONDS = 120L
-        private const val UNINSTALL_TIMEOUT_SECONDS = 30L
-        private const val PROBE_TIMEOUT_SECONDS = 5L
-        private const val PROMPT_TIMEOUT_SECONDS = 60L
-        private const val READER_DRAIN_TIMEOUT_MS = 1_000L
+        private const val SHELL_TIMEOUT_SECONDS = 10L
 
         private val PACKAGE_NAME_PATTERN =
             Regex("""^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$""")
-
-        private val SU_PATHS =
-            listOf(
-                "/system/bin/su",
-                "/system/xbin/su",
-                "/sbin/su",
-                "/su/bin/su",
-                "/magisk/.core/bin/su",
-                "/data/adb/magisk/su",
-                "/data/adb/ksu/bin/su",
-                "/data/adb/ap/su",
-            )
     }
 }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -20,7 +20,8 @@
         "Discovery cards now show every platform a repo ships installers for, not just the one whose endpoint listed it.",
         "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column.",
         "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file.",
-        "Windows 11 title bar now matches system dark mode instead of staying glaringly white."
+        "Windows 11 title bar now matches system dark mode instead of staying glaringly white.",
+        "Silent install via root now properly triggers the Magisk / KernelSU permission prompt on Android 14+ instead of immediately reporting 'No root'; the root path was rewritten on top of libsu."
       ]
     }
   ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ landscapist = "2.9.5"
 coil3 = "3.3.0"
 highlights = "1.0.0"
 shizuku = "13.1.5"
+libsu = "6.0.0"
 dhizuku = "2.5.4"
 hidden-api = "4.4.0"
 jsystemthemedetector = "3.9.1"
@@ -169,6 +170,9 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
 hidden-api-stub = { module = "dev.rikka.hidden:stub", version.ref = "hidden-api" }
+
+# libsu (root shell)
+libsu-core = { module = "com.github.topjohnwu.libsu:core", version.ref = "libsu" }
 
 # Dhizuku
 dhizuku-api = { module = "io.github.iamr0s:Dhizuku-API", version.ref = "dhizuku" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,11 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
+        maven("https://jitpack.io") {
+            mavenContent {
+                includeGroupAndSubgroups("com.github.topjohnwu")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #651.

The previous root installer spawned `su` via `Runtime.exec` directly against a hardcoded list of su binary paths. On modern Magisk (≥27) + Android 14/15 this never triggers the superuser daemon prompt — the binary is hidden from non-granted callers, so the probe immediately returns "no su" and the Root tile shows "No root" with no permission dialog.

Rewrote `RootServiceManager` on top of [libsu](https://github.com/topjohnwu/libsu) 6.0.0 (the canonical lib from the Magisk author, used by LSPosed/Shizuku/etc.). It handles binary discovery, the daemon socket, MagiskHide quirks, and works out of the box with KernelSU + APatch.

Behaviour changes:

- Status: `Shell.isAppGrantedRoot()` (null → NOT_AVAILABLE, false → PERMISSION_NEEDED, true → READY).
- Prompt: `Shell.getShell()` forces main shell creation, which surfaces the Magisk/KernelSU/APatch grant dialog properly.
- `installPackage`: stages APK to `/data/local/tmp` (avoids SELinux path-access issues), `pm install -r -i <installer> <tmp>`, cleans up.
- `uninstallPackage`: `pm uninstall <pkg>` via libsu shell.
- Public API + `RootStatus` enum unchanged; all callsites (`SilentInstallerDispatcher`, `AndroidInstallerStatusProvider`, `AutoUpdateWorker`, Tweaks UI) untouched.

Added JitPack repo scoped to `com.github.topjohnwu` only (no wide-net resolution).

Tested by compile-verifying `:composeApp:assembleDebug`. I do not have a rooted device to manually verify; flagging for community confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On Android 14+, silent installation via root now correctly triggers Magisk/KernelSU permission prompts instead of reporting "No root".

* **Improvements**
  * Root-enabled install/uninstall flows made more reliable and consistent, with better root-state handling and clearer success/failure reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->