### PR TITLE
i18n: extract hardcoded strings + sync all translations

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/onboarding/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/onboarding/OnboardingScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.domain.model.AppTheme
 import zed.rainxch.core.domain.model.ThemeMode
@@ -54,6 +55,23 @@ import zed.rainxch.core.presentation.utils.constrainedContentWidth
 import zed.rainxch.core.presentation.utils.primaryColor
 import zed.rainxch.core.presentation.vocabulary.CookieShape
 import zed.rainxch.core.presentation.vocabulary.Squiggle
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.onboarding_get_started
+import zed.rainxch.githubstore.core.presentation.res.onboarding_next
+import zed.rainxch.githubstore.core.presentation.res.onboarding_palette_subtitle
+import zed.rainxch.githubstore.core.presentation.res.onboarding_palette_title
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_allow
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_granted
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_install
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_install_desc
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_notifications
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permission_notifications_desc
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permissions_subtitle
+import zed.rainxch.githubstore.core.presentation.res.onboarding_permissions_title
+import zed.rainxch.githubstore.core.presentation.res.onboarding_signin_button
+import zed.rainxch.githubstore.core.presentation.res.onboarding_signin_subtitle
+import zed.rainxch.githubstore.core.presentation.res.onboarding_skip
+import zed.rainxch.githubstore.core.presentation.res.sign_in_with_github
 
 @Composable
 fun OnboardingRoot(
@@ -155,7 +173,7 @@ private fun StepPalette(
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         Text(
-            text = "Pick your palette",
+            text = stringResource(Res.string.onboarding_palette_title),
             style =
                 MaterialTheme.typography.displaySmall.copy(
                     fontFamily = geist,
@@ -166,7 +184,7 @@ private fun StepPalette(
         )
         Squiggle()
         Text(
-            text = "Four palettes × Light, Dark, AMOLED, System.",
+            text = stringResource(Res.string.onboarding_palette_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -291,7 +309,7 @@ private fun StepSignIn(onAction: (OnboardingAction) -> Unit) {
             )
         }
         Text(
-            text = "Sign in with GitHub",
+            text = stringResource(Res.string.sign_in_with_github),
             style =
                 MaterialTheme.typography.headlineSmall.copy(
                     fontFamily = geist,
@@ -302,14 +320,14 @@ private fun StepSignIn(onAction: (OnboardingAction) -> Unit) {
         )
         Squiggle()
         Text(
-            text = "Stars, profile, and rate-limit headroom. Optional — skip to browse anonymously.",
+            text = stringResource(Res.string.onboarding_signin_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
         GhsButton(
             onClick = { onAction(OnboardingAction.OnSignInClick) },
-            label = "Sign in",
+            label = stringResource(Res.string.onboarding_signin_button),
             variant = GhsButtonVariant.Primary,
         )
     }
@@ -324,7 +342,7 @@ private fun StepPermissions(controller: OnboardingPermissionsController) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "Two quick prompts",
+            text = stringResource(Res.string.onboarding_permissions_title),
             style =
                 MaterialTheme.typography.headlineSmall.copy(
                     fontFamily = geist,
@@ -335,22 +353,22 @@ private fun StepPermissions(controller: OnboardingPermissionsController) {
         )
         Squiggle()
         Text(
-            text = "Both optional. You can flip these later in Tweaks.",
+            text = stringResource(Res.string.onboarding_permissions_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
         PermissionRow(
             icon = Icons.Outlined.Notifications,
-            label = "Notifications",
-            description = "Update alerts and install progress",
+            label = stringResource(Res.string.onboarding_permission_notifications),
+            description = stringResource(Res.string.onboarding_permission_notifications_desc),
             isGranted = notificationsGranted,
             onAllowClick = { controller.requestNotifications() },
         )
         PermissionRow(
             icon = Icons.Outlined.DownloadForOffline,
-            label = "Install unknown apps",
-            description = "Required to install APKs outside Play",
+            label = stringResource(Res.string.onboarding_permission_install),
+            description = stringResource(Res.string.onboarding_permission_install_desc),
             isGranted = installSourcesGranted,
             onAllowClick = { controller.requestInstallSources() },
         )
@@ -414,7 +432,7 @@ private fun PermissionRow(
             ) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Granted",
+                    contentDescription = stringResource(Res.string.onboarding_permission_granted),
                     tint = cs.onPrimary,
                     modifier = Modifier.size(20.dp),
                 )
@@ -422,7 +440,7 @@ private fun PermissionRow(
         } else {
             GhsButton(
                 onClick = onAllowClick,
-                label = "Allow",
+                label = stringResource(Res.string.onboarding_permission_allow),
                 variant = GhsButtonVariant.Tonal,
             )
         }
@@ -442,7 +460,7 @@ private fun ActionRow(
         if (state.currentStep == OnboardingStep.SIGN_IN || state.currentStep == OnboardingStep.PERMISSIONS) {
             GhsButton(
                 onClick = { onAction(OnboardingAction.OnSkipStepClick) },
-                label = "Skip",
+                label = stringResource(Res.string.onboarding_skip),
                 variant = GhsButtonVariant.Outline,
             )
         } else {
@@ -450,7 +468,7 @@ private fun ActionRow(
         }
         GhsButton(
             onClick = { onAction(OnboardingAction.OnNextClick) },
-            label = if (state.isLast) "Get started" else "Next",
+            label = if (state.isLast) stringResource(Res.string.onboarding_get_started) else stringResource(Res.string.onboarding_next),
             variant = GhsButtonVariant.Primary,
         )
     }

--- a/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ar/strings-ar.xml
@@ -1317,4 +1317,42 @@
     <string name="interval_weekly">أسبوعيًا</string>
     <string name="interval_biweekly">كل أسبوعين</string>
     <string name="interval_monthly">كل 30 يومًا</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">اختر لوحة ألوانك</string>
+    <string name="onboarding_palette_subtitle">أربع لوحات ألوان × فاتح، داكن، AMOLED، النظام.</string>
+    <string name="onboarding_signin_subtitle">نجومك وملفك الشخصي ومتّسع أكبر في حد الطلبات. اختياري — تخطَّ لتتصفّح كمجهول.</string>
+    <string name="onboarding_signin_button">تسجيل الدخول</string>
+    <string name="onboarding_permissions_title">طلبان سريعان</string>
+    <string name="onboarding_permissions_subtitle">كلاهما اختياري. يمكنك تغييرهما لاحقاً من التعديلات.</string>
+    <string name="onboarding_permission_notifications">الإشعارات</string>
+    <string name="onboarding_permission_notifications_desc">تنبيهات التحديث وتقدّم التثبيت</string>
+    <string name="onboarding_permission_install">تثبيت التطبيقات غير المعروفة</string>
+    <string name="onboarding_permission_install_desc">مطلوب لتثبيت ملفات APK خارج Play</string>
+    <string name="onboarding_permission_granted">ممنوح</string>
+    <string name="onboarding_permission_allow">السماح</string>
+    <string name="onboarding_skip">تخطّي</string>
+    <string name="onboarding_get_started">لنبدأ</string>
+    <string name="onboarding_next">التالي</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">نشاط المساهمات</string>
+    <string name="dev_profile_contributions_this_year">%1$d هذا العام</string>
+    <string name="dev_profile_contributions_load_failed">تعذّر تحميل المساهمات.</string>
+    <string name="dev_profile_contributions_less">أقل</string>
+    <string name="dev_profile_contributions_more">أكثر</string>
+    <string name="dev_profile_org_badge">منظمة</string>
+
+    <!-- Common -->
+    <string name="loading">جارٍ التحميل…</string>
+    <string name="failed_to_load">فشل التحميل</string>
+    <string name="failed_to_load_details">فشل تحميل التفاصيل</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">تعذّر تحميل التراخيص.</string>
+    <string name="tweaks_app_info_website">الموقع الإلكتروني</string>
+    <string name="tweaks_clear_downloads_failed">فشل مسح التنزيلات</string>
+    <string name="tweaks_custom_forge_invalid_hostname">أدخل اسم مضيف صالحاً (مثل forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">تعذّر حفظ المضيف. حاول مرة أخرى.</string>
+    <string name="tweaks_custom_forge_remove_failed">تعذّر إزالة المضيف. حاول مرة أخرى.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
+++ b/core/presentation/src/commonMain/composeResources/values-bn/strings-bn.xml
@@ -1279,4 +1279,42 @@
     <string name="interval_weekly">সাপ্তাহিক</string>
     <string name="interval_biweekly">প্রতি 2 সপ্তাহে</string>
     <string name="interval_monthly">প্রতি 30 দিনে</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">আপনার প্যালেট বেছে নিন</string>
+    <string name="onboarding_palette_subtitle">চারটি প্যালেট × উজ্জ্বল, অন্ধকার, AMOLED, সিস্টেম।</string>
+    <string name="onboarding_signin_subtitle">স্টার, প্রোফাইল এবং বাড়তি রেট লিমিট। ঐচ্ছিক — বাদ দিয়ে বেনামে ব্রাউজ করুন।</string>
+    <string name="onboarding_signin_button">সাইন ইন</string>
+    <string name="onboarding_permissions_title">দুটি দ্রুত অনুরোধ</string>
+    <string name="onboarding_permissions_subtitle">দুটিই ঐচ্ছিক। আপনি এগুলো পরে টুইকস থেকে বদলাতে পারবেন।</string>
+    <string name="onboarding_permission_notifications">বিজ্ঞপ্তি</string>
+    <string name="onboarding_permission_notifications_desc">আপডেট সতর্কতা এবং ইনস্টলের অগ্রগতি</string>
+    <string name="onboarding_permission_install">অজানা অ্যাপ ইনস্টল</string>
+    <string name="onboarding_permission_install_desc">Play-এর বাইরে APK ইনস্টল করতে প্রয়োজন</string>
+    <string name="onboarding_permission_granted">অনুমতি দেওয়া হয়েছে</string>
+    <string name="onboarding_permission_allow">অনুমতি দিন</string>
+    <string name="onboarding_skip">বাদ দিন</string>
+    <string name="onboarding_get_started">শুরু করুন</string>
+    <string name="onboarding_next">পরবর্তী</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">অবদানের কার্যকলাপ</string>
+    <string name="dev_profile_contributions_this_year">এ বছর %1$d টি</string>
+    <string name="dev_profile_contributions_load_failed">অবদান লোড করা যায়নি।</string>
+    <string name="dev_profile_contributions_less">কম</string>
+    <string name="dev_profile_contributions_more">বেশি</string>
+    <string name="dev_profile_org_badge">প্রতিষ্ঠান</string>
+
+    <!-- Common -->
+    <string name="loading">লোড হচ্ছে…</string>
+    <string name="failed_to_load">লোড করতে ব্যর্থ</string>
+    <string name="failed_to_load_details">বিস্তারিত লোড করতে ব্যর্থ</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">লাইসেন্স লোড করা যায়নি।</string>
+    <string name="tweaks_app_info_website">ওয়েবসাইট</string>
+    <string name="tweaks_clear_downloads_failed">ডাউনলোড মুছতে ব্যর্থ</string>
+    <string name="tweaks_custom_forge_invalid_hostname">একটি বৈধ হোস্টনেম দিন (যেমন forgejo.example.com)।</string>
+    <string name="tweaks_custom_forge_save_failed">হোস্ট সংরক্ষণ করা যায়নি। আবার চেষ্টা করুন।</string>
+    <string name="tweaks_custom_forge_remove_failed">হোস্ট সরানো যায়নি। আবার চেষ্টা করুন।</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
+++ b/core/presentation/src/commonMain/composeResources/values-es/strings-es.xml
@@ -1258,4 +1258,42 @@
     <string name="interval_weekly">Semanalmente</string>
     <string name="interval_biweekly">Cada 2 semanas</string>
     <string name="interval_monthly">Cada 30 días</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Elige tu paleta</string>
+    <string name="onboarding_palette_subtitle">Cuatro paletas × Claro, Oscuro, AMOLED, Sistema.</string>
+    <string name="onboarding_signin_subtitle">Estrellas, perfil y un margen extra en el límite de solicitudes. Opcional — omítelo para navegar de forma anónima.</string>
+    <string name="onboarding_signin_button">Iniciar sesión</string>
+    <string name="onboarding_permissions_title">Dos permisos rápidos</string>
+    <string name="onboarding_permissions_subtitle">Ambos son opcionales. Puedes cambiarlos más tarde en Ajustes.</string>
+    <string name="onboarding_permission_notifications">Notificaciones</string>
+    <string name="onboarding_permission_notifications_desc">Avisos de actualización y progreso de instalación</string>
+    <string name="onboarding_permission_install">Instalar apps desconocidas</string>
+    <string name="onboarding_permission_install_desc">Necesario para instalar APK fuera de Play</string>
+    <string name="onboarding_permission_granted">Concedido</string>
+    <string name="onboarding_permission_allow">Permitir</string>
+    <string name="onboarding_skip">Omitir</string>
+    <string name="onboarding_get_started">Empezar</string>
+    <string name="onboarding_next">Siguiente</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Actividad de contribuciones</string>
+    <string name="dev_profile_contributions_this_year">%1$d este año</string>
+    <string name="dev_profile_contributions_load_failed">No se pudieron cargar las contribuciones.</string>
+    <string name="dev_profile_contributions_less">Menos</string>
+    <string name="dev_profile_contributions_more">Más</string>
+    <string name="dev_profile_org_badge">Org</string>
+
+    <!-- Common -->
+    <string name="loading">Cargando…</string>
+    <string name="failed_to_load">Error al cargar</string>
+    <string name="failed_to_load_details">Error al cargar los detalles</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">No se pudieron cargar las licencias.</string>
+    <string name="tweaks_app_info_website">Sitio web</string>
+    <string name="tweaks_clear_downloads_failed">No se pudieron borrar las descargas</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Introduce un hostname válido (p. ej. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">No se pudo guardar el host. Inténtalo de nuevo.</string>
+    <string name="tweaks_custom_forge_remove_failed">No se pudo eliminar el host. Inténtalo de nuevo.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -205,12 +205,12 @@
     <string name="starred_repositories">Dépôts Étoilés</string>
     <string name="repository_starred">Le dépôt est étoilé</string>
     <string name="repository_not_starred">Le dépôt n'est pas étoilé</string>
-    <string name="star_from_github">Vous pouvez ajouter ce dépôt aux favoris sur GitHub</string>
-    <string name="unstar_from_github">Vous pouvez retirer ce dépôt des favoris sur GitHub</string>
+    <string name="star_from_github">Vous pouvez mettre une étoile à ce dépôt sur GitHub</string>
+    <string name="unstar_from_github">Vous pouvez retirer l'étoile de ce dépôt sur GitHub</string>
 
     <string name="sign_in_required">Connexion requise</string>
-    <string name="no_starred_repos">Aucun dépôt favori</string>
-    <string name="sign_in_with_github_for_stars">Connectez-vous avec GitHub pour voir vos dépôts favoris</string>
+    <string name="no_starred_repos">Aucun dépôt étoilé</string>
+    <string name="sign_in_with_github_for_stars">Connectez-vous avec GitHub pour voir vos dépôts étoilés</string>
     <string name="star_repos_hint">Ajoutez des dépôts avec des versions installables sur GitHub pour les voir ici</string>
     <string name="last_synced">Dernière synchronisation</string>
     <string name="just_now">À l'instant</string>
@@ -218,7 +218,7 @@
     <string name="hours_ago">Il y a %1$d h</string>
     <string name="days_ago">Il y a %1$d j</string>
     <string name="dismiss">Fermer</string>
-    <string name="sync_starred_failed">Échec de la synchronisation des dépôts favoris</string>
+    <string name="sync_starred_failed">Échec de la synchronisation des dépôts étoilés</string>
 
 
     <!-- Developer Profile - General -->
@@ -589,7 +589,7 @@
     <string name="match_source_fingerprint">Signature</string>
     <string name="match_source_search">Recherche</string>
     <string name="match_source_manual">Manuel</string>
-    <string name="match_source_starred">Favori</string>
+    <string name="match_source_starred">Étoilés</string>
     <string name="pat_sheet_title">Se connecter avec un Personal Access Token</string>
     <string name="pat_sheet_description">Créez un Personal Access Token (classic ou fine-grained) sur un appareil ayant accès à GitHub, puis collez-le ci-dessous. Nécessite un accès en lecture aux dépôts et à votre profil.</string>
     <string name="pat_open_settings">Ouvrir les paramètres de tokens GitHub</string>
@@ -800,7 +800,7 @@
     <string name="mirror_removed_toast">%1$s n'est plus disponible, basculé vers GitHub direct.</string>
 
     <!-- ───── 1.8.1 backlog ───── -->
-    <string name="add_from_starred_title">Ajouter depuis les favoris</string>
+    <string name="add_from_starred_title">Ajouter depuis les dépôts étoilés</string>
     <string name="announcements_acknowledge">J'ai lu</string>
     <string name="announcements_acknowledged">Pris en compte</string>
     <string name="announcements_category_news">Actualités</string>
@@ -926,20 +926,20 @@
     <string name="releases_unavailable_temporarily">Les releases sont temporairement indisponibles. Réessayez dans un moment.</string>
     <string name="starred_picker_already_tracked">Suivi</string>
     <string name="starred_picker_apk_badge">APK</string>
-    <string name="starred_picker_empty">Aucun dépôt favori. Mettez en favori des dépôts sur GitHub pour les voir ici.</string>
+    <string name="starred_picker_empty">Aucun dépôt étoilé. Mettez une étoile à des dépôts sur GitHub pour les voir ici.</string>
     <string name="starred_picker_filter_show_all">Afficher les dépôts sans release APK</string>
-    <string name="starred_picker_header_counts">%1$d favoris · %2$d publient des APK · %3$d déjà suivis</string>
+    <string name="starred_picker_header_counts">%1$d étoilés · %2$d publient des APK · %3$d déjà suivis</string>
     <string name="starred_picker_no_match">Aucun résultat.</string>
     <string name="starred_picker_progress">Vérification %1$d / %2$d…</string>
     <string name="starred_picker_rate_limited">Limite GitHub atteinte. Reprendre pour continuer la vérification.</string>
     <string name="starred_picker_resume">Reprendre</string>
     <string name="starred_picker_search_hint">Rechercher propriétaire / dépôt / description</string>
-    <string name="starred_picker_sign_in_required">Connectez-vous à GitHub pour voir vos dépôts favoris.</string>
+    <string name="starred_picker_sign_in_required">Connectez-vous à GitHub pour voir vos dépôts étoilés.</string>
     <string name="starred_picker_sort_alphabetical">A → Z</string>
-    <string name="starred_picker_sort_recent">Mis en favori récemment</string>
+    <string name="starred_picker_sort_recent">Étoilés récemment</string>
     <string name="starred_picker_sort_stars">Plus d'étoiles</string>
     <string name="starred_picker_star_dedup_tooltip">Retirer l'étoile sur GitHub n'arrêtera pas le suivi de l'app.</string>
-    <string name="starred_picker_title">Ajouter depuis les favoris</string>
+    <string name="starred_picker_title">Ajouter depuis les dépôts étoilés</string>
     <string name="whats_new_cta_dismiss">Compris</string>
     <string name="whats_new_cta_history">Voir les versions précédentes</string>
     <string name="whats_new_history_empty">Pas encore d'entrée de changelog.</string>
@@ -1029,7 +1029,7 @@
     <string name="feedback_hub_subtitle">Nous lisons chaque retour.</string>
     <string name="home_action_get">Obtenir</string>
     <string name="home_rank_format">n°%1$d</string>
-    <string name="home_section_from_your_stars">Depuis vos favoris</string>
+    <string name="home_section_from_your_stars">Depuis vos étoiles</string>
     <string name="home_section_hot_releases">Versions chaudes</string>
     <string name="home_section_most_popular">Les plus populaires</string>
     <string name="home_section_trending_now">Tendances du moment</string>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -203,8 +203,8 @@
     <string name="added_on_date">ajouté le %1$s</string>
 
     <string name="starred_repositories">Dépôts Étoilés</string>
-    <string name="repository_starred">Le dépôt est en favori</string>
-    <string name="repository_not_starred">Le dépôt n'est pas en favori</string>
+    <string name="repository_starred">Le dépôt est étoilé</string>
+    <string name="repository_not_starred">Le dépôt n'est pas étoilé</string>
     <string name="star_from_github">Vous pouvez ajouter ce dépôt aux favoris sur GitHub</string>
     <string name="unstar_from_github">Vous pouvez retirer ce dépôt des favoris sur GitHub</string>
 

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -5,7 +5,7 @@
     <string name="check_for_updates">Vérifier les mises à jour</string>
 
     <string name="cannot_launch">Impossible de lancer %1$s</string>
-    <string name="failed_to_open">Impossible d’ouvrir %1$s</string>
+    <string name="failed_to_open">Impossible d'ouvrir %1$s</string>
     <string name="failed_to_update">Échec de la mise à jour de %1$s : %2$s</string>
     <string name="update_all_failed">Échec de la mise à jour globale : %1$s</string>
     <string name="all_apps_updated_successfully">Toutes les applications ont été mises à jour</string>
@@ -26,9 +26,9 @@
     <string name="updating_x_of_y">Mise à jour %1$d sur %2$d</string>
     <string name="currently_updating">Actuellement : %1$s</string>
 
-    <string name="waiting_for_authorization">En attente d’autorisation…</string>
+    <string name="waiting_for_authorization">En attente d'autorisation…</string>
     <string name="signed_in">Connecté !</string>
-    <string name="redirecting_message">Vous pouvez maintenant utiliser l’application. Redirection…</string>
+    <string name="redirecting_message">Vous pouvez maintenant utiliser l'application. Redirection…</string>
     <string name="try_again">Réessayer</string>
 
     <string name="auth_error_with_message">Erreur : %1$s</string>
@@ -37,7 +37,7 @@
     <string name="copy_code">Copier le code</string>
     <string name="open_github">Ouvrir GitHub</string>
 
-    <string name="unlock_full_experience">Débloquez l’expérience\ncomplète</string>
+    <string name="unlock_full_experience">Débloquez l'expérience\ncomplète</string>
 
     <string name="more_requests">Plus de requêtes</string>
     <string name="more_requests_description">
@@ -63,7 +63,7 @@
     <string name="sort_by">Trier par</string>
     <string name="close">Fermer</string>
 
-    <string name="sort_most_stars">Le plus d’étoiles</string>
+    <string name="sort_most_stars">Le plus d'étoiles</string>
     <string name="sort_most_forks">Le plus de forks</string>
     <string name="sort_best_match">Meilleure correspondance</string>
     <string name="sort_recently_released">Récemment publiés</string>
@@ -88,7 +88,7 @@
     <string name="language_ruby">Ruby</string>
     <string name="language_php">PHP</string>
 
-    <string name="search_failed">La recherche a échoué</string>
+    <string name="search_failed">Échec de la recherche</string>
     <string name="no_repositories_found">Aucun dépôt trouvé</string>
 
     <string name="profile_title">Profil</string>
@@ -115,7 +115,7 @@
     <string name="theme_plum">Plum</string>
 
     <string name="about_this_app">À propos de cette application</string>
-    <string name="install_logs">Journaux d’installation</string>
+    <string name="install_logs">Journaux d'installation</string>
     <string name="whats_new">Nouveautés</string>
 
     <string name="installed">Installé</string>
@@ -142,7 +142,7 @@
     <string name="architecture_compatible">Architecture compatible</string>
     <string name="update_to_version">Mettre à jour vers %1$s</string>
 
-    <string name="installer_saved_downloads">L’installateur a été enregistré dans Téléchargements</string>
+    <string name="installer_saved_downloads">L'installateur a été enregistré dans Téléchargements</string>
 
     <string name="log_download_started">Téléchargement démarré</string>
     <string name="log_downloaded">Téléchargé</string>
@@ -168,7 +168,7 @@
 
 
 
-    <string name="home_finding_repositories">Recherche de dépôts...</string>
+    <string name="home_finding_repositories">Recherche de dépôts…</string>
     <string name="home_retry">Réessayer</string>
     <string name="home_failed_to_load_repositories">Impossible de charger les dépôts</string>
 
@@ -196,7 +196,7 @@
     <string name="remove_from_favourites">Retirer des favoris</string>
     <string name="favourites">Favoris</string>
 
-    <string name="added_just_now">ajouté à l’instant</string>
+    <string name="added_just_now">ajouté à l'instant</string>
     <string name="added_hours_ago">ajouté il y a %1$d heure(s)</string>
     <string name="added_yesterday">ajouté hier</string>
     <string name="added_days_ago">ajouté il y a %1$d jour(s)</string>
@@ -204,7 +204,7 @@
 
     <string name="starred_repositories">Dépôts Étoilés</string>
     <string name="repository_starred">Le dépôt est en favori</string>
-    <string name="repository_not_starred">Le dépôt n’est pas en favori</string>
+    <string name="repository_not_starred">Le dépôt n'est pas en favori</string>
     <string name="star_from_github">Vous pouvez ajouter ce dépôt aux favoris sur GitHub</string>
     <string name="unstar_from_github">Vous pouvez retirer ce dépôt des favoris sur GitHub</string>
 
@@ -213,7 +213,7 @@
     <string name="sign_in_with_github_for_stars">Connectez-vous avec GitHub pour voir vos dépôts favoris</string>
     <string name="star_repos_hint">Ajoutez des dépôts avec des versions installables sur GitHub pour les voir ici</string>
     <string name="last_synced">Dernière synchronisation</string>
-    <string name="just_now">À l’instant</string>
+    <string name="just_now">À l'instant</string>
     <string name="minutes_ago">Il y a %1$d min</string>
     <string name="hours_ago">Il y a %1$d h</string>
     <string name="days_ago">Il y a %1$d j</string>
@@ -222,7 +222,7 @@
 
 
     <!-- Developer Profile - General -->
-    <string name="failed_to_load_repositories">Échec du chargement des dépôts</string>
+    <string name="failed_to_load_repositories">Impossible de charger les dépôts</string>
     <string name="failed_to_load_profile">Échec du chargement du profil</string>
 
     <!-- Developer Profile - Stats -->
@@ -265,7 +265,7 @@
     <string name="count_millions">%1$dM</string>
     <string name="count_thousands">%1$dk</string>
 
-    <string name="released_just_now">Publié à l’instant</string>
+    <string name="released_just_now">Publié à l'instant</string>
     <string name="released_hours_ago">Publié il y a %1$d heure(s)</string>
     <string name="released_yesterday">Publié hier</string>
     <string name="released_days_ago">Publié il y a %1$d jour(s)</string>
@@ -330,11 +330,11 @@
     <string name="proxy_port">Port</string>
     <string name="proxy_username">Nom d'utilisateur (facultatif)</string>
     <string name="proxy_password">Mot de passe (facultatif)</string>
-    <string name="proxy_save">Sauvegarder le Proxy</string>
+    <string name="proxy_save">Enregistrer le proxy</string>
     <string name="proxy_saved">Paramètres du proxy enregistrés</string>
     <string name="failed_to_save_proxy_settings">Échec de l'enregistrement des paramètres du proxy</string>
-    <string name="proxy_host_required">L’hôte du proxy est requis</string>
-    <string name="proxy_host_invalid">Saisissez un nom d’hôte ou une adresse IP valide</string>
+    <string name="proxy_host_required">L'hôte du proxy est requis</string>
+    <string name="proxy_host_invalid">Saisissez un nom d'hôte ou une adresse IP valide</string>
     <string name="invalid_proxy_port">Port proxy invalide</string>
     <string name="proxy_test_success">Connexion OK (%1$d ms)</string>
     <string name="proxy_test_error_dns">Impossible de résoudre l'hôte. Vérifiez l'adresse du proxy.</string>
@@ -365,7 +365,7 @@
     <string name="auth_hint_try_again">Veuillez réessayer de vous connecter pour obtenir un nouveau code.</string>
     <string name="auth_hint_check_connection">Vérifiez votre connexion internet et réessayez.</string>
     <string name="auth_hint_denied">Vous avez refusé la demande d'autorisation. Réessayez si c'était involontaire.</string>
-    <string name="auth_check_status">J’ai déjà autorisé</string>
+    <string name="auth_check_status">J'ai déjà autorisé</string>
     <string name="auth_polling_status">Vérification…</string>
     <string name="auth_rate_limited">Limite atteinte — nouvelle tentative dans %1$d s</string>
 
@@ -387,7 +387,7 @@
     <string name="open_in_app">Ouvrir dans l'app</string>
     <string name="no_github_link_in_clipboard">Aucun lien GitHub trouvé dans le presse-papiers</string>
 
-    <string name="clear">Vider</string>
+    <string name="clear">Effacer</string>
 
 
 
@@ -408,7 +408,7 @@
     <string name="shizuku_status_not_running">Shizuku n'est pas en cours d'exécution</string>
     <string name="shizuku_status_permission_needed">Autorisation requise</string>
     <string name="shizuku_status_ready">Prêt</string>
-    <string name="shizuku_grant_permission">Accorder l'autorisation</string>
+    <string name="shizuku_grant_permission">Accorder la permission</string>
     <string name="shizuku_install_hint">Installez Shizuku pour activer l'installation silencieuse</string>
     <string name="shizuku_start_hint">Démarrez Shizuku pour activer l'installation silencieuse</string>
     <string name="shizuku_install_failed_fallback">L'installation via Shizuku a échoué, utilisation de l'installateur standard</string>
@@ -637,7 +637,7 @@
         <item quantity="one">%1$d application examinée</item>
         <item quantity="other">%1$d applications examinées</item>
     </plurals>
-    <string name="external_import_card_action_skip">Ignorer</string>
+    <string name="external_import_card_action_skip">Passer</string>
     <string name="external_import_card_action_link">Lier</string>
     <string name="external_import_card_action_more">Plus de correspondances</string>
     <string name="external_import_card_action_less">Masquer les correspondances</string>
@@ -717,7 +717,7 @@
     <string name="details_unlink_external_app_success">Délié. Nous proposerons une correspondance lors du prochain scan.</string>
     <string name="details_unlink_external_app_failure">Impossible de délier — réessayez.</string>
     <string name="details_linked_repo_banner_title">Lié à %1$s/%2$s</string>
-    <string name="details_linked_repo_banner_body">Liée manuellement — vérifiée par toi. Dissocie pour relancer le scan.</string>
+    <string name="details_linked_repo_banner_body">Liée manuellement — vérifiée par vous. Dissociez pour relancer le scan.</string>
 
     <!-- Details manual refresh -->
     <string name="details_refresh">Actualiser</string>
@@ -771,7 +771,7 @@
     <!-- Tweaks - Custom forges -->
     <string name="custom_forges_entry_label">Forges personnalisées</string>
     <string name="custom_forges_dialog_title">Forges personnalisées</string>
-    <string name="custom_forges_dialog_help">Saisis le nom d'hôte d'une instance Forgejo ou Gitea (ex. git.example.com). GHS acceptera les URLs de ces hôtes dans le formulaire de liaison manuelle.</string>
+    <string name="custom_forges_dialog_help">Saisissez le nom d'hôte d'une instance Forgejo ou Gitea (ex. git.example.com). GHS acceptera les URLs de ces hôtes dans le formulaire de liaison manuelle.</string>
     <string name="custom_forges_add_button">Ajouter</string>
     <string name="custom_forges_empty">Aucune forge personnalisée pour l'instant.</string>
     <string name="done">Terminé</string>
@@ -867,7 +867,7 @@
     <string name="apps_section_up_to_date">À jour</string>
     <string name="confirm_discard_pending_message">Abandonner l'installeur en attente pour %1$s et retirer la ligne de votre liste d'apps ? L'APK téléchargé sera supprimé.</string>
     <string name="confirm_discard_pending_title">Abandonner l'installation en attente ?</string>
-    <string name="dhizuku_grant_permission">Accorder l'autorisation</string>
+    <string name="dhizuku_grant_permission">Accorder la permission</string>
     <string name="dhizuku_install_hint">Installez Dhizuku et activez-le comme Device Owner pour activer les installations silencieuses</string>
     <string name="dhizuku_start_hint">Activez Dhizuku comme Device Owner pour activer les installations silencieuses</string>
     <string name="installer_type_root">Root</string>
@@ -1034,7 +1034,7 @@
     <string name="home_section_most_popular">Les plus populaires</string>
     <string name="home_section_trending_now">Tendances du moment</string>
     <string name="home_topbar_discover">Découvrir</string>
-    <string name="home_view_all">Tout voir</string>
+    <string name="home_view_all">Tout afficher</string>
     <string name="home_view_more">Voir plus</string>
     <string name="host_tokens_action_add">Ajouter un jeton</string>
     <string name="host_tokens_action_back">Retour</string>
@@ -1212,8 +1212,10 @@
     <string name="tweaks_privacy_clipboard_title">Détecter les liens de dépôts dans le presse-papiers</string>
     <string name="tweaks_privacy_hidden_repos_body">Dépôts que vous avez masqués des flux et de la recherche.</string>
     <string name="tweaks_privacy_hidden_repos_title">Dépôts masqués</string>
+    <string name="tweaks_privacy_usage_data_section">Données d'utilisation</string>
     <string name="tweaks_privacy_hide_seen_body">Ignorer les dépôts déjà vus dans les flux et la recherche.</string>
-    <string name="tweaks_privacy_hide_seen_title">Masquer les dépôts déjà consultés</string>    <string name="tweaks_privacy_telemetry_collect_no_identifiers">Aucun identifiant.</string>    <string name="tweaks_privacy_telemetry_collect_os">Système d'exploitation et plateforme.</string>    <string name="tweaks_search_empty">Aucun paramètre ne correspond à « %1$s ».</string>
+    <string name="tweaks_privacy_hide_seen_title">Masquer les dépôts déjà consultés</string>
+    <string name="tweaks_search_empty">Aucun paramètre ne correspond à « %1$s ».</string>
     <string name="tweaks_search_placeholder">Rechercher dans les paramètres</string>
     <string name="tweaks_sources_add_a_host">Ajouter un hôte Forgejo ou Gitea</string>
     <string name="tweaks_sources_added_hosts_section">Hôtes ajoutés</string>
@@ -1222,7 +1224,7 @@
     <string name="tweaks_sources_intro_title">Où l'application cherche les dépôts</string>
     <string name="tweaks_sources_mirror_default">Par défaut (github.com)</string>
     <string name="tweaks_storage_downloaded_apks_body">Nous conservons les installateurs pour que les mises à jour reprennent rapidement.</string>
-    <string name="tweaks_storage_downloaded_apks_clear">Vider</string>
+    <string name="tweaks_storage_downloaded_apks_clear">Effacer</string>
     <string name="tweaks_storage_downloaded_apks_title">APK téléchargés</string>
     <string name="tweaks_storage_empty_size">0 o</string>
     <string name="tweaks_storage_using_label">Utilisation : %1$s</string>
@@ -1247,7 +1249,7 @@
     <string name="auth_more_signin_options">Plus d'options de connexion</string>
     <string name="auth_hide_signin_options">Masquer les options</string>
     <string name="tweaks_sources_platforms_title">Plateformes de découverte</string>
-    <string name="tweaks_sources_platforms_body">Filtre le fil d&#39;accueil par plateforme. Laisse tout désactivé pour tout voir.</string>
+    <string name="tweaks_sources_platforms_body">Filtrez le fil d&#39;accueil par plateforme. Laissez tout désactivé pour tout voir.</string>
     <string name="profile_entry_about_title">À propos</string>
     <string name="profile_entry_about_subtitle">Version, communauté, mentions légales</string>
     <string name="filter_with_installable">Installable ici</string>
@@ -1258,4 +1260,42 @@
     <string name="interval_weekly">Hebdomadaire</string>
     <string name="interval_biweekly">Toutes les 2 semaines</string>
     <string name="interval_monthly">Tous les 30 jours</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Choisissez votre palette</string>
+    <string name="onboarding_palette_subtitle">Quatre palettes × Clair, Sombre, AMOLED, Système.</string>
+    <string name="onboarding_signin_subtitle">Vos étoiles, votre profil et une marge sur la limite de requêtes. Facultatif — passez pour naviguer anonymement.</string>
+    <string name="onboarding_signin_button">Se connecter</string>
+    <string name="onboarding_permissions_title">Deux autorisations rapides</string>
+    <string name="onboarding_permissions_subtitle">Les deux sont facultatives. Vous pourrez les modifier plus tard dans les Réglages.</string>
+    <string name="onboarding_permission_notifications">Notifications</string>
+    <string name="onboarding_permission_notifications_desc">Alertes de mise à jour et progression des installations</string>
+    <string name="onboarding_permission_install">Installer des applications inconnues</string>
+    <string name="onboarding_permission_install_desc">Nécessaire pour installer des APK hors de Play</string>
+    <string name="onboarding_permission_granted">Accordée</string>
+    <string name="onboarding_permission_allow">Autoriser</string>
+    <string name="onboarding_skip">Passer</string>
+    <string name="onboarding_get_started">Commencer</string>
+    <string name="onboarding_next">Suivant</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Activité de contribution</string>
+    <string name="dev_profile_contributions_this_year">%1$s cette année</string>
+    <string name="dev_profile_contributions_load_failed">Impossible de charger les contributions.</string>
+    <string name="dev_profile_contributions_less">Moins</string>
+    <string name="dev_profile_contributions_more">Plus</string>
+    <string name="dev_profile_org_badge">Orga</string>
+
+    <!-- Common -->
+    <string name="loading">Chargement…</string>
+    <string name="failed_to_load">Échec du chargement</string>
+    <string name="failed_to_load_details">Échec du chargement des détails</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Impossible de charger les licences.</string>
+    <string name="tweaks_app_info_website">Site web</string>
+    <string name="tweaks_clear_downloads_failed">Échec de la suppression des téléchargements</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Saisissez un nom d'hôte valide (ex. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Impossible d'enregistrer l'hôte. Réessayez.</string>
+    <string name="tweaks_custom_forge_remove_failed">Impossible de supprimer l'hôte. Réessayez.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-fr/strings-fr.xml
@@ -1280,7 +1280,7 @@
 
     <!-- Developer profile -->
     <string name="dev_profile_contribution_activity">Activité de contribution</string>
-    <string name="dev_profile_contributions_this_year">%1$s cette année</string>
+    <string name="dev_profile_contributions_this_year">%1$d cette année</string>
     <string name="dev_profile_contributions_load_failed">Impossible de charger les contributions.</string>
     <string name="dev_profile_contributions_less">Moins</string>
     <string name="dev_profile_contributions_more">Plus</string>

--- a/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
+++ b/core/presentation/src/commonMain/composeResources/values-hi/strings-hi.xml
@@ -1294,4 +1294,42 @@
     <string name="interval_weekly">साप्ताहिक</string>
     <string name="interval_biweekly">हर 2 सप्ताह</string>
     <string name="interval_monthly">हर 30 दिन</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">अपना पैलेट चुनें</string>
+    <string name="onboarding_palette_subtitle">चार पैलेट × हल्का, डार्क, AMOLED, सिस्टम।</string>
+    <string name="onboarding_signin_subtitle">स्टार्स, प्रोफ़ाइल और ज़्यादा रेट-लिमिट हेडरूम। वैकल्पिक — गुमनाम रूप से ब्राउज़ करने के लिए छोड़ें।</string>
+    <string name="onboarding_signin_button">साइन इन</string>
+    <string name="onboarding_permissions_title">दो छोटे प्रॉम्प्ट</string>
+    <string name="onboarding_permissions_subtitle">दोनों वैकल्पिक हैं। इन्हें बाद में ट्वीक्स में बदल सकते हैं।</string>
+    <string name="onboarding_permission_notifications">सूचनाएँ</string>
+    <string name="onboarding_permission_notifications_desc">अपडेट अलर्ट और इंस्टॉल प्रगति</string>
+    <string name="onboarding_permission_install">अज्ञात ऐप्स इंस्टॉल करें</string>
+    <string name="onboarding_permission_install_desc">Play के बाहर APK इंस्टॉल करने के लिए आवश्यक</string>
+    <string name="onboarding_permission_granted">स्वीकृत</string>
+    <string name="onboarding_permission_allow">अनुमति दें</string>
+    <string name="onboarding_skip">छोड़ें</string>
+    <string name="onboarding_get_started">शुरू करें</string>
+    <string name="onboarding_next">आगे</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">योगदान गतिविधि</string>
+    <string name="dev_profile_contributions_this_year">इस साल %1$d</string>
+    <string name="dev_profile_contributions_load_failed">योगदान लोड नहीं हो सके।</string>
+    <string name="dev_profile_contributions_less">कम</string>
+    <string name="dev_profile_contributions_more">ज़्यादा</string>
+    <string name="dev_profile_org_badge">संगठन</string>
+
+    <!-- Common -->
+    <string name="loading">लोड हो रहा है…</string>
+    <string name="failed_to_load">लोड करने में विफल</string>
+    <string name="failed_to_load_details">विवरण लोड करने में विफल</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">लाइसेंस लोड नहीं हो सके।</string>
+    <string name="tweaks_app_info_website">वेबसाइट</string>
+    <string name="tweaks_clear_downloads_failed">डाउनलोड साफ़ करने में विफल</string>
+    <string name="tweaks_custom_forge_invalid_hostname">मान्य होस्टनेम दर्ज करें (जैसे forgejo.example.com)।</string>
+    <string name="tweaks_custom_forge_save_failed">होस्ट सहेजा नहीं जा सका। पुनः प्रयास करें।</string>
+    <string name="tweaks_custom_forge_remove_failed">होस्ट हटाया नहीं जा सका। पुनः प्रयास करें।</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
+++ b/core/presentation/src/commonMain/composeResources/values-it/strings-it.xml
@@ -1292,4 +1292,42 @@
     <string name="interval_weekly">Settimanale</string>
     <string name="interval_biweekly">Ogni 2 settimane</string>
     <string name="interval_monthly">Ogni 30 giorni</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Scegli la tua palette</string>
+    <string name="onboarding_palette_subtitle">Quattro palette × Chiaro, Scuro, AMOLED, Sistema.</string>
+    <string name="onboarding_signin_subtitle">Stelle, profilo e più margine sul limite di richieste. Facoltativo — salta per navigare in anonimo.</string>
+    <string name="onboarding_signin_button">Accedi</string>
+    <string name="onboarding_permissions_title">Due richieste veloci</string>
+    <string name="onboarding_permissions_subtitle">Entrambe facoltative. Puoi cambiarle in seguito da Modifiche.</string>
+    <string name="onboarding_permission_notifications">Notifiche</string>
+    <string name="onboarding_permission_notifications_desc">Avvisi di aggiornamento e avanzamento dell'installazione</string>
+    <string name="onboarding_permission_install">Installa app sconosciute</string>
+    <string name="onboarding_permission_install_desc">Necessario per installare APK al di fuori di Play</string>
+    <string name="onboarding_permission_granted">Concesso</string>
+    <string name="onboarding_permission_allow">Consenti</string>
+    <string name="onboarding_skip">Salta</string>
+    <string name="onboarding_get_started">Inizia</string>
+    <string name="onboarding_next">Avanti</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Attività dei contributi</string>
+    <string name="dev_profile_contributions_this_year">%1$d quest'anno</string>
+    <string name="dev_profile_contributions_load_failed">Impossibile caricare i contributi.</string>
+    <string name="dev_profile_contributions_less">Meno</string>
+    <string name="dev_profile_contributions_more">Più</string>
+    <string name="dev_profile_org_badge">Org</string>
+
+    <!-- Common -->
+    <string name="loading">Caricamento…</string>
+    <string name="failed_to_load">Impossibile caricare</string>
+    <string name="failed_to_load_details">Impossibile caricare i dettagli</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Impossibile caricare le licenze.</string>
+    <string name="tweaks_app_info_website">Sito web</string>
+    <string name="tweaks_clear_downloads_failed">Impossibile eliminare i download</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Inserisci un hostname valido (es. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Impossibile salvare l'host. Riprova.</string>
+    <string name="tweaks_custom_forge_remove_failed">Impossibile rimuovere l'host. Riprova.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ja/strings-ja.xml
@@ -1248,4 +1248,42 @@
     <string name="interval_weekly">毎週</string>
     <string name="interval_biweekly">2 週間ごと</string>
     <string name="interval_monthly">30 日ごと</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">パレットを選択</string>
+    <string name="onboarding_palette_subtitle">4 つのパレット × ライト、ダーク、AMOLED、システム。</string>
+    <string name="onboarding_signin_subtitle">スター、プロフィール、レート制限の余裕。任意です — スキップして匿名で閲覧できます。</string>
+    <string name="onboarding_signin_button">サインイン</string>
+    <string name="onboarding_permissions_title">2 つの簡単な確認</string>
+    <string name="onboarding_permissions_subtitle">どちらも任意です。あとから「調整」で変更できます。</string>
+    <string name="onboarding_permission_notifications">通知</string>
+    <string name="onboarding_permission_notifications_desc">更新の通知とインストールの進捗</string>
+    <string name="onboarding_permission_install">提供元不明のアプリのインストール</string>
+    <string name="onboarding_permission_install_desc">Play 以外の APK をインストールするのに必要</string>
+    <string name="onboarding_permission_granted">許可済み</string>
+    <string name="onboarding_permission_allow">許可</string>
+    <string name="onboarding_skip">スキップ</string>
+    <string name="onboarding_get_started">始める</string>
+    <string name="onboarding_next">次へ</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">コントリビューション</string>
+    <string name="dev_profile_contributions_this_year">今年 %1$d 件</string>
+    <string name="dev_profile_contributions_load_failed">コントリビューションを読み込めませんでした。</string>
+    <string name="dev_profile_contributions_less">少ない</string>
+    <string name="dev_profile_contributions_more">多い</string>
+    <string name="dev_profile_org_badge">組織</string>
+
+    <!-- Common -->
+    <string name="loading">読み込み中…</string>
+    <string name="failed_to_load">読み込みに失敗しました</string>
+    <string name="failed_to_load_details">詳細の読み込みに失敗しました</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">ライセンスを読み込めませんでした。</string>
+    <string name="tweaks_app_info_website">ウェブサイト</string>
+    <string name="tweaks_clear_downloads_failed">ダウンロードの消去に失敗しました</string>
+    <string name="tweaks_custom_forge_invalid_hostname">有効なホスト名を入力してください（例: forgejo.example.com）。</string>
+    <string name="tweaks_custom_forge_save_failed">ホストを保存できませんでした。再試行してください。</string>
+    <string name="tweaks_custom_forge_remove_failed">ホストを削除できませんでした。再試行してください。</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ko/strings-ko.xml
@@ -1278,4 +1278,42 @@
     <string name="interval_weekly">매주</string>
     <string name="interval_biweekly">2주마다</string>
     <string name="interval_monthly">30일마다</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">팔레트를 선택하세요</string>
+    <string name="onboarding_palette_subtitle">4가지 팔레트 × 라이트, 다크, AMOLED, 시스템.</string>
+    <string name="onboarding_signin_subtitle">별표, 프로필, 그리고 넉넉한 요청 한도. 선택 사항이며 — 건너뛰면 익명으로 둘러볼 수 있습니다.</string>
+    <string name="onboarding_signin_button">로그인</string>
+    <string name="onboarding_permissions_title">두 가지 간단한 권한 요청</string>
+    <string name="onboarding_permissions_subtitle">둘 다 선택 사항입니다. 나중에 조정에서 변경할 수 있습니다.</string>
+    <string name="onboarding_permission_notifications">알림</string>
+    <string name="onboarding_permission_notifications_desc">업데이트 알림 및 설치 진행 상황</string>
+    <string name="onboarding_permission_install">알 수 없는 앱 설치</string>
+    <string name="onboarding_permission_install_desc">Play 외부에서 APK를 설치하려면 필요합니다</string>
+    <string name="onboarding_permission_granted">허용됨</string>
+    <string name="onboarding_permission_allow">허용</string>
+    <string name="onboarding_skip">건너뛰기</string>
+    <string name="onboarding_get_started">시작하기</string>
+    <string name="onboarding_next">다음</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">기여 활동</string>
+    <string name="dev_profile_contributions_this_year">올해 %1$d회</string>
+    <string name="dev_profile_contributions_load_failed">기여 내역을 불러올 수 없습니다.</string>
+    <string name="dev_profile_contributions_less">적음</string>
+    <string name="dev_profile_contributions_more">많음</string>
+    <string name="dev_profile_org_badge">조직</string>
+
+    <!-- Common -->
+    <string name="loading">불러오는 중…</string>
+    <string name="failed_to_load">불러오지 못했습니다</string>
+    <string name="failed_to_load_details">세부 정보를 불러오지 못했습니다</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">라이선스를 불러올 수 없습니다.</string>
+    <string name="tweaks_app_info_website">웹사이트</string>
+    <string name="tweaks_clear_downloads_failed">다운로드를 지우지 못했습니다</string>
+    <string name="tweaks_custom_forge_invalid_hostname">유효한 호스트명을 입력하세요 (예: forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">호스트를 저장할 수 없습니다. 다시 시도하세요.</string>
+    <string name="tweaks_custom_forge_remove_failed">호스트를 제거할 수 없습니다. 다시 시도하세요.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
+++ b/core/presentation/src/commonMain/composeResources/values-pl/strings-pl.xml
@@ -1287,4 +1287,42 @@
     <string name="interval_weekly">Co tydzień</string>
     <string name="interval_biweekly">Co 2 tygodnie</string>
     <string name="interval_monthly">Co 30 dni</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Wybierz swoją paletę</string>
+    <string name="onboarding_palette_subtitle">Cztery palety × Jasny, Ciemny, AMOLED, Systemowy.</string>
+    <string name="onboarding_signin_subtitle">Gwiazdki, profil i wyższe limity zapytań. Opcjonalne — pomiń, aby przeglądać anonimowo.</string>
+    <string name="onboarding_signin_button">Zaloguj się</string>
+    <string name="onboarding_permissions_title">Dwa szybkie pytania</string>
+    <string name="onboarding_permissions_subtitle">Oba opcjonalne. Możesz je później zmienić w Ustawieniach.</string>
+    <string name="onboarding_permission_notifications">Powiadomienia</string>
+    <string name="onboarding_permission_notifications_desc">Alerty o aktualizacjach i postęp instalacji</string>
+    <string name="onboarding_permission_install">Instalowanie nieznanych aplikacji</string>
+    <string name="onboarding_permission_install_desc">Wymagane do instalacji APK spoza Play</string>
+    <string name="onboarding_permission_granted">Przyznano</string>
+    <string name="onboarding_permission_allow">Zezwól</string>
+    <string name="onboarding_skip">Pomiń</string>
+    <string name="onboarding_get_started">Rozpocznij</string>
+    <string name="onboarding_next">Dalej</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Aktywność wkładu</string>
+    <string name="dev_profile_contributions_this_year">%1$d w tym roku</string>
+    <string name="dev_profile_contributions_load_failed">Nie udało się załadować wkładu.</string>
+    <string name="dev_profile_contributions_less">Mniej</string>
+    <string name="dev_profile_contributions_more">Więcej</string>
+    <string name="dev_profile_org_badge">Org</string>
+
+    <!-- Common -->
+    <string name="loading">Ładowanie…</string>
+    <string name="failed_to_load">Nie udało się załadować</string>
+    <string name="failed_to_load_details">Nie udało się załadować szczegółów</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Nie udało się załadować licencji.</string>
+    <string name="tweaks_app_info_website">Strona internetowa</string>
+    <string name="tweaks_clear_downloads_failed">Nie udało się wyczyścić pobrań</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Wpisz prawidłową nazwę hosta (np. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Nie można zapisać hosta. Spróbuj ponownie.</string>
+    <string name="tweaks_custom_forge_remove_failed">Nie można usunąć hosta. Spróbuj ponownie.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1293,7 +1293,7 @@
     <string name="onboarding_palette_subtitle">Четыре палитры × Светлая, Тёмная, AMOLED, Системная.</string>
     <string name="onboarding_signin_subtitle">Звёзды, профиль и более высокий лимит запросов. Необязательно — пропусти, чтобы просматривать анонимно.</string>
     <string name="onboarding_signin_button">Войти</string>
-    <string name="onboarding_permissions_title">Два быстрых запроса</string>
+    <string name="onboarding_permissions_title">Два быстрых разрешения</string>
     <string name="onboarding_permissions_subtitle">Оба необязательны. Их можно изменить позже в Настройках.</string>
     <string name="onboarding_permission_notifications">Уведомления</string>
     <string name="onboarding_permission_notifications_desc">Оповещения об обновлениях и ход установки</string>
@@ -1307,11 +1307,11 @@
 
     <!-- Developer profile -->
     <string name="dev_profile_contribution_activity">Активность вкладов</string>
-    <string name="dev_profile_contributions_this_year">%1$d за этот год</string>
+    <string name="dev_profile_contributions_this_year">%1$d в этом году</string>
     <string name="dev_profile_contributions_load_failed">Не удалось загрузить вклады.</string>
     <string name="dev_profile_contributions_less">Меньше</string>
     <string name="dev_profile_contributions_more">Больше</string>
-    <string name="dev_profile_org_badge">Орг</string>
+    <string name="dev_profile_org_badge">Организация</string>
 
     <!-- Common -->
     <string name="loading">Загрузка…</string>

--- a/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
+++ b/core/presentation/src/commonMain/composeResources/values-ru/strings-ru.xml
@@ -1287,4 +1287,42 @@
     <string name="interval_weekly">Еженедельно</string>
     <string name="interval_biweekly">Раз в 2 недели</string>
     <string name="interval_monthly">Каждые 30 дней</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Выбери палитру</string>
+    <string name="onboarding_palette_subtitle">Четыре палитры × Светлая, Тёмная, AMOLED, Системная.</string>
+    <string name="onboarding_signin_subtitle">Звёзды, профиль и более высокий лимит запросов. Необязательно — пропусти, чтобы просматривать анонимно.</string>
+    <string name="onboarding_signin_button">Войти</string>
+    <string name="onboarding_permissions_title">Два быстрых запроса</string>
+    <string name="onboarding_permissions_subtitle">Оба необязательны. Их можно изменить позже в Настройках.</string>
+    <string name="onboarding_permission_notifications">Уведомления</string>
+    <string name="onboarding_permission_notifications_desc">Оповещения об обновлениях и ход установки</string>
+    <string name="onboarding_permission_install">Установка неизвестных приложений</string>
+    <string name="onboarding_permission_install_desc">Нужно для установки APK вне Play</string>
+    <string name="onboarding_permission_granted">Предоставлено</string>
+    <string name="onboarding_permission_allow">Разрешить</string>
+    <string name="onboarding_skip">Пропустить</string>
+    <string name="onboarding_get_started">Начать</string>
+    <string name="onboarding_next">Далее</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Активность вкладов</string>
+    <string name="dev_profile_contributions_this_year">%1$d за этот год</string>
+    <string name="dev_profile_contributions_load_failed">Не удалось загрузить вклады.</string>
+    <string name="dev_profile_contributions_less">Меньше</string>
+    <string name="dev_profile_contributions_more">Больше</string>
+    <string name="dev_profile_org_badge">Орг</string>
+
+    <!-- Common -->
+    <string name="loading">Загрузка…</string>
+    <string name="failed_to_load">Не удалось загрузить</string>
+    <string name="failed_to_load_details">Не удалось загрузить детали</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Не удалось загрузить лицензии.</string>
+    <string name="tweaks_app_info_website">Веб-сайт</string>
+    <string name="tweaks_clear_downloads_failed">Не удалось очистить загрузки</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Введи корректное имя хоста (например, forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Не удалось сохранить хост. Попробуй снова.</string>
+    <string name="tweaks_custom_forge_remove_failed">Не удалось удалить хост. Попробуй снова.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1295,7 +1295,7 @@
     <string name="onboarding_palette_subtitle">Dört palet × Aydınlık, Karanlık, AMOLED, Sistem.</string>
     <string name="onboarding_signin_subtitle">Yıldızlar, profil ve daha geniş hız sınırı. İsteğe bağlı — anonim gezinmek için atlayın.</string>
     <string name="onboarding_signin_button">Giriş yap</string>
-    <string name="onboarding_permissions_title">İki hızlı istek</string>
+    <string name="onboarding_permissions_title">İki hızlı izin</string>
     <string name="onboarding_permissions_subtitle">İkisi de isteğe bağlı. Bunları daha sonra İnce Ayarlar'dan değiştirebilirsiniz.</string>
     <string name="onboarding_permission_notifications">Bildirimler</string>
     <string name="onboarding_permission_notifications_desc">Güncelleme uyarıları ve kurulum ilerlemesi</string>
@@ -1309,7 +1309,7 @@
 
     <!-- Developer profile -->
     <string name="dev_profile_contribution_activity">Katkı etkinliği</string>
-    <string name="dev_profile_contributions_this_year">Bu yıl %1$d</string>
+    <string name="dev_profile_contributions_this_year">Bu yıl %1$d katkı</string>
     <string name="dev_profile_contributions_load_failed">Katkılar yüklenemedi.</string>
     <string name="dev_profile_contributions_less">Az</string>
     <string name="dev_profile_contributions_more">Çok</string>

--- a/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
+++ b/core/presentation/src/commonMain/composeResources/values-tr/strings-tr.xml
@@ -1289,4 +1289,42 @@
     <string name="interval_weekly">Haftalık</string>
     <string name="interval_biweekly">2 haftada bir</string>
     <string name="interval_monthly">30 günde bir</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Paletini seç</string>
+    <string name="onboarding_palette_subtitle">Dört palet × Aydınlık, Karanlık, AMOLED, Sistem.</string>
+    <string name="onboarding_signin_subtitle">Yıldızlar, profil ve daha geniş hız sınırı. İsteğe bağlı — anonim gezinmek için atlayın.</string>
+    <string name="onboarding_signin_button">Giriş yap</string>
+    <string name="onboarding_permissions_title">İki hızlı istek</string>
+    <string name="onboarding_permissions_subtitle">İkisi de isteğe bağlı. Bunları daha sonra İnce Ayarlar'dan değiştirebilirsiniz.</string>
+    <string name="onboarding_permission_notifications">Bildirimler</string>
+    <string name="onboarding_permission_notifications_desc">Güncelleme uyarıları ve kurulum ilerlemesi</string>
+    <string name="onboarding_permission_install">Bilinmeyen uygulamaları yükle</string>
+    <string name="onboarding_permission_install_desc">Play dışındaki APK'ları yüklemek için gerekli</string>
+    <string name="onboarding_permission_granted">Verildi</string>
+    <string name="onboarding_permission_allow">İzin ver</string>
+    <string name="onboarding_skip">Atla</string>
+    <string name="onboarding_get_started">Başla</string>
+    <string name="onboarding_next">İleri</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Katkı etkinliği</string>
+    <string name="dev_profile_contributions_this_year">Bu yıl %1$d</string>
+    <string name="dev_profile_contributions_load_failed">Katkılar yüklenemedi.</string>
+    <string name="dev_profile_contributions_less">Az</string>
+    <string name="dev_profile_contributions_more">Çok</string>
+    <string name="dev_profile_org_badge">Kuruluş</string>
+
+    <!-- Common -->
+    <string name="loading">Yükleniyor…</string>
+    <string name="failed_to_load">Yükleme başarısız</string>
+    <string name="failed_to_load_details">Ayrıntılar yüklenemedi</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Lisanslar yüklenemedi.</string>
+    <string name="tweaks_app_info_website">Web sitesi</string>
+    <string name="tweaks_clear_downloads_failed">İndirmeler temizlenemedi</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Geçerli bir host adı girin (ör. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Host kaydedilemedi. Tekrar deneyin.</string>
+    <string name="tweaks_custom_forge_remove_failed">Host kaldırılamadı. Tekrar deneyin.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
+++ b/core/presentation/src/commonMain/composeResources/values-zh-rCN/strings-zh-rCN.xml
@@ -1251,4 +1251,42 @@
     <string name="interval_weekly">每周</string>
     <string name="interval_biweekly">每 2 周</string>
     <string name="interval_monthly">每 30 天</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">选择你的配色</string>
+    <string name="onboarding_palette_subtitle">四种配色 × 浅色、深色、AMOLED、跟随系统。</string>
+    <string name="onboarding_signin_subtitle">星标、个人资料，以及更高的请求限额。可选 — 跳过即可匿名浏览。</string>
+    <string name="onboarding_signin_button">登录</string>
+    <string name="onboarding_permissions_title">两个快速授权</string>
+    <string name="onboarding_permissions_subtitle">两者均为可选。你随时可以在“调整”中更改。</string>
+    <string name="onboarding_permission_notifications">通知</string>
+    <string name="onboarding_permission_notifications_desc">更新提醒与安装进度</string>
+    <string name="onboarding_permission_install">安装未知应用</string>
+    <string name="onboarding_permission_install_desc">在 Play 之外安装 APK 所必需</string>
+    <string name="onboarding_permission_granted">已授权</string>
+    <string name="onboarding_permission_allow">允许</string>
+    <string name="onboarding_skip">跳过</string>
+    <string name="onboarding_get_started">开始使用</string>
+    <string name="onboarding_next">下一步</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">贡献活动</string>
+    <string name="dev_profile_contributions_this_year">今年 %1$d 次</string>
+    <string name="dev_profile_contributions_load_failed">无法加载贡献记录。</string>
+    <string name="dev_profile_contributions_less">较少</string>
+    <string name="dev_profile_contributions_more">较多</string>
+    <string name="dev_profile_org_badge">组织</string>
+
+    <!-- Common -->
+    <string name="loading">正在加载…</string>
+    <string name="failed_to_load">加载失败</string>
+    <string name="failed_to_load_details">加载详情失败</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">无法加载许可证。</string>
+    <string name="tweaks_app_info_website">网站</string>
+    <string name="tweaks_clear_downloads_failed">清除下载失败</string>
+    <string name="tweaks_custom_forge_invalid_hostname">请输入有效的主机名（例如 forgejo.example.com）。</string>
+    <string name="tweaks_custom_forge_save_failed">无法保存该主机。请重试。</string>
+    <string name="tweaks_custom_forge_remove_failed">无法移除该主机。请重试。</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1325,4 +1325,42 @@
     <string name="tweaks_licenses_title">Open source licenses</string>
     <string name="tweaks_licenses_intro_title">GitHub Store stands on these libraries.</string>
     <string name="tweaks_licenses_intro_body">Tap any entry to open its project page.</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_palette_title">Pick your palette</string>
+    <string name="onboarding_palette_subtitle">Four palettes × Light, Dark, AMOLED, System.</string>
+    <string name="onboarding_signin_subtitle">Stars, profile, and rate-limit headroom. Optional — skip to browse anonymously.</string>
+    <string name="onboarding_signin_button">Sign in</string>
+    <string name="onboarding_permissions_title">Two quick prompts</string>
+    <string name="onboarding_permissions_subtitle">Both optional. You can flip these later in Tweaks.</string>
+    <string name="onboarding_permission_notifications">Notifications</string>
+    <string name="onboarding_permission_notifications_desc">Update alerts and install progress</string>
+    <string name="onboarding_permission_install">Install unknown apps</string>
+    <string name="onboarding_permission_install_desc">Required to install APKs outside Play</string>
+    <string name="onboarding_permission_granted">Granted</string>
+    <string name="onboarding_permission_allow">Allow</string>
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_get_started">Get started</string>
+    <string name="onboarding_next">Next</string>
+
+    <!-- Developer profile -->
+    <string name="dev_profile_contribution_activity">Contribution activity</string>
+    <string name="dev_profile_contributions_this_year">%1$s this year</string>
+    <string name="dev_profile_contributions_load_failed">Couldn't load contributions.</string>
+    <string name="dev_profile_contributions_less">Less</string>
+    <string name="dev_profile_contributions_more">More</string>
+    <string name="dev_profile_org_badge">Org</string>
+
+    <!-- Common -->
+    <string name="loading">Loading…</string>
+    <string name="failed_to_load">Failed to load</string>
+    <string name="failed_to_load_details">Failed to load details</string>
+
+    <!-- Tweaks: licenses / app info / custom forges -->
+    <string name="tweaks_licenses_load_failed">Couldn't load licenses.</string>
+    <string name="tweaks_app_info_website">Website</string>
+    <string name="tweaks_clear_downloads_failed">Failed to clear downloads</string>
+    <string name="tweaks_custom_forge_invalid_hostname">Enter a valid hostname (e.g. forgejo.example.com).</string>
+    <string name="tweaks_custom_forge_save_failed">Couldn't save the host. Try again.</string>
+    <string name="tweaks_custom_forge_remove_failed">Couldn't remove the host. Try again.</string>
 </resources>

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1345,7 +1345,7 @@
 
     <!-- Developer profile -->
     <string name="dev_profile_contribution_activity">Contribution activity</string>
-    <string name="dev_profile_contributions_this_year">%1$s this year</string>
+    <string name="dev_profile_contributions_this_year">%1$d this year</string>
     <string name="dev_profile_contributions_load_failed">Couldn't load contributions.</string>
     <string name="dev_profile_contributions_less">Less</string>
     <string name="dev_profile_contributions_more">More</string>

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsViewModel.kt
@@ -82,6 +82,7 @@ import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.added_to_favourites
 import zed.rainxch.githubstore.core.presentation.res.details_unlink_external_app_failure
 import zed.rainxch.githubstore.core.presentation.res.details_unlink_external_app_success
+import zed.rainxch.githubstore.core.presentation.res.failed_to_load_details
 import zed.rainxch.githubstore.core.presentation.res.failed_to_open_app
 import zed.rainxch.githubstore.core.presentation.res.failed_to_share_link
 import zed.rainxch.githubstore.core.presentation.res.failed_to_uninstall
@@ -2497,7 +2498,7 @@ class DetailsViewModel(
                 _state.value =
                     _state.value.copy(
                         isLoading = false,
-                        errorMessage = t.message ?: "Failed to load details",
+                        errorMessage = t.message ?: getString(Res.string.failed_to_load_details),
                     )
             }
         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -46,6 +46,7 @@ import zed.rainxch.details.presentation.utils.rememberMarkdownTypography
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.cd_back
 import zed.rainxch.githubstore.core.presentation.res.details_about_screen_title
+import zed.rainxch.githubstore.core.presentation.res.retry
 
 @Composable
 fun AboutRoot(
@@ -124,7 +125,7 @@ private fun AboutScreen(
                     )
                     Spacer(Modifier.size(8.dp))
                     Text(
-                        text = "Retry",
+                        text = stringResource(Res.string.retry),
                         style = MaterialTheme.typography.labelLarge,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/DetailsAboutViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/DetailsAboutViewModel.kt
@@ -6,10 +6,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import zed.rainxch.details.domain.repository.DetailsRepository
 import zed.rainxch.details.domain.repository.TranslationRepository
 import zed.rainxch.details.presentation.model.SupportedLanguages
 import zed.rainxch.details.presentation.model.TranslationState
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.failed_to_load
+import zed.rainxch.githubstore.core.presentation.res.translation_failed
 
 class DetailsAboutViewModel(
     private val repositoryId: Long,
@@ -67,7 +71,7 @@ class DetailsAboutViewModel(
                     it.copy(
                         translation = it.translation.copy(
                             isTranslating = false,
-                            error = e.message ?: "Translation failed",
+                            error = e.message ?: getString(Res.string.translation_failed),
                         ),
                     )
                 }
@@ -125,7 +129,7 @@ class DetailsAboutViewModel(
                     )
                 }
             }.onFailure { e ->
-                _state.update { it.copy(isLoading = false, errorMessage = e.message ?: "Failed to load") }
+                _state.update { it.copy(isLoading = false, errorMessage = e.message ?: getString(Res.string.failed_to_load)) }
             }
         }
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/whatsnew/DetailsWhatsNewViewModel.kt
@@ -6,10 +6,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import zed.rainxch.details.domain.repository.DetailsRepository
 import zed.rainxch.details.domain.repository.TranslationRepository
 import zed.rainxch.details.presentation.model.SupportedLanguages
 import zed.rainxch.details.presentation.model.TranslationState
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.failed_to_load
+import zed.rainxch.githubstore.core.presentation.res.translation_failed
 
 class DetailsWhatsNewViewModel(
     private val repositoryId: Long,
@@ -68,7 +72,7 @@ class DetailsWhatsNewViewModel(
                     it.copy(
                         translation = it.translation.copy(
                             isTranslating = false,
-                            error = e.message ?: "Translation failed",
+                            error = e.message ?: getString(Res.string.translation_failed),
                         ),
                     )
                 }
@@ -123,7 +127,7 @@ class DetailsWhatsNewViewModel(
                     )
                 }
             }.onFailure { e ->
-                _state.update { it.copy(isLoading = false, errorMessage = e.message ?: "Failed to load") }
+                _state.update { it.copy(isLoading = false, errorMessage = e.message ?: getString(Res.string.failed_to_load)) }
             }
         }
     }

--- a/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/components/ContributionCalendar.kt
+++ b/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/components/ContributionCalendar.kt
@@ -30,9 +30,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.presentation.theme.tokens.Radii
 import zed.rainxch.devprofile.domain.model.ContributionCalendar
 import zed.rainxch.devprofile.domain.model.ContributionDay
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_contribution_activity
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_contributions_load_failed
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_contributions_less
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_contributions_more
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_contributions_this_year
+import zed.rainxch.githubstore.core.presentation.res.loading
 
 private val CELL_SIZE = 11.dp
 private val CELL_GAP = 3.dp
@@ -56,7 +64,7 @@ fun ContributionCalendarCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "Contribution activity",
+                    text = stringResource(Res.string.dev_profile_contribution_activity),
                     style = MaterialTheme.typography.titleSmall.copy(
                         fontWeight = FontWeight.SemiBold,
                     ),
@@ -64,7 +72,7 @@ fun ContributionCalendarCard(
                 )
                 contributions?.let {
                     Text(
-                        text = "${it.totalLastYear} this year",
+                        text = stringResource(Res.string.dev_profile_contributions_this_year, it.totalLastYear),
                         style = MaterialTheme.typography.labelSmall.copy(
                             fontFamily = FontFamily.Monospace,
                         ),
@@ -76,14 +84,14 @@ fun ContributionCalendarCard(
             when {
                 isLoading && contributions == null -> {
                     Text(
-                        text = "Loading…",
+                        text = stringResource(Res.string.loading),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 contributions == null -> {
                     Text(
-                        text = "Couldn't load contributions.",
+                        text = stringResource(Res.string.dev_profile_contributions_load_failed),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -155,7 +163,7 @@ private fun CalendarGrid(days: List<ContributionDay>) {
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(
-            text = "Less",
+            text = stringResource(Res.string.dev_profile_contributions_less),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -168,7 +176,7 @@ private fun CalendarGrid(days: List<ContributionDay>) {
             )
         }
         Text(
-            text = "More",
+            text = stringResource(Res.string.dev_profile_contributions_more),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/components/ProfileInfoCard.kt
+++ b/feature/dev-profile/presentation/src/commonMain/kotlin/zed/rainxch/devprofile/presentation/components/ProfileInfoCard.kt
@@ -45,10 +45,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil3.CoilImage
+import org.jetbrains.compose.resources.stringResource
 import zed.rainxch.core.presentation.theme.tokens.Radii
 import zed.rainxch.core.presentation.utils.formatCount
 import zed.rainxch.devprofile.domain.model.DeveloperProfile
 import zed.rainxch.devprofile.presentation.DeveloperProfileAction
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.dev_profile_org_badge
+import zed.rainxch.githubstore.core.presentation.res.followers
+import zed.rainxch.githubstore.core.presentation.res.following
+import zed.rainxch.githubstore.core.presentation.res.profile_repos
 
 private val MentionRegex = Regex("(?<![A-Za-z0-9-])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?)")
 
@@ -170,11 +176,11 @@ private fun MetricsStrip(repos: Int, followers: Int, following: Int) {
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Metric(value = formatCount(repos), label = "Repos", modifier = Modifier.weight(1f))
+        Metric(value = formatCount(repos), label = stringResource(Res.string.profile_repos), modifier = Modifier.weight(1f))
         MetricDivider()
-        Metric(value = formatCount(followers), label = "Followers", modifier = Modifier.weight(1f))
+        Metric(value = formatCount(followers), label = stringResource(Res.string.followers), modifier = Modifier.weight(1f))
         MetricDivider()
-        Metric(value = formatCount(following), label = "Following", modifier = Modifier.weight(1f))
+        Metric(value = formatCount(following), label = stringResource(Res.string.following), modifier = Modifier.weight(1f))
     }
 }
 
@@ -220,7 +226,7 @@ private fun OrgPill() {
         color = MaterialTheme.colorScheme.tertiaryContainer,
     ) {
         Text(
-            text = "Org",
+            text = stringResource(Res.string.dev_profile_org_badge),
             style = MaterialTheme.typography.labelSmall.copy(
                 fontWeight = FontWeight.SemiBold,
             ),

--- a/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/categorylist/CategoryListViewModel.kt
+++ b/feature/home/presentation/src/commonMain/kotlin/zed/rainxch/home/presentation/categorylist/CategoryListViewModel.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.failed_to_load
 import zed.rainxch.home.domain.model.HomeCategory
 import zed.rainxch.home.domain.repository.HomeRepository
 import zed.rainxch.home.presentation.model.toHomeRepoCardUi
@@ -106,7 +109,7 @@ class CategoryListViewModel(
                         it.copy(
                             isLoading = false,
                             isLoadingMore = false,
-                            errorMessage = e.message ?: "Failed to load",
+                            errorMessage = e.message ?: getString(Res.string.failed_to_load),
                         )
                     }
                 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/TweaksViewModel.kt
@@ -47,6 +47,10 @@ import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_status
 import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_timeout
 import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_unknown
 import zed.rainxch.githubstore.core.presentation.res.proxy_test_error_unreachable
+import zed.rainxch.githubstore.core.presentation.res.tweaks_clear_downloads_failed
+import zed.rainxch.githubstore.core.presentation.res.tweaks_custom_forge_invalid_hostname
+import zed.rainxch.githubstore.core.presentation.res.tweaks_custom_forge_remove_failed
+import zed.rainxch.githubstore.core.presentation.res.tweaks_custom_forge_save_failed
 import zed.rainxch.tweaks.presentation.model.ProxyType
 
 class TweaksViewModel(
@@ -849,7 +853,7 @@ class TweaksViewModel(
                     }.onFailure { error ->
                         _events.send(
                             TweaksEvent.OnCacheClearError(
-                                error.message ?: "Failed to clear downloads",
+                                error.message ?: getString(Res.string.tweaks_clear_downloads_failed),
                             ),
                         )
                     }
@@ -1145,13 +1149,13 @@ class TweaksViewModel(
                     .removePrefix("https://")
                     .removePrefix("http://")
                     .substringBefore('/')
-                if (raw.isEmpty() || !raw.contains('.') || raw.contains(' ')) {
-                    _state.update {
-                        it.copy(customForgeError = "Enter a valid hostname (e.g. forgejo.example.com).")
-                    }
-                    return
-                }
                 viewModelScope.launch {
+                    if (raw.isEmpty() || !raw.contains('.') || raw.contains(' ')) {
+                        _state.update {
+                            it.copy(customForgeError = getString(Res.string.tweaks_custom_forge_invalid_hostname))
+                        }
+                        return@launch
+                    }
                     val result = runCatching { tweaksRepository.addCustomForgeHost(raw) }
                     if (result.isSuccess) {
                         _state.update { it.copy(customForgeDraft = "", customForgeError = null) }
@@ -1160,7 +1164,7 @@ class TweaksViewModel(
                         _state.update {
                             it.copy(
                                 customForgeError = result.exceptionOrNull()?.message
-                                    ?: "Couldn't save the host. Try again.",
+                                    ?: getString(Res.string.tweaks_custom_forge_save_failed),
                             )
                         }
                     }
@@ -1186,7 +1190,7 @@ class TweaksViewModel(
                         _state.update {
                             it.copy(
                                 customForgeError = result.exceptionOrNull()?.message
-                                    ?: "Couldn't remove the host. Try again.",
+                                    ?: getString(Res.string.tweaks_custom_forge_remove_failed),
                             )
                         }
                     }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/appinfo/TweaksAppInfoRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/appinfo/TweaksAppInfoRoot.kt
@@ -55,6 +55,7 @@ import zed.rainxch.core.presentation.components.buttons.GhsButtonSize
 import zed.rainxch.core.presentation.components.buttons.GhsButtonVariant
 import zed.rainxch.core.presentation.components.hub.GhsSectionHeader
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_app_name
+import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_website
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_cta
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_subtitle
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_title
@@ -308,7 +309,7 @@ private fun CommunityCard(
                     modifier = Modifier.weight(1f),
                 )
                 SocialTile(
-                    label = "Website",
+                    label = stringResource(Res.string.tweaks_app_info_website),
                     iconFallback = Icons.Outlined.Language,
                     accent = GhsAccents.Sage,
                     onClick = onWebsite,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/appinfo/TweaksAppInfoRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/appinfo/TweaksAppInfoRoot.kt
@@ -55,7 +55,6 @@ import zed.rainxch.core.presentation.components.buttons.GhsButtonSize
 import zed.rainxch.core.presentation.components.buttons.GhsButtonVariant
 import zed.rainxch.core.presentation.components.hub.GhsSectionHeader
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_app_name
-import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_website
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_cta
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_subtitle
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_community_business_title
@@ -69,6 +68,7 @@ import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_privacy_pol
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_source_code_subtitle
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_source_code_title
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_tagline
+import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_website
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_whats_new_subtitle
 import zed.rainxch.githubstore.core.presentation.res.tweaks_app_info_whats_new_title
 import zed.rainxch.githubstore.core.presentation.res.tweaks_entry_app_info

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/licenses/LicensesRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/licenses/LicensesRoot.kt
@@ -32,9 +32,14 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import zed.rainxch.core.presentation.theme.tokens.Radii
 import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.tweaks_licenses_intro_body
+import zed.rainxch.githubstore.core.presentation.res.tweaks_licenses_intro_title
+import zed.rainxch.githubstore.core.presentation.res.tweaks_licenses_load_failed
+import zed.rainxch.githubstore.core.presentation.res.tweaks_licenses_title
 import zed.rainxch.tweaks.presentation.TweaksAction
 import zed.rainxch.tweaks.presentation.TweaksViewModel
 import zed.rainxch.tweaks.presentation.components.TweaksSubScreenScaffold
@@ -78,7 +83,7 @@ fun LicensesRoot(
     }
 
     TweaksSubScreenScaffold(
-        title = "Open source licenses",
+        title = stringResource(Res.string.tweaks_licenses_title),
         onNavigateBack = onNavigateBack,
         snackbarState = snackbarState,
         restartReasons = state.needsRestartReasons,
@@ -95,13 +100,13 @@ fun LicensesRoot(
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(
-                        text = "GitHub Store stands on these libraries.",
+                        text = stringResource(Res.string.tweaks_licenses_intro_title),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "Tap any entry to open its project page.",
+                        text = stringResource(Res.string.tweaks_licenses_intro_body),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -127,7 +132,7 @@ fun LicensesRoot(
             loadError -> {
                 item(key = "error") {
                     Text(
-                        text = "Couldn't load licenses.",
+                        text = stringResource(Res.string.tweaks_licenses_load_failed),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                         modifier = Modifier.padding(16.dp),

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/mirror/MirrorPickerViewModel.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/mirror/MirrorPickerViewModel.kt
@@ -13,10 +13,12 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.compose.resources.getString
 import zed.rainxch.core.domain.model.MirrorConfig
 import zed.rainxch.core.domain.model.MirrorPreference
 import zed.rainxch.core.domain.repository.MirrorRepository
 import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.error_unknown
 import zed.rainxch.githubstore.core.presentation.res.mirror_custom_validation_https
 import zed.rainxch.githubstore.core.presentation.res.mirror_custom_validation_template
 import kotlin.time.TimeSource
@@ -129,7 +131,7 @@ class MirrorPickerViewModel(
                         if (status in 200..299) TestResult.Success(ms) else TestResult.HttpError(status)
                     }
                     result.exceptionOrNull() is UnresolvedAddressException -> TestResult.DnsFailure
-                    else -> TestResult.Other(result.exceptionOrNull()?.message ?: "Unknown error")
+                    else -> TestResult.Other(result.exceptionOrNull()?.message ?: getString(Res.string.error_unknown))
                 }
             _state.update { it.copy(isTesting = false, testResult = testResult) }
         }


### PR DESCRIPTION
## Summary

Two related i18n passes bundled into one PR.

### 1. Extraction (30 new keys, 12 files)
Externalizes hardcoded user-facing strings to `values/strings.xml` + `values-fr/strings-fr.xml`:
- **Onboarding screen** fully externalized (16 strings: palette / sign-in / permissions steps).
- **dev-profile**: `ContributionCalendar` (6), `ProfileInfoCard` metrics + Org badge (4).
- **Licenses screen** (4) — three of these reuse keys that were already defined in `strings.xml` but had been left hardcoded.
- **app-info** "Website" tile.
- **ViewModel error fallbacks** now route through `getString(Res.string.…)` instead of literals, matching the existing pattern (`CategoryList`, `DetailsAbout`, `DetailsWhatsNew`, `Details`, `MirrorPicker`, `Tweaks`). `TweaksViewModel.OnAddCustomForge` validation moved inside the existing `launch` so the suspend `getString` is reachable.
- Reused existing keys where identical: `sign_in_with_github`, `retry`, `followers`, `following`, `profile_repos`, `tweaks_licenses_*`, `translation_failed`, `error_unknown`.

Intentionally out of scope (noted for later): notification channels (need `runBlocking`), install-flow exception messages, `FeedbackComposer` (maintainer-facing English issue body), `@Preview`/sample data, unused `WaxSealTrustCard`.

### 2. French sync & review (`values-fr`)
- **Tutoiement → vouvoiement**: harmonized the few remaining tu-form strings (`custom_forges_dialog_help`, `details_linked_repo_banner_body`, `tweaks_sources_platforms_body`).
- **Apostrophes**: unified to straight `'` (U+0027), the file's actual convention (194 straight vs 14 curly before); 21 curly converted.
- **EN parity**: added missing `tweaks_privacy_usage_data_section`; removed 2 dead orphan FR keys (`tweaks_privacy_telemetry_collect_*`, no EN counterpart / no generated accessor). Result: **1081 string keys identical on both sides** + 12 plurals each.
- **Terminology consistency** (one FR term per EN term, following the file's dominant pattern): search failed → « Échec de la recherche », view all → « Tout afficher », failed to load repositories → « Impossible de charger les dépôts », grant permission → « Accorder la permission », clear → « Effacer », skip → « Passer ».
- **Quality**: fixed `proxy_save` faux-ami (« Sauvegarder » → « Enregistrer le proxy »); ellipsis `...` → `…`.

## Verification
- `./gradlew :composeApp:compileDebugKotlinAndroid` passes (generated `Res.string.*` accessors resolve, Composable/suspend contexts correct).
- EN + FR XML valid (`xmllint`), UTF-8, no mojibake.
- Parity: 1081 string keys identical, 12 plurals each, 0 missing, 0 orphan.
- 0 tutoiement, 100% straight apostrophes.

## Note
The EN source has one stray curly apostrophe in `whats_new` ("What's New") vs 76 straight elsewhere — left untouched (source of truth, outside this FR pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide localization extended to onboarding (palette/sign-in/permissions), developer profile, contribution calendar, details/what’s‑new, tweaks, and misc UI labels; new translations added for many locales.
* **Style**
  * French copy refined for punctuation, formality, and clearer UX phrasing.
* **Bug Fixes**
  * Replaced hardcoded English messages with localized strings for errors, loading, retry, actions, and custom‑forge/tweaks feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->