### PR TITLE
feat(desktop): real logo in drawer and fluid content width

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
@@ -66,7 +66,7 @@ fun DesktopDrawer(
                 contentDescription = null,
                 modifier =
                     Modifier
-                        .size(28.dp)
+                        .size(40.dp)
                         .clip(CookieShape),
                 contentScale = ContentScale.Crop,
             )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.githubstore.app.navigation
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -21,15 +22,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.presentation.theme.geist
 import zed.rainxch.core.presentation.theme.tokens.Radii
 import zed.rainxch.core.presentation.vocabulary.CookieShape
 import zed.rainxch.core.presentation.vocabulary.VersionStack
 import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.app_icon
 import zed.rainxch.githubstore.core.presentation.res.app_name
 
 @Composable
@@ -57,26 +61,15 @@ fun DesktopDrawer(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(
+            Image(
+                painter = painterResource(Res.drawable.app_icon),
+                contentDescription = null,
                 modifier =
                     Modifier
                         .size(28.dp)
-                        .clip(CookieShape)
-                        .background(cs.primary),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "G",
-                    color = Color.White,
-                    style =
-                        MaterialTheme.typography.titleMedium.copy(
-                            fontFamily = geist,
-                            fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 15.sp,
-                        ),
-                )
-            }
+                        .clip(CookieShape),
+                contentScale = ContentScale.Crop,
+            )
             Text(
                 text = stringResource(Res.string.app_name),
                 color = cs.onSurface,

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/DesktopDrawer.kt
@@ -76,7 +76,6 @@ fun DesktopDrawer(
                 style =
                     MaterialTheme.typography.titleMedium.copy(
                         fontFamily = geist,
-                        fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
                         fontWeight = FontWeight.SemiBold,
                     ),
             )

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/19.json
@@ -20,7 +20,9 @@
         "Discovery cards now show every platform a repo ships installers for, not just the one whose endpoint listed it.",
         "What's New tag row no longer wraps long release tags into a one-character-wide vertical date column.",
         "Checksum mismatch when a mirror was active — fixed a race between mirror and direct downloads writing to the same destination file.",
-        "Windows 11 title bar now matches system dark mode instead of staying glaringly white."
+        "Windows 11 title bar now matches system dark mode instead of staying glaringly white.",
+        "Desktop side drawer now shows the actual GitHub Store logo instead of a 'G' placeholder.",
+        "Desktop content width (Home, Details, Auth) now scales as a fraction of the window — Compact / Wide / Extra wide adapt to monitor size instead of being capped to fixed pixel widths."
       ]
     }
   ]

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ConstrainedContentWidth.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/ConstrainedContentWidth.kt
@@ -4,17 +4,31 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import zed.rainxch.core.domain.model.ContentWidth
 import zed.rainxch.core.presentation.locals.LocalContentWidth
 
+private val MIN_CONTENT_DP = 480.dp
+private val MAX_CONTENT_DP = 1600.dp
+
+private fun ContentWidth.fraction(): Float = when (this) {
+    ContentWidth.COMPACT -> 0.55f
+    ContentWidth.WIDE -> 0.75f
+    ContentWidth.EXTRA_WIDE -> 0.95f
+}
+
 @Composable
 @ReadOnlyComposable
-fun Modifier.constrainedContentWidth(): Modifier {
-    val cap = when (LocalContentWidth.current) {
-        ContentWidth.COMPACT -> 680.dp
-        ContentWidth.WIDE -> 960.dp
-        ContentWidth.EXTRA_WIDE -> null
-    }
-    return if (cap != null) widthIn(max = cap) else this
+fun contentWidthCap(): Dp {
+    val fraction = LocalContentWidth.current.fraction()
+    val windowPx = LocalWindowInfo.current.containerSize.width
+    val windowDp = with(LocalDensity.current) { windowPx.toDp() }
+    return (windowDp * fraction).coerceIn(MIN_CONTENT_DP, MAX_CONTENT_DP)
 }
+
+@Composable
+@ReadOnlyComposable
+fun Modifier.constrainedContentWidth(): Modifier = widthIn(max = contentWidthCap())

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -89,14 +89,13 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.domain.model.DiscoveryPlatform
 import zed.rainxch.core.domain.model.InstallSource
-import zed.rainxch.core.domain.model.ContentWidth
 import zed.rainxch.core.presentation.components.FloatingPill
 import zed.rainxch.core.presentation.components.ScrollbarContainer
 import zed.rainxch.core.presentation.components.buttons.GhsButton
 import zed.rainxch.core.presentation.components.buttons.GhsButtonSize
 import zed.rainxch.core.presentation.components.buttons.GhsButtonVariant
-import zed.rainxch.core.presentation.locals.LocalContentWidth
 import zed.rainxch.core.presentation.locals.LocalScrollbarEnabled
+import zed.rainxch.core.presentation.utils.contentWidthCap
 import zed.rainxch.core.presentation.theme.GithubStoreTheme
 import zed.rainxch.core.presentation.utils.ObserveAsEvents
 import zed.rainxch.core.presentation.utils.arrowKeyScroll
@@ -537,11 +536,7 @@ fun DetailsScreen(
             val collapsedSectionHeight = containerHeightDp * 0.4f
             val listState = rememberLazyListState()
             val isScrollbarEnabled = LocalScrollbarEnabled.current
-            val contentWidthDp = when (LocalContentWidth.current) {
-                ContentWidth.COMPACT -> 680.dp
-                ContentWidth.WIDE -> 960.dp
-                ContentWidth.EXTRA_WIDE -> androidx.compose.ui.unit.Dp.Unspecified
-            }
+            val contentWidthDp = contentWidthCap()
             val pullEnabled = remember { isPullToRefreshSupported() }
 
             val isDesktop = remember { getPlatform() != Platform.ANDROID }


### PR DESCRIPTION
Two desktop polish items.

**1. Drawer logo.** The desktop-only side drawer was rendering a generic 'G' character inside a `CookieShape` chip as a placeholder. Replaced with the actual app icon (`Res.drawable.app_icon`), 28dp, clipped to the same shape so the chrome matches the macOS dock / Windows taskbar / Android launcher icon.

**2. Fluid content width.** `Home`, `Details`, `Auth`, and other screens using `LocalContentWidth` were capped with hardcoded dp values — `Compact = 680dp`, `Wide = 960dp`, `Extra wide = no cap`. On 4K monitors `Compact` looked tiny, on ultrawides `Wide` left huge gutters, and there was no smooth scaling between laptop and external display.

Switched to a fraction-of-window model with min/max guardrails:

- `Compact` → 55% of window width
- `Wide` → 75% of window width
- `Extra wide` → 95% of window width
- Clamp `[480dp, 1600dp]` so phones still fill and ultrawides don't stretch reading lines past the eye-comfort limit.

Implementation lives in `core/presentation/utils/ConstrainedContentWidth.kt`. Added `contentWidthCap(): Dp` helper for inline `widthIn(max = …)` use; refactored `DetailsRoot` to consume it instead of duplicating the switch. The existing `Modifier.constrainedContentWidth()` extension is now a one-liner over the same helper, so every call site (Home, Auth, future screens) inherits the new behavior automatically.

Compile-verified `:composeApp:compileKotlinJvm :composeApp:compileDebugKotlinAndroid` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop content width now scales responsively with the window and is clamped to sensible min/max bounds.

* **Bug Fixes**
  * Desktop side drawer displays the actual app logo.
  * Windows 11 title bar now follows system dark mode.

* **Documentation**
  * Updated "What's New" notes for version 1.9.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->