### PR TITLE
fix(root): detect granted root on KernelSU/APatch

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -124,11 +124,12 @@ class RootServiceManager(
     }
 
     private fun computeStatus(): RootStatus {
-        val granted = Shell.isAppGrantedRoot()
-        return when (granted) {
+        Shell.getCachedShell()?.let { shell ->
+            return if (shell.isRoot) RootStatus.READY else RootStatus.NOT_AVAILABLE
+        }
+        return when (Shell.isAppGrantedRoot()) {
             true -> RootStatus.READY
-            false -> RootStatus.PERMISSION_NEEDED
-            null -> RootStatus.NOT_AVAILABLE
+            false, null -> RootStatus.PERMISSION_NEEDED
         }
     }
 


### PR DESCRIPTION
Closes #680.

Root install showed "No root" on KernelSU even with root granted.

PR #673 mapped libsu's `isAppGrantedRoot()` as `null -> NOT_AVAILABLE`. But `null` means "su present, grant not yet confirmed" (KernelSU), and `true` is impossible until a shell is built — which `computeStatus()` never did. So it could never reach READY.

Fix: `null`/`false -> PERMISSION_NEEDED` (surfaces the Grant button), and a cached-shell check returns READY once a confirmed root shell exists, else clean "No root". Keeps #673's #651 fix intact.

Compile-verified. Untested on-device; community confirmation welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root permission status detection by prioritizing cached shell checks, reducing redundant permission queries and providing more accurate permission availability reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->