### PR TITLE
Desktop title bar follows the app's dark theme

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -207,7 +207,7 @@ fun App(
         isAmoledTheme = state.isAmoledTheme,
         isDarkTheme = resolvedDarkTheme,
     ) {
-        ApplyAndroidSystemBars(state.isDarkTheme)
+        ApplyAndroidSystemBars(resolvedDarkTheme)
 
         val onAuthScreen = currentScreen is GithubStoreGraph.AuthenticationScreen
         LaunchedEffect(onAuthScreen, state.showRateLimitDialog) {

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/Main.kt
@@ -39,6 +39,7 @@ import kotlin.time.Duration.Companion.milliseconds
 fun App(
     deepLinkUri: String? = null,
     onDeepLinkConsumed: () -> Unit = {},
+    onResolvedDarkTheme: (Boolean) -> Unit = {},
 ) {
     setSingletonImageLoaderFactory { context ->
         ImageLoader
@@ -197,11 +198,14 @@ fun App(
         }
     }
 
+    val resolvedDarkTheme = state.isDarkTheme ?: isSystemInDarkTheme()
+    LaunchedEffect(resolvedDarkTheme) { onResolvedDarkTheme(resolvedDarkTheme) }
+
     GithubStoreTheme(
         fontTheme = state.currentFontTheme,
         appTheme = state.currentColorTheme,
         isAmoledTheme = state.isAmoledTheme,
-        isDarkTheme = state.isDarkTheme ?: isSystemInDarkTheme(),
+        isDarkTheme = resolvedDarkTheme,
     ) {
         ApplyAndroidSystemBars(state.isDarkTheme)
 

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -1,6 +1,5 @@
 package zed.rainxch.githubstore
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -56,7 +55,9 @@ import zed.rainxch.githubstore.desktop.applyWindowsImmersiveDarkMode
 import zed.rainxch.githubstore.desktop.installMacosSystemAppearance
 import java.awt.Desktop
 import java.net.URI
+import java.security.Security
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
 
 private const val PRIVACY_POLICY_URL = "https://github-store.org/privacy-policy"
 
@@ -70,8 +71,8 @@ fun main(args: Array<String>) {
 
     selectLinuxRenderBackendIfRequested()
 
-    java.security.Security.setProperty("networkaddress.cache.ttl", "30")
-    java.security.Security.setProperty("networkaddress.cache.negative.ttl", "5")
+    Security.setProperty("networkaddress.cache.ttl", "30")
+    Security.setProperty("networkaddress.cache.negative.ttl", "5")
 
     initKoin()
 
@@ -79,14 +80,13 @@ fun main(args: Array<String>) {
         val koin = GlobalContext.get()
         val tweaksRepo = koin.get<TweaksRepository>()
         val localization = koin.get<LocalizationManager>()
-        val tag =
-            try {
-                withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS) {
-                    tweaksRepo.getAppLanguage().first()
-                }
-            } catch (_: Exception) {
-                null
+        val tag = try {
+            withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds) {
+                tweaksRepo.getAppLanguage().first()
             }
+        } catch (_: Exception) {
+            null
+        }
         localization.setActiveLanguageTag(tag)
     }
 
@@ -115,7 +115,7 @@ fun main(args: Array<String>) {
             snapshotFlow {
                 Triple(windowState.placement, windowState.position, windowState.size)
             }.distinctUntilChanged()
-                .debounce(500)
+                .debounce(500.milliseconds)
                 .collect {
                     withContext(Dispatchers.IO) {
                         WindowStateStore.save(windowState)
@@ -167,10 +167,11 @@ fun main(args: Array<String>) {
                 }
             },
         ) {
-            val isOsDark = isSystemInDarkTheme()
-            LaunchedEffect(window, isOsDark) {
-                applyWindowsImmersiveDarkMode(window, isOsDark)
-                applyMacosWindowAppearance(window, isOsDark)
+            var resolvedDark by remember { mutableStateOf<Boolean?>(null) }
+            LaunchedEffect(window, resolvedDark) {
+                val dark = resolvedDark ?: return@LaunchedEffect
+                applyWindowsImmersiveDarkMode(window, dark)
+                applyMacosWindowAppearance(window, dark)
             }
             MenuBar {
                 Menu(text = stringResource(Res.string.menubar_file_menu)) {
@@ -239,6 +240,7 @@ fun main(args: Array<String>) {
             App(
                 deepLinkUri = deepLinkUri,
                 onDeepLinkConsumed = { deepLinkUri = null },
+                onResolvedDarkTheme = { resolvedDark = it },
             )
         }
     }

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/desktop/WindowsDarkTitleBar.kt
@@ -1,7 +1,9 @@
 package zed.rainxch.githubstore.desktop
 
 import com.sun.jna.Native
+import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.WinDef
+import com.sun.jna.ptr.IntByReference
 import com.sun.jna.win32.StdCallLibrary
 import java.awt.Window
 
@@ -10,6 +12,13 @@ private interface DwmApi : StdCallLibrary {
         hwnd: WinDef.HWND,
         attribute: Int,
         value: WinDef.BOOLByReference,
+        size: Int,
+    ): Int
+
+    fun DwmSetWindowAttribute(
+        hwnd: WinDef.HWND,
+        attribute: Int,
+        value: IntByReference,
         size: Int,
     ): Int
 
@@ -23,6 +32,10 @@ private interface DwmApi : StdCallLibrary {
 
 private const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20
 private const val DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1 = 19
+private const val DWMWA_BORDER_COLOR = 34
+private const val DWMWA_CAPTION_COLOR = 35
+private const val DWMWA_COLOR_DEFAULT = -1
+private const val DARK_TITLE_BAR_COLORREF = 0x001E1E1E
 private const val S_OK = 0
 
 private val osName: String
@@ -60,16 +73,21 @@ fun applyWindowsImmersiveDarkMode(
     val dwm = DwmApi.INSTANCE ?: return
     val hwnd =
         runCatching {
-            WinDef.HWND(com.sun.jna.Pointer(Native.getWindowID(window)))
+            WinDef.HWND(Pointer(Native.getWindowID(window)))
         }.getOrNull() ?: return
     val flag = WinDef.BOOLByReference(WinDef.BOOL(isDark))
     val hr =
         runCatching {
             dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, flag, 4)
         }.getOrElse { -1 }
+
     if (hr != S_OK) {
         runCatching {
             dwm.DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_PRE_20H1, flag, 4)
         }
     }
+
+    val colorRef = IntByReference(if (isDark) DARK_TITLE_BAR_COLORREF else DWMWA_COLOR_DEFAULT)
+    runCatching { dwm.DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, colorRef, 4) }
+    runCatching { dwm.DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, colorRef, 4) }
 }


### PR DESCRIPTION
Dark mode showed a white title bar / top edge on Windows (#747).

The window's dark-mode call was driven by `isSystemInDarkTheme()` (OS only), while the content follows the app's own theme setting. Force the app to dark on a light-themed OS → dark content, light title bar.

- `App()` now reports its resolved dark state up; `DesktopApp` applies that to the window instead of the OS theme (macOS NSAppearance rides along).
- `applyWindowsImmersiveDarkMode` also sets `DWMWA_CAPTION_COLOR` + `DWMWA_BORDER_COLOR` (Win11) to remove the thin light top edge; older Windows ignores them harmlessly.

Linux title bars are window-manager-controlled and not app-themable, so they're unchanged.

Fixes #747.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dark theme application on Windows with improved caption and border color handling.
  * More consistent startup theming to reduce flicker and better sync app/system dark mode.
  * Optimized window state persistence responsiveness.

* **Chores**
  * Updated desktop DNS cache configuration for improved system integration.
  * Refined language preference loading timeout handling for more reliable startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->