### PR TITLE
fix: disable Compose accessibility bridge on macOS

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
@@ -6,12 +6,16 @@ import java.awt.Toolkit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object A11yCrashGuard {
+    private const val COMPOSE_ACCESSIBILITY_ENABLE = "compose.accessibility.enable"
+
     private val warnedEdt = AtomicBoolean(false)
     private val warnedUncaught = AtomicBoolean(false)
 
     fun install() {
         val osName = System.getProperty("os.name")?.lowercase().orEmpty()
         if (!osName.contains("mac")) return
+
+        disableComposeAccessibilityBridgeByDefault()
 
         Toolkit.getDefaultToolkit().systemEventQueue.push(FilteringEventQueue())
 
@@ -30,6 +34,18 @@ object A11yCrashGuard {
             previous?.uncaughtException(thread, throwable)
                 ?: throwable.printStackTrace(System.err)
         }
+    }
+
+    private fun disableComposeAccessibilityBridgeByDefault() {
+        if (System.getProperty(COMPOSE_ACCESSIBILITY_ENABLE) != null) return
+
+        // Compose MP 1.10.x can still crash on macOS when the AWT accessibility bridge
+        // queries detached Compose components. Keep it off unless a user explicitly opts in.
+        System.setProperty(COMPOSE_ACCESSIBILITY_ENABLE, "false")
+        System.err.println(
+            "[A11yCrashGuard] Disabled Compose accessibility bridge on macOS " +
+                "(known issue, see GitHub-Store#330 / #639 / #640).",
+        )
     }
 
     private fun isComposeA11yNpe(throwable: Throwable): Boolean {


### PR DESCRIPTION
## What

Disable the Compose accessibility bridge by default on macOS during desktop startup.

The existing `A11yCrashGuard` stays in place as a fallback if someone explicitly enables Compose accessibility again.

## Why

I hit this on GitHub Store v1.9.0 with macOS 26.5. The app was closing a few seconds after launch, and the log showed a Compose accessibility NPE around `getDefaultTransform` / `ComposeAccessible`.

I tested the same workaround locally in the installed app by adding `-Dcompose.accessibility.enable=false` to `GitHub-Store.cfg`, then re-signing the app. After that the app stopped crashing.

## Linked issues

This should cover the same macOS Compose accessibility crash family mentioned in #330 and #639, as long as those crashes are coming from the Compose accessibility bridge.

#640 / #645 handled some NPE paths by suppressing them. This change avoids the trigger by keeping the bridge off by default on macOS.

I am not marking this as `Closes #330` because that issue is broad, but this should fix the crash path I reproduced on v1.9.0.

## How to test

Run:

```bash
./gradlew :composeApp:ktlintCheck :composeApp:compileKotlinJvm
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS stability by optimizing default accessibility settings. Enhanced startup logging to track configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenHub-Store/GitHub-Store/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->