### PR TITLE
Fix proxy settings not saving (startup deadlock)

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/network/HttpClientFactory.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/network/HttpClientFactory.android.kt
@@ -28,7 +28,7 @@ actual fun createPlatformHttpClient(proxyConfig: ProxyConfig): HttpClient {
                     proxy =
                         Proxy(
                             Proxy.Type.HTTP,
-                            InetSocketAddress(proxyConfig.host, proxyConfig.port),
+                            InetSocketAddress.createUnresolved(proxyConfig.host, proxyConfig.port),
                         )
                     if (proxyConfig.username != null) {
                         config {
@@ -51,7 +51,7 @@ actual fun createPlatformHttpClient(proxyConfig: ProxyConfig): HttpClient {
                     proxy =
                         Proxy(
                             Proxy.Type.SOCKS,
-                            InetSocketAddress(proxyConfig.host, proxyConfig.port),
+                            InetSocketAddress.createUnresolved(proxyConfig.host, proxyConfig.port),
                         )
 
                     if (proxyConfig.username != null) {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ProxyRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ProxyRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import zed.rainxch.core.data.network.ProxyManager
 import zed.rainxch.core.domain.logging.GitHubStoreLogger
 import zed.rainxch.core.domain.model.settings.ProxyConfig
@@ -137,34 +138,38 @@ class ProxyRepositoryImpl(
 
     override suspend fun setProxyConfig(scope: ProxyScope, config: ProxyConfig) {
         migrationDeferred.await()
-        val keys = keysFor(scope)
-        when (config) {
-            is ProxyConfig.None -> {
-                ksafe.safePut(keys.type, "none")
-                ksafe.safeDelete(keys.host); ksafe.safeDelete(keys.port)
-                ksafe.safeDelete(keys.username); ksafe.safeDelete(keys.password)
+        // KSafe encrypt + disk writes are blocking; keep them off the caller's thread
+        // (the save handler runs on the main dispatcher) so saving doesn't freeze the UI.
+        withContext(Dispatchers.IO) {
+            val keys = keysFor(scope)
+            when (config) {
+                is ProxyConfig.None -> {
+                    ksafe.safePut(keys.type, "none")
+                    ksafe.safeDelete(keys.host); ksafe.safeDelete(keys.port)
+                    ksafe.safeDelete(keys.username); ksafe.safeDelete(keys.password)
+                }
+                is ProxyConfig.System -> {
+                    ksafe.safePut(keys.type, "system")
+                    ksafe.safeDelete(keys.host); ksafe.safeDelete(keys.port)
+                    ksafe.safeDelete(keys.username); ksafe.safeDelete(keys.password)
+                }
+                is ProxyConfig.Http -> {
+                    ksafe.safePut(keys.type, "http")
+                    ksafe.safePut(keys.host, config.host)
+                    ksafe.safePut(keys.port, config.port)
+                    writeOrClear(keys.username, config.username)
+                    writeOrClear(keys.password, config.password)
+                }
+                is ProxyConfig.Socks -> {
+                    ksafe.safePut(keys.type, "socks")
+                    ksafe.safePut(keys.host, config.host)
+                    ksafe.safePut(keys.port, config.port)
+                    writeOrClear(keys.username, config.username)
+                    writeOrClear(keys.password, config.password)
+                }
             }
-            is ProxyConfig.System -> {
-                ksafe.safePut(keys.type, "system")
-                ksafe.safeDelete(keys.host); ksafe.safeDelete(keys.port)
-                ksafe.safeDelete(keys.username); ksafe.safeDelete(keys.password)
-            }
-            is ProxyConfig.Http -> {
-                ksafe.safePut(keys.type, "http")
-                ksafe.safePut(keys.host, config.host)
-                ksafe.safePut(keys.port, config.port)
-                writeOrClear(keys.username, config.username)
-                writeOrClear(keys.password, config.password)
-            }
-            is ProxyConfig.Socks -> {
-                ksafe.safePut(keys.type, "socks")
-                ksafe.safePut(keys.host, config.host)
-                ksafe.safePut(keys.port, config.port)
-                writeOrClear(keys.username, config.username)
-                writeOrClear(keys.password, config.password)
-            }
+            ProxyManager.setConfig(scope, config)
         }
-        ProxyManager.setConfig(scope, config)
     }
 
     private suspend fun writeOrClear(key: String, value: String?) {
@@ -191,7 +196,7 @@ class ProxyRepositoryImpl(
         writeMasterConfig(config)
     }
 
-    private suspend fun writeMasterConfig(config: ProxyConfig) {
+    private suspend fun writeMasterConfig(config: ProxyConfig) = withContext(Dispatchers.IO) {
         when (config) {
             is ProxyConfig.None -> {
                 ksafe.safePut(MasterKeys.TYPE, "none")
@@ -231,7 +236,7 @@ class ProxyRepositoryImpl(
     }
 
     private suspend fun writeUseMaster(scope: ProxyScope, useMaster: Boolean) {
-        ksafe.safePut(useMasterKeyFor(scope), useMaster)
+        withContext(Dispatchers.IO) { ksafe.safePut(useMasterKeyFor(scope), useMaster) }
     }
 
     private suspend fun migrateIfNeeded() {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ProxyRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ProxyRepositoryImpl.kt
@@ -188,6 +188,10 @@ class ProxyRepositoryImpl(
 
     override suspend fun setMasterProxyConfig(config: ProxyConfig) {
         migrationDeferred.await()
+        writeMasterConfig(config)
+    }
+
+    private suspend fun writeMasterConfig(config: ProxyConfig) {
         when (config) {
             is ProxyConfig.None -> {
                 ksafe.safePut(MasterKeys.TYPE, "none")
@@ -223,6 +227,10 @@ class ProxyRepositoryImpl(
 
     override suspend fun setUseMaster(scope: ProxyScope, useMaster: Boolean) {
         migrationDeferred.await()
+        writeUseMaster(scope, useMaster)
+    }
+
+    private suspend fun writeUseMaster(scope: ProxyScope, useMaster: Boolean) {
         ksafe.safePut(useMasterKeyFor(scope), useMaster)
     }
 
@@ -321,8 +329,6 @@ class ProxyRepositoryImpl(
             scope to readScopeConfigDirect(scope)
         }
 
-        // Plurality vote: most common scope config becomes the master.
-        // Tie-break: Download > Discovery > Translation (most-common scope usage order).
         val tieBreakOrder = listOf(ProxyScope.DOWNLOAD, ProxyScope.DISCOVERY, ProxyScope.TRANSLATION)
         val counts = configs.groupBy { it.second }.mapValues { it.value.size }
         val maxCount = counts.values.maxOrNull() ?: 0
@@ -331,11 +337,11 @@ class ProxyRepositoryImpl(
             configs.firstOrNull { it.first == scope && it.second in winners }?.second
         } ?: configs.first().second
 
-        runCatching { setMasterProxyConfig(winnerConfig) }
+        runCatching { writeMasterConfig(winnerConfig) }
 
         configs.forEach { (scope, config) ->
             val matches = config == winnerConfig
-            runCatching { setUseMaster(scope, matches) }
+            runCatching { writeUseMaster(scope, matches) }
         }
 
         runCatching { ksafe.safePut(MIGRATION_MARKER_MASTER_V2, true) }

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/network/HttpClientFactory.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/network/HttpClientFactory.jvm.kt
@@ -31,7 +31,7 @@ actual fun createPlatformHttpClient(proxyConfig: ProxyConfig): HttpClient =
                     }
 
                     is ProxyConfig.Http -> {
-                        proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyConfig.host, proxyConfig.port)))
+                        proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(proxyConfig.host, proxyConfig.port)))
                         val username = proxyConfig.username
                         val password = proxyConfig.password
                         if (!username.isNullOrEmpty() && !password.isNullOrEmpty()) {
@@ -47,7 +47,7 @@ actual fun createPlatformHttpClient(proxyConfig: ProxyConfig): HttpClient =
                     }
 
                     is ProxyConfig.Socks -> {
-                        proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(proxyConfig.host, proxyConfig.port)))
+                        proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress.createUnresolved(proxyConfig.host, proxyConfig.port)))
                         val username = proxyConfig.username
                         val password = proxyConfig.password
                         val proxyHost = proxyConfig.host

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/TweaksSubScreenScaffold.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/components/TweaksSubScreenScaffold.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -73,7 +74,9 @@ fun TweaksSubScreenScaffold(
         snackbarHost = {
             SnackbarHost(
                 hostState = snackbarState,
-                modifier = Modifier.padding(bottom = bottomNavHeight + 16.dp),
+                modifier = Modifier
+                    .imePadding()
+                    .padding(bottom = bottomNavHeight + 16.dp),
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/connection/TweaksConnectionRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/connection/TweaksConnectionRoot.kt
@@ -103,14 +103,24 @@ fun TweaksConnectionRoot(
     val snackbarState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     var pasteSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var masterSaving by remember { mutableStateOf(false) }
+    var savingScope by remember { mutableStateOf<ProxyScope?>(null) }
 
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
-            TweaksEvent.OnProxySaved -> coroutineScope.launch {
-                snackbarState.showSnackbar(getString(Res.string.proxy_saved))
+            TweaksEvent.OnProxySaved -> {
+                masterSaving = false
+                savingScope = null
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(getString(Res.string.proxy_saved))
+                }
             }
-            is TweaksEvent.OnProxySaveError -> coroutineScope.launch {
-                snackbarState.showSnackbar(event.message)
+            is TweaksEvent.OnProxySaveError -> {
+                masterSaving = false
+                savingScope = null
+                coroutineScope.launch {
+                    snackbarState.showSnackbar(event.message)
+                }
             }
             is TweaksEvent.OnProxyTestSuccess -> coroutineScope.launch {
                 snackbarState.showSnackbar(
@@ -149,7 +159,11 @@ fun TweaksConnectionRoot(
         item(key = "main_card") {
             MainConnectionCard(
                 form = state.masterProxyForm,
-                onAction = { viewModel.onAction(it) },
+                isSaving = masterSaving,
+                onAction = {
+                    if (it is TweaksAction.OnMasterProxySave) masterSaving = true
+                    viewModel.onAction(it)
+                },
                 onPasteUrl = { pasteSheetOpen = true },
             )
             Spacer(Modifier.height(16.dp))
@@ -158,7 +172,11 @@ fun TweaksConnectionRoot(
         item(key = "overrides_card") {
             OverridesCard(
                 state = state,
-                onAction = { viewModel.onAction(it) },
+                savingScope = savingScope,
+                onAction = {
+                    if (it is TweaksAction.OnProxySave) savingScope = it.scope
+                    viewModel.onAction(it)
+                },
             )
         }
     }
@@ -211,6 +229,7 @@ private fun IntroCard() {
 @Composable
 private fun MainConnectionCard(
     form: ProxyScopeFormState,
+    isSaving: Boolean,
     onAction: (TweaksAction) -> Unit,
     onPasteUrl: () -> Unit,
 ) {
@@ -279,6 +298,8 @@ private fun MainConnectionCard(
                             label = stringResource(Res.string.proxy_save),
                             variant = GhsButtonVariant.Primary,
                             leadingIcon = Icons.Default.Save,
+                            enabled = !isSaving && !form.isTestInProgress,
+                            loading = isSaving,
                             modifier = Modifier.weight(1f),
                         )
                     }
@@ -410,6 +431,7 @@ private fun ModePillSegment(
 @Composable
 private fun OverridesCard(
     state: TweaksState,
+    savingScope: ProxyScope?,
     onAction: (TweaksAction) -> Unit,
 ) {
     Surface(
@@ -440,6 +462,7 @@ private fun OverridesCard(
                     scope = scope,
                     useMain = state.useMain(scope),
                     scopeForm = state.formFor(scope),
+                    isSaving = savingScope == scope,
                     onToggle = { useMain ->
                         onAction(TweaksAction.OnScopeUseMainToggled(scope, useMain))
                     },
@@ -455,6 +478,7 @@ private fun ScopeOverrideRow(
     scope: ProxyScope,
     useMain: Boolean,
     scopeForm: ProxyScopeFormState,
+    isSaving: Boolean,
     onToggle: (Boolean) -> Unit,
     onAction: (TweaksAction) -> Unit,
 ) {
@@ -549,6 +573,8 @@ private fun ScopeOverrideRow(
                                     label = stringResource(Res.string.proxy_save),
                                     variant = GhsButtonVariant.Tonal,
                                     leadingIcon = Icons.Default.Save,
+                                    enabled = !isSaving && !scopeForm.isTestInProgress,
+                                    loading = isSaving,
                                     modifier = Modifier.weight(1f),
                                 )
                             }


### PR DESCRIPTION
Proxy settings can't be saved — Save does nothing and everything reverts to default on restart (#740, #703).

Root cause: a startup self-deadlock in `ProxyRepositoryImpl`. Every proxy read/write awaits `migrationDeferred`, which `init` only completes after migration finishes. But `migrateMasterV2IfNeeded()` called the public `setMasterProxyConfig()` / `setUseMaster()`, which themselves await that same deferred — so migration waited on the gate it was responsible for opening. The deferred never completed, so every proxy read/write hung forever (commonMain, so all platforms).

Fix: migration now writes through non-awaiting private helpers (`writeMasterConfig` / `writeUseMaster`); public setters keep the await. Migration finishes, the deferred completes, saves persist.

Also resolves proxy hosts per-connection via `InetSocketAddress.createUnresolved` so a domain proxy tracks DNS changes without an app restart (#756).

Fixes #740.
Fixes #703.
Fixes #756.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved proxy handling and persistence to make network connections more reliable and non-blocking.

* **New Features**
  * Save flows now show per-scope and global saving state with loading/disabling of Save buttons.
  * Success and error snackbars shown after save attempts.

* **Bug Fixes**
  * Snackbar now adjusts for the on-screen keyboard/insets for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->