### PR TITLE
Fix tracked apps vanishing from the library

### DIFF
--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/use_cases/SyncInstalledAppsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/use_cases/SyncInstalledAppsUseCase.kt
@@ -65,6 +65,25 @@ class SyncInstalledAppsUseCase(
                     }
                 }
 
+                // Guard against a visibility-restricted package scan wiping the library (GH#748).
+                // getAllInstalledPackageNames() is filtered by Android package visibility; on some
+                // OEM ROMs it returns little more than this app itself, which would flag every
+                // tracked app as uninstalled. Real uninstalls are handled in real time by
+                // PackageEventReceiver, so if the scan recognises fewer than half of the tracked
+                // apps it is untrustworthy, not a genuine mass-uninstall — skip the catch-up deletes.
+                val nonPendingCount = appsInDb.count { !it.isPendingInstall }
+                val recognizedCount = appsInDb.count {
+                    !it.isPendingInstall && installedPackageNames.contains(it.packageName)
+                }
+                if (nonPendingCount >= 2 && recognizedCount * 2 < nonPendingCount) {
+                    logger.error(
+                        "Installed-apps sync: package scan recognised only $recognizedCount of " +
+                            "$nonPendingCount tracked apps (visibility restricted?). Skipping " +
+                            "${toDelete.size} deletions to avoid wiping the library (GH#748).",
+                    )
+                    toDelete.clear()
+                }
+
                 executeInTransaction {
                     toDelete.forEach { packageName ->
                         try {


### PR DESCRIPTION
Tracked apps in the library disappear after reopening the app, leaving only `komi-store` itself (#748; Meizu / Android 16).

`SyncInstalledAppsUseCase` runs on every reopen and deletes any tracked app missing from `getInstalledPackages()` — a package-visibility-filtered scan. On some OEM ROMs that scan returns ~self only, so every tracked app is wrongly flagged and deleted. Real uninstalls are already handled by `PackageEventReceiver` (`PACKAGE_FULLY_REMOVED`), so the enumeration catch-up is pure downside.

Fix: skip the catch-up deletions when the scan recognises fewer than half of the tracked apps (≥2 tracked) — a bad scan, not a genuine mass-uninstall. Normal single-app cleanup is unaffected.

Fixes #748.