### PR TITLE
Suppress a11y-originated crashes on macOS (#684)

### DIFF
--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/A11yCrashGuard.kt
@@ -21,11 +21,11 @@ object A11yCrashGuard {
 
         val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            if (isComposeA11yNpe(throwable)) {
+            if (isComposeA11yCrash(throwable)) {
                 if (warnedUncaught.compareAndSet(false, true)) {
                     System.err.println(
-                        "[A11yCrashGuard] Suppressed Compose a11y NPE via uncaught-exception path " +
-                            "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",
+                        "[A11yCrashGuard] Suppressed Compose a11y crash via uncaught-exception path " +
+                            "(known issue, see GitHub-Store#330 / #639 / #640 / #684). Further occurrences silenced.",
                     )
                 }
                 return@setDefaultUncaughtExceptionHandler
@@ -48,14 +48,12 @@ object A11yCrashGuard {
         )
     }
 
-    private fun isComposeA11yNpe(throwable: Throwable): Boolean {
-        if (throwable !is NullPointerException) return false
+    private fun isComposeA11yCrash(throwable: Throwable): Boolean {
         var current: Throwable? = throwable
         while (current != null) {
             if (current.stackTrace.any { frame ->
                     frame.className.startsWith("androidx.compose.ui.platform.a11y") ||
-
-                        frame.className.startsWith("sun.lwawt.macosx.CAccessible\$AXChangeNotifier")
+                        frame.className.startsWith("sun.lwawt.macosx.CAccessib")
                 }
             ) {
                 return true
@@ -69,17 +67,17 @@ object A11yCrashGuard {
         override fun dispatchEvent(event: AWTEvent) {
             try {
                 super.dispatchEvent(event)
-            } catch (npe: NullPointerException) {
-                if (isComposeA11yNpe(npe)) {
+            } catch (ex: RuntimeException) {
+                if (isComposeA11yCrash(ex)) {
                     if (warnedEdt.compareAndSet(false, true)) {
                         System.err.println(
-                            "[A11yCrashGuard] Suppressed Compose a11y NPE on macOS " +
-                                "(known issue, see GitHub-Store#330 / #640). Further occurrences silenced.",
+                            "[A11yCrashGuard] Suppressed Compose a11y crash on macOS " +
+                                "(known issue, see GitHub-Store#330 / #639 / #640 / #684). Further occurrences silenced.",
                         )
                     }
                     return
                 }
-                throw npe
+                throw ex
             }
         }
     }

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/20.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/20.json
@@ -21,7 +21,8 @@
       "bullets": [
         "Debian 12 / Ubuntu 22.04 can now install the .deb again — the package no longer demands the time64 'libasound2t64' / 'libpng16-16t64' libraries that only exist on Debian 13+, so a single .deb installs across every Debian generation.",
         "Desktop sign-in no longer gets stuck on “Waiting for authorization…” — if the browser hand-off doesn't come back, it now times out so you can retry or switch to a device code or token.",
-        "Windows: “Open in GitHub Store” links now reliably open the app — the githubstore:// handler is registered more robustly and re-registered after updates, so links no longer fail with “no application associated”."
+        "Windows: “Open in GitHub Store” links now reliably open the app — the githubstore:// handler is registered more robustly and re-registered after updates, so links no longer fail with “no application associated”.",
+        "macOS: the app no longer quits unexpectedly when you open your Profile or switch between windows."
       ]
     }
   ]


### PR DESCRIPTION
Fixes #684.

macOS accessibility (`CAccessibility`/`AXChangeNotifier`) queries Compose's semantics tree on window-focus change, which could either drive a navigation that throws `IllegalStateException: State must be at least 'CREATED'...` or NPE in `accessibleParentOf` — crashing the EDT and closing the app on Profile open / window switch.

The bridge is already disabled by default on macOS (#694), which prevents this for everyone in the next release. This hardens the runtime guard so the app also survives when a screen-reader user opts back in via `compose.accessibility.enable=true`: the guard now swallows any a11y-originated `RuntimeException` (covers the nav `IllegalStateException`, not just NPE), still scoped to a11y stack frames so unrelated errors propagate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS stability issue where the app would quit unexpectedly when opening the Profile or switching between windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->