### PR TITLE
 fix: broken badges and update repo URLs in docs

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -579,7 +579,7 @@ jobs:
           pkgname = ${PKG_NAME}
           pkgver = ${VERSION}-1
           pkgdesc = Cross-platform app store for GitHub releases
-          url = https://github.com/OpenHub-Store/GitHub-Store
+          url = https://github.com/kurikomi-labs/komi-store
           builddate = $(date +%s)
           packager = GitHub Actions
           arch = x86_64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Plenty of ways to help, even without writing code:
 - **Report bugs.** Reproducible reports with logs are gold.
 - **Suggest features.** Open an issue describing the user-facing problem first; the implementation can be discussed there.
 - **Triage issues.** Reproduce open bugs, ask for missing info, label them.
-- **Write code.** Pick up a [`good first issue`](https://github.com/OpenHub-Store/GitHub-Store/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or any [`help wanted`](https://github.com/OpenHub-Store/GitHub-Store/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issue.
+- **Write code.** Pick up a [`good first issue`](https://github.com/kurikomi-labs/komi-store/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or any [`help wanted`](https://github.com/kurikomi-labs/komi-store/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issue.
 - **Translate strings.** See [Translations](#translations).
 - **Test pre-releases.** Watch the repo for new tags and try them out.
 
@@ -48,7 +48,7 @@ Plenty of ways to help, even without writing code:
 Two ways:
 
 - **Inside the app: `Profile → Send feedback`.** Auto-fills app version, platform, and installer. Pick the channel (email or GitHub issue) and you're done.
-- **On GitHub: [open a bug report](https://github.com/OpenHub-Store/GitHub-Store/issues/new?template=bug_report.md).** Tell us what went wrong, how to reproduce, your setup. Logs and screenshots help but aren't required.
+- **On GitHub: [open a bug report](https://github.com/kurikomi-labs/komi-store/issues/new?template=bug_report.md).** Tell us what went wrong, how to reproduce, your setup. Logs and screenshots help but aren't required.
 
 If you have logs handy, grab them from:
 
@@ -59,7 +59,7 @@ If you have logs handy, grab them from:
 
 ## Suggesting features
 
-[Open a feature request](https://github.com/OpenHub-Store/GitHub-Store/issues/new?template=feature_request.md). Lead with the **pain**, not the solution: what are you trying to do, where does the app fall short?
+[Open a feature request](https://github.com/kurikomi-labs/komi-store/issues/new?template=feature_request.md). Lead with the **pain**, not the solution: what are you trying to do, where does the app fall short?
 
 For bigger ideas (new screens, new platform, architectural shifts), open the issue first and wait for a quick discussion before writing code.
 
@@ -77,8 +77,8 @@ For bigger ideas (new screens, new platform, architectural shifts), open the iss
 ### One-time setup
 
 ```bash
-git clone https://github.com/OpenHub-Store/GitHub-Store.git
-cd GitHub-Store
+git clone https://github.com/kurikomi-labs/komi-store.git
+cd komi-store
 ```
 
 Create `local.properties` in the repo root:
@@ -306,7 +306,7 @@ You don't normally need to touch this as a contributor; just be aware that landi
 
 ## Security disclosures
 
-**Do not open public issues for security vulnerabilities.** Use [GitHub's private vulnerability reporting](https://github.com/OpenHub-Store/GitHub-Store/security/advisories/new) or email **hello@github-store.org** with the details.
+**Do not open public issues for security vulnerabilities.** Use [GitHub's private vulnerability reporting](https://github.com/kurikomi-labs/komi-store/security/advisories/new) or email **hello@github-store.org** with the details.
 
 We treat token leaks, install-flow exploits, and signing-bypass paths as critical. Other issues we'll triage on a best-effort basis.
 
@@ -316,7 +316,7 @@ We treat token leaks, install-flow exploits, and signing-bypass paths as critica
 
 - **Real-time chat:** join the [Discord server](https://discord.github-store.org) — fastest way to get a hand from maintainers and other contributors.
 - **Email:** **hello@github-store.org** for anything that doesn't fit a public channel — sponsorship, partnerships, sensitive coordination.
-- **General questions / discussion:** open a [GitHub Discussion](https://github.com/OpenHub-Store/GitHub-Store/discussions) (if enabled) or a feature-request issue.
+- **General questions / discussion:** open a [GitHub Discussion](https://github.com/kurikomi-labs/komi-store/discussions) (if enabled) or a feature-request issue.
 - **Stuck on local setup:** open a draft PR with what you have and ask for help in the description — we'd rather help you finish than have you give up silently.
 - **Sibling repos:** [backend](https://github.com/OpenHub-Store/backend) and [api](https://github.com/OpenHub-Store/api) have their own contributing notes.
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Built with Kotlin Multiplatform and Compose Multiplatform for Android and Deskto
 
 <p align="center">
   <a href="https://github.com/kurikomi-labs/komi-store/releases">
-    <img src="https://i.ibb.co/q0mdc4Z/get-it-on-github.png" height="80" />
+    <img src="https://i.ibb.co/q0mdc4Z/get-it-on-github.png" height="80" alt="Get it on GitHub" />
   </a>
   <a href="https://f-droid.org/en/packages/zed.rainxch.githubstore/">
-    <img src="https://f-droid.org/badge/get-it-on.png" height="80" />
+    <img src="https://f-droid.org/badge/get-it-on.png" height="80" alt="Get it on F-Droid" />
   </a>
   <br/>
   <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/kurikomi-labs/komi-store/">

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
   <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/downloads/5/2?label=Downloads%20:" alt="Downloads"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/stargazers">
-  <img src="https://m3-markdown-badges.vercel.app/stars/3/2/kurikomi-labs/komi-store" alt="Stars"/>
+  <img src="https://img.shields.io/github/stars/kurikomi-labs/komi-store?style=for-the-badge&logo=github&label=Stars" alt="Stars"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/issues">
-  <img src="https://m3-markdown-badges.vercel.app/issues/1/2/kurikomi-labs/komi-store" alt="Issues"/>
+  <img src="https://img.shields.io/github/issues/kurikomi-labs/komi-store?style=for-the-badge&logo=github&label=Issues" alt="Issues"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/releases/latest">
   <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/release/9/1?label=Latest%20version%20:" alt="Latest release"/>

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
   <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/downloads/5/2?label=Downloads%20:" alt="Downloads"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/stargazers">
-  <img src="https://img.shields.io/github/stars/kurikomi-labs/komi-store?style=for-the-badge&logo=github&label=Stars" alt="Stars"/>
+  <img src="https://m3-markdown-badges.vercel.app/stars/3/2/OpenHub-Store/GitHub-Store" alt="Stars"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/issues">
-  <img src="https://img.shields.io/github/issues/kurikomi-labs/komi-store?style=for-the-badge&logo=github&label=Issues" alt="Issues"/>
+  <img src="https://m3-markdown-badges.vercel.app/issues/1/2/OpenHub-Store/GitHub-Store" alt="Issues"/>
 </a>
 <a href="https://github.com/kurikomi-labs/komi-store/releases/latest">
   <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/release/9/1?label=Latest%20version%20:" alt="Latest release"/>

--- a/README.md
+++ b/README.md
@@ -17,27 +17,27 @@
   <img src="https://ziadoua.github.io/m3-Markdown-Badges/badges/Linux/linux2.svg" />
   <br/>
   <br/>
- <a href="https://github.com/OpenHub-Store/GitHub-Store/releases/latest">
-  <img src="https://api.github-store.org/v1/badge/OpenHub-Store/GitHub-Store/downloads/5/2?label=Downloads%20:" alt="Downloads"/>
+ <a href="https://github.com/kurikomi-labs/komi-store/releases/latest">
+  <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/downloads/5/2?label=Downloads%20:" alt="Downloads"/>
 </a>
-<a href="https://github.com/OpenHub-Store/GitHub-Store/stargazers">
-  <img src="https://m3-markdown-badges.vercel.app/stars/3/2/OpenHub-Store/GitHub-Store" alt="Stars"/>
+<a href="https://github.com/kurikomi-labs/komi-store/stargazers">
+  <img src="https://m3-markdown-badges.vercel.app/stars/3/2/kurikomi-labs/komi-store" alt="Stars"/>
 </a>
-<a href="https://github.com/OpenHub-Store/GitHub-Store/issues">
-  <img src="https://m3-markdown-badges.vercel.app/issues/1/2/OpenHub-Store/GitHub-Store" alt="Issues"/>
+<a href="https://github.com/kurikomi-labs/komi-store/issues">
+  <img src="https://m3-markdown-badges.vercel.app/issues/1/2/kurikomi-labs/komi-store" alt="Issues"/>
 </a>
-<a href="https://github.com/OpenHub-Store/GitHub-Store/releases/latest">
-  <img src="https://api.github-store.org/v1/badge/OpenHub-Store/GitHub-Store/release/9/1?label=Latest%20version%20:" alt="Latest release"/>
+<a href="https://github.com/kurikomi-labs/komi-store/releases/latest">
+  <img src="https://api.github-store.org/v1/badge/kurikomi-labs/komi-store/release/9/1?label=Latest%20version%20:" alt="Latest release"/>
 </a>
 </p>
 
 <table align="center">
   <tr>
     <td>
-      <a href="https://trendshift.io/repositories/22313" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22313" alt="OpenHub-Store%2FGitHub-Store | Trendshift" width="250" height="55" /></a>
+      <a href="https://trendshift.io/repositories/22313" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22313" alt="kurikomi-labs%2Fkomi-store | Trendshift" width="250" height="55" /></a>
     </td>
     <td>
-      <a href="https://hellogithub.com/en/repository/OpenHub-Store/GitHub-Store" target="_blank"><img src="https://abroad.hellogithub.com/v1/widgets/recommend.svg?rid=a95f4a4830bc4a69b56f96ac7efaacf8&claim_uid=sOz1lfiG4ARQYIK&theme=dark" alt="Featured｜HelloGitHub" width="250" height="54" /></a>
+      <a href="https://hellogithub.com/en/repository/kurikomi-labs/komi-store" target="_blank"><img src="https://abroad.hellogithub.com/v1/widgets/recommend.svg?rid=a95f4a4830bc4a69b56f96ac7efaacf8&claim_uid=sOz1lfiG4ARQYIK&theme=dark" alt="Featured｜HelloGitHub" width="250" height="54" /></a>
     </td>
   </tr>
 </table>
@@ -80,17 +80,17 @@ Built with Kotlin Multiplatform and Compose Multiplatform for Android and Deskto
 </div>
 
 <p align="center">
-  <a href="https://github.com/OpenHub-Store/GitHub-Store/releases">
+  <a href="https://github.com/kurikomi-labs/komi-store/releases">
     <img src="https://i.ibb.co/q0mdc4Z/get-it-on-github.png" height="80" />
   </a>
   <a href="https://f-droid.org/en/packages/zed.rainxch.githubstore/">
     <img src="https://f-droid.org/badge/get-it-on.png" height="80" />
   </a>
   <br/>
-  <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/OpenHub-Store/GitHub-Store/">
+  <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/kurikomi-labs/komi-store/">
     <img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" height="55" alt="Get it on Obtainium" />
   </a>
-  <a href="https://github-store.org/app?repo=OpenHub-Store/GitHub-Store">
+  <a href="https://github-store.org/app?repo=kurikomi-labs/komi-store">
     <img src="media-resources/ghs_download_badge.png" alt="Get it on Komi Store" height="58" />
   </a>
 </p>
@@ -302,7 +302,7 @@ automatically—no manual submission required.
   <br/>
   <strong>HowToMen:</strong> <a href="https://www.youtube.com/watch?v=7favc9MDedQ">Top 20 Best Android Apps 2026</a> | <a href="https://www.youtube.com/watch?v=VR-MEwPDw4k">Top 12 App Stores that are Better than Google Play Store</a>
   <br/>
-  <strong>HelloGitHub:</strong> <a href="https://hellogithub.com/en/repository/OpenHub-Store/GitHub-Store">Featured Project</a>
+  <strong>HelloGitHub:</strong> <a href="https://hellogithub.com/en/repository/kurikomi-labs/komi-store">Featured Project</a>
 </p>
 
 ---
@@ -414,7 +414,7 @@ Sync the project and run the app. You should now be able to sign in with GitHub.
 
 </div>
 
-Check out Komi Store [Wiki](https://github.com/OpenHub-Store/GitHub-Store/wiki) for FAQ and useful information
+Check out Komi Store [Wiki](https://github.com/kurikomi-labs/komi-store/wiki) for FAQ and useful information
 
 🌐 **Website:** [github-store.org](https://github-store.org)
 💬 **Discord:** [Join the community](https://discord.github-store.org)
@@ -430,9 +430,9 @@ Check out Komi Store [Wiki](https://github.com/OpenHub-Store/GitHub-Store/wiki) 
 
 Komi Store is 100% free. No ads. No tracking.
 
-- ⭐ **[Star](https://github.com/OpenHub-Store/GitHub-Store/star)** this repository
-- 🐛 **[Report](https://github.com/OpenHub-Store/GitHub-Store/issues)** bugs and issues
-- 💡 **[Suggest](https://github.com/OpenHub-Store/GitHub-Store/discussions)** new features
+- ⭐ **[Star](https://github.com/kurikomi-labs/komi-store/star)** this repository
+- 🐛 **[Report](https://github.com/kurikomi-labs/komi-store/issues)** bugs and issues
+- 💡 **[Suggest](https://github.com/kurikomi-labs/komi-store/discussions)** new features
 - 💳 **[Sponsor](https://github.com/sponsors/rainxchzed)** the developer
 
 ---
@@ -487,11 +487,11 @@ fit for any particular purpose.
 
 </div>
 
-<a href="https://www.star-history.com/#OpenHub-Store/GitHub-Store&type=timeline&legend=top-left">
+<a href="https://www.star-history.com/#kurikomi-labs/komi-store&type=timeline&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=OpenHub-Store/GitHub-Store&type=timeline&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=OpenHub-Store/GitHub-Store&type=timeline&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OpenHub-Store/GitHub-Store&type=timeline&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kurikomi-labs/komi-store&type=timeline&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kurikomi-labs/komi-store&type=timeline&legend=top-left" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kurikomi-labs/komi-store&type=timeline&legend=top-left" />
   </picture>
 </a>
 

--- a/dist/homebrew/Casks/github-store.rb
+++ b/dist/homebrew/Casks/github-store.rb
@@ -5,10 +5,10 @@ cask "github-store" do
   sha256 arm:   "ad0c532873c0400736b7ea706a33604f7ef93b2479a4a6f32673a789b18ccd8e",
          intel: "faf002283c301db2a97f7a32193778f678d42ed71551a623711cd170d6fde16a"
 
-  url "https://github.com/OpenHub-Store/GitHub-Store/releases/download/v#{version}/GitHub-Store-#{version}-#{arch}.dmg"
+  url "https://github.com/kurikomi-labs/komi-store/releases/download/v#{version}/GitHub-Store-#{version}-#{arch}.dmg"
   name "GitHub Store"
   desc "Cross-platform app store for GitHub releases"
-  homepage "https://github.com/OpenHub-Store/GitHub-Store"
+  homepage "https://github.com/kurikomi-labs/komi-store"
 
   livecheck do
     url :url

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -21,4 +21,4 @@ FEATURES
 
 Also available on Desktop (Windows, macOS, Linux) with tablet two-pane layout, fluid content width, persistent window state, and a native dark title bar on Windows 11 and macOS.
 
-Built with Kotlin Multiplatform and Compose Multiplatform. Source on GitHub at OpenHub-Store/GitHub-Store.
+Built with Kotlin Multiplatform and Compose Multiplatform. Source on GitHub at kurikomi-labs/komi-store.

--- a/packaging/flatpak/zed.rainxch.githubstore.metainfo.xml
+++ b/packaging/flatpak/zed.rainxch.githubstore.metainfo.xml
@@ -30,25 +30,25 @@
   <screenshots>
     <screenshot type="default">
       <caption>Home screen showing trending repositories</caption>
-      <image>https://raw.githubusercontent.com/OpenHub-Store/GitHub-Store/main/media-resources/screenshots/desktop/desktop_linux_home.jpg</image>
+      <image>https://raw.githubusercontent.com/kurikomi-labs/komi-store/main/media-resources/screenshots/desktop/desktop_linux_home.jpg</image>
     </screenshot>
     <screenshot>
       <caption>Repository details with release info</caption>
-      <image>https://raw.githubusercontent.com/OpenHub-Store/GitHub-Store/main/media-resources/screenshots/desktop/desktop_linux_details.jpg</image>
+      <image>https://raw.githubusercontent.com/kurikomi-labs/komi-store/main/media-resources/screenshots/desktop/desktop_linux_details.jpg</image>
     </screenshot>
     <screenshot>
       <caption>Installing packages on Linux</caption>
-      <image>https://raw.githubusercontent.com/OpenHub-Store/GitHub-Store/main/media-resources/screenshots/desktop/desktop_linux_installing_rpm.jpg</image>
+      <image>https://raw.githubusercontent.com/kurikomi-labs/komi-store/main/media-resources/screenshots/desktop/desktop_linux_installing_rpm.jpg</image>
     </screenshot>
     <screenshot>
       <caption>AppImage support on Linux</caption>
-      <image>https://raw.githubusercontent.com/OpenHub-Store/GitHub-Store/main/media-resources/screenshots/desktop/desktop_linux_appimage.jpg</image>
+      <image>https://raw.githubusercontent.com/kurikomi-labs/komi-store/main/media-resources/screenshots/desktop/desktop_linux_appimage.jpg</image>
     </screenshot>
   </screenshots>
 
-  <url type="homepage">https://github.com/OpenHub-Store/GitHub-Store</url>
-  <url type="bugtracker">https://github.com/OpenHub-Store/GitHub-Store/issues</url>
-  <url type="vcs-browser">https://github.com/OpenHub-Store/GitHub-Store</url>
+  <url type="homepage">https://github.com/kurikomi-labs/komi-store</url>
+  <url type="bugtracker">https://github.com/kurikomi-labs/komi-store/issues</url>
+  <url type="vcs-browser">https://github.com/kurikomi-labs/komi-store</url>
 
   <developer id="zed.rainxch">
     <name>rainxchzed</name>

--- a/packaging/flatpak/zed.rainxch.githubstore.yml
+++ b/packaging/flatpak/zed.rainxch.githubstore.yml
@@ -125,7 +125,7 @@ modules:
     sources:
       # NOTE: For Flathub submission, switch this to:
       #   type: git
-      #   url: https://github.com/OpenHub-Store/GitHub-Store.git
+      #   url: https://github.com/kurikomi-labs/komi-store.git
       #   tag: <release-tag>
       - type: dir
         path: ../../


### PR DESCRIPTION
Was going through the README and noticed a couple things broken.

First, all the badges and links were still pointing to OpenHub-Store/GitHub-Store instead of the current repo (kurikomi-labs/komi-store). Went through every doc file and updated them like README, CONTRIBUTING, fastlane description, homebrew cask, flatpak metadata, and the workflow yml.

Second, the stars and issues badges from m3-markdown-badges weren't rendering at all. Checked the service and it's just dead (403 on everything). Swapped them to shields.io instead, which actually works. Also caught a small bug in CONTRIBUTING.md where the clone directory didn't match the new repo URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository URLs and references across documentation (README/CONTRIBUTING), build workflow packaging metadata, and mobile/desktop release descriptions.
  * Refreshed Flatpak manifest and AppStream metadata to use the new upstream image and repository links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->