### PR TITLE
Guard import-stars favourite toggle against DB failure

### DIFF
--- a/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/import/ImportStarsViewModel.kt
+++ b/feature/favourites/presentation/src/commonMain/kotlin/zed/rainxch/favourites/presentation/import/ImportStarsViewModel.kt
@@ -191,7 +191,8 @@ class ImportStarsViewModel(
                 lastSyncedAt = now,
             )
 
-            favouritesRepository.toggleFavorite(favourite)
+            val toggled = runCatching { favouritesRepository.toggleFavorite(favourite) }.isSuccess
+            if (!toggled) return@launch
 
             _state.update { current ->
                 val updated = current.candidates.map { candidateUi ->


### PR DESCRIPTION
Single-star toggle in the import-stars screen called toggleFavorite bare inside viewModelScope.launch. A Room DAO throw (constraint violation, disk-full) would propagate uncaught on the supervisor scope and crash on the main thread.

Wrap it in runCatching and only flip the UI star on success, matching the existing addAll guard. Failure now no-ops instead of crashing, and the star never shows a state that wasn't persisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of the favorites toggle feature to gracefully handle errors during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->