### PR TITLE
fix(mirror): drop cache TTL 24h → 1h so stale DOWN clears within a session

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mirror/MirrorRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mirror/MirrorRepositoryImpl.kt
@@ -46,11 +46,6 @@ class MirrorRepositoryImpl(
     private val appScope: CoroutineScope,
 ) : MirrorRepository {
     private val json = Json { ignoreUnknownKeys = true }
-    // 1h not 24h. Backend probes mirrors hourly, so 24h cache held stale
-    // DOWN states for an entire day after a transient backend probe flap —
-    // the user-facing symptom in OpenHub-Store/GitHub-Store#698 where
-    // ghfast.top kept showing as 不可用 even after recovery. With 1h TTL,
-    // a single bad backend probe clears within one app foreground.
     private val cacheTtlMs = 60L * 60 * 1000
 
     private val _catalog = MutableStateFlow<List<MirrorConfig>>(emptyList())

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mirror/MirrorRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/mirror/MirrorRepositoryImpl.kt
@@ -46,7 +46,12 @@ class MirrorRepositoryImpl(
     private val appScope: CoroutineScope,
 ) : MirrorRepository {
     private val json = Json { ignoreUnknownKeys = true }
-    private val cacheTtlMs = 24L * 60 * 60 * 1000
+    // 1h not 24h. Backend probes mirrors hourly, so 24h cache held stale
+    // DOWN states for an entire day after a transient backend probe flap —
+    // the user-facing symptom in OpenHub-Store/GitHub-Store#698 where
+    // ghfast.top kept showing as 不可用 even after recovery. With 1h TTL,
+    // a single bad backend probe clears within one app foreground.
+    private val cacheTtlMs = 60L * 60 * 1000
 
     private val _catalog = MutableStateFlow<List<MirrorConfig>>(emptyList())
     private val _removedNotices = MutableSharedFlow<MirrorRemoved>(


### PR DESCRIPTION
Fixes #698. Companion to backend PR https://github.com/OpenHub-Store/backend/pull/25.

## What
\`MirrorRepositoryImpl.cacheTtlMs\` from 24h to 1h.

## Why
The backend probes mirrors hourly. A 24h client cache held a stale \`DOWN\` for an entire day after a single transient backend probe failure (ghfast.top et al flap under the 5s FSN→CN-mirror probe timeout). User-facing symptom: 'ghfast.top明明可用，但就说不可用'.

Backend PR #25 cuts the false-DOWN rate at the source. This PR caps how long any remaining false-DOWN can linger on a device.

## Trade-off
~24× more \`/v1/mirrors/list\` requests per active user. Endpoint is `Cache-Control: max-age=300, s-maxage=3600` (Cloudflare-fronted, 1h edge cache), so the actual origin load barely moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache refresh interval reduced from 24 hours to 1 hour; cached mirror catalog is now treated as stale after 1 hour.
  * Catalog refresh now runs more frequently, causing mirror listings to update on an hourly cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->