### PR TITLE
fix: linked apps show 'Update' immediately when version is older

### DIFF
--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -20,7 +20,8 @@
         "Discovery cards now show every platform a repo ships installers for, not just the one whose endpoint listed it.",
         "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column.",
         "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file.",
-        "Windows 11 title bar now matches system dark mode instead of staying glaringly white."
+        "Windows 11 title bar now matches system dark mode instead of staying glaringly white.",
+        "Linking an installed app to a GitHub repo now immediately shows 'Update to X' when the installed version is older, instead of misleading 'Install vX' until the next update check."
       ]
     }
   ]

--- a/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
+++ b/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
@@ -30,6 +30,7 @@ import zed.rainxch.core.data.network.executeRequest
 import zed.rainxch.core.data.network.shouldFallbackToGithubOrRethrow
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.DeviceApp
+import zed.rainxch.core.domain.util.VersionMath
 import zed.rainxch.core.domain.model.ExportedApp
 import zed.rainxch.core.domain.model.ExportedAppList
 import zed.rainxch.core.domain.model.GithubRelease
@@ -273,6 +274,12 @@ class AppsRepositoryImpl(
         val resolvedGlob = assetGlobPattern ?: freshFingerprint?.glob
         val resolvedSiblingCount = pickedAssetSiblingCount.takeIf { it > 0 }
 
+        val initialIsUpdateAvailable =
+            VersionMath.isVersionNewer(
+                candidate = repoInfo.latestReleaseTag,
+                current = deviceApp.versionName,
+            )
+
         val installedApp =
             InstalledApp(
                 packageName = deviceApp.packageName,
@@ -295,7 +302,7 @@ class AppsRepositoryImpl(
                 installedAt = now,
                 lastCheckedAt = 0L,
                 lastUpdatedAt = now,
-                isUpdateAvailable = false,
+                isUpdateAvailable = initialIsUpdateAvailable,
                 updateCheckEnabled = true,
                 releaseNotes = null,
                 systemArchitecture = "",


### PR DESCRIPTION
Refs #638.

Sub-bug reported by @HikaruIchijyo after the v1.8.3 fix:

> if i link a repo to an app(local app scan) it shows install only — if i unlink it shows update.

Root cause: `AppsRepositoryImpl.linkAppToRepo` hardcoded `isUpdateAvailable = false` for the freshly-linked row. Even when the installed `versionName` was older than `repoInfo.latestReleaseTag`, the Details screen's `SmartInstallButton` fell into the `isInstalled && versions differ` branch and rendered "Install v1.2.3" instead of "Update to 1.2.3" until the next `checkForUpdates` cycle (up to 30 min, or on next manual refresh).

Fix: at link time, compute `isUpdateAvailable` upfront using the already-fetched `repoInfo.latestReleaseTag` against the device's `versionName` via `VersionMath.isVersionNewer`. The button now reflects the correct CTA the moment linking completes.

The other two sub-bugs raised in the same comment (2 APKs in one repo collapsing to a single update row, stale link badge after unlinking) are separate code paths and will be tracked / fixed in follow-up PRs so this stays scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app update detection so installed apps now show accurate "update available" status.

* **Documentation**
  * Updated 1.9.0 release notes: preserved Windows 11 title bar dark-mode bullet and added note that linking an installed app to a repo immediately shows "Update to X" when the installed version is older.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->