### PR TITLE
Curb false update nags: persist versionCode + dedupe auto-link

### DIFF
--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -265,6 +265,7 @@ val coreModule =
             ExternalImportRepositoryImpl(
                 scanner = get<ExternalAppScanner>(),
                 externalLinkDao = get(),
+                installedAppDao = get(),
                 signingFingerprintDao = get(),
                 ksafe = get(qualifier = named("prefs")),
                 legacyDataStore = get(),

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/InstalledAppDao.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/local/db/dao/InstalledAppDao.kt
@@ -47,6 +47,9 @@ interface InstalledAppDao {
     @Query("DELETE FROM installed_apps WHERE packageName = :packageName")
     suspend fun deleteByPackageName(packageName: String)
 
+    @Query("SELECT packageName FROM installed_apps")
+    suspend fun getTrackedPackageNames(): List<String>
+
     @Query(
         """
     UPDATE installed_apps

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ExternalImportRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/ExternalImportRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.update
 import kotlin.time.Clock
 import zed.rainxch.core.data.dto.ExternalMatchRequest
 import zed.rainxch.core.data.local.db.dao.ExternalLinkDao
+import zed.rainxch.core.data.local.db.dao.InstalledAppDao
 import zed.rainxch.core.data.local.db.dao.SigningFingerprintDao
 import zed.rainxch.core.data.local.db.entities.ExternalLinkEntity
 import zed.rainxch.core.data.local.db.entities.SigningFingerprintEntity
@@ -44,6 +45,7 @@ import zed.rainxch.core.domain.system.InstallerKind
 class ExternalImportRepositoryImpl(
     private val scanner: ExternalAppScanner,
     private val externalLinkDao: ExternalLinkDao,
+    private val installedAppDao: InstalledAppDao,
     private val signingFingerprintDao: SigningFingerprintDao,
     private val ksafe: KSafe,
     private val legacyDataStore: DataStore<Preferences>,
@@ -84,12 +86,19 @@ class ExternalImportRepositoryImpl(
         val started = nowMillis()
         val granted = scanner.isPermissionGranted()
         val rawCandidates = scanner.snapshot()
+        // Apps already tracked by the store are not link candidates — offering them
+        // would let the user re-link an already-managed app and create a conflicting
+        // entry (GH#729). prunePendingReviewNotIn below also clears any stale rows.
+        val trackedPackages =
+            runCatching { installedAppDao.getTrackedPackageNames().toSet() }.getOrDefault(emptySet())
         val candidates =
-            if (includeUnverified) {
-                rawCandidates
-            } else {
-                rawCandidates.filter { hasPositiveEvidence(it) }
-            }
+            (
+                if (includeUnverified) {
+                    rawCandidates
+                } else {
+                    rawCandidates.filter { hasPositiveEvidence(it) }
+                }
+            ).filterNot { it.packageName in trackedPackages }
         candidateSnapshot.update { candidates.associateBy { it.packageName } }
 
         val now = nowMillis()
@@ -129,10 +138,17 @@ class ExternalImportRepositoryImpl(
         var newCandidates = 0
         var pendingReview = 0
         val deltaCandidates = mutableListOf<ExternalAppCandidate>()
+        val trackedPackages =
+            runCatching { installedAppDao.getTrackedPackageNames().toSet() }.getOrDefault(emptySet())
 
         changedPackageNames.forEach { pkg ->
             val rawCandidate = scanner.snapshotSingle(pkg)
             val existing = externalLinkDao.get(pkg)
+
+            if (pkg in trackedPackages) {
+                if (existing != null) externalLinkDao.deleteByPackageName(pkg)
+                return@forEach
+            }
 
             if (rawCandidate == null) {
                 if (existing != null) {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -74,7 +74,8 @@ class InstalledAppsRepositoryImpl(
             .getAppByPackage(packageName)
             ?.toDomain()
 
-    override suspend fun getAppByRepoId(repoId: Long): InstalledApp? = installedAppsDao.getAppByRepoId(repoId)?.toDomain()
+    override suspend fun getAppByRepoId(repoId: Long): InstalledApp? =
+        installedAppsDao.getAppByRepoId(repoId)?.toDomain()
 
     override fun getAppByRepoIdAsFlow(repoId: Long): Flow<InstalledApp?> =
         installedAppsDao.getAppByRepoIdAsFlow(repoId).map { it?.toDomain() }
@@ -85,7 +86,8 @@ class InstalledAppsRepositoryImpl(
     override fun getAppsByRepoIdAsFlow(repoId: Long): Flow<List<InstalledApp>> =
         installedAppsDao.getAppsByRepoIdAsFlow(repoId).map { list -> list.map { it.toDomain() } }
 
-    override suspend fun isAppInstalled(repoId: Long): Boolean = installedAppsDao.getAppByRepoId(repoId) != null
+    override suspend fun isAppInstalled(repoId: Long): Boolean =
+        installedAppsDao.getAppByRepoId(repoId) != null
 
     override suspend fun saveInstalledApp(app: InstalledApp) {
         installedAppsDao.insertApp(app.toEntity())
@@ -143,13 +145,13 @@ class InstalledAppsRepositoryImpl(
                     val flagSays = release.isPrerelease
                     val tagSays =
                         VersionMath.isPreReleaseTag(release.tagName) ||
-                            VersionMath.isPreReleaseTag(release.name)
+                                VersionMath.isPreReleaseTag(release.name)
                     if (flagSays != tagSays) {
                         Logger.w {
                             "Pre-release flag/tag mismatch for $owner/$repo " +
-                                "release '${release.tagName}' (name='${release.name}'): " +
-                                "apiFlag=$flagSays, tagMarker=$tagSays — " +
-                                "treating as pre-release=${flagSays || tagSays}"
+                                    "release '${release.tagName}' (name='${release.name}'): " +
+                                    "apiFlag=$flagSays, tagMarker=$tagSays — " +
+                                    "treating as pre-release=${true}"
                         }
                     }
                 }
@@ -193,8 +195,8 @@ class InstalledAppsRepositoryImpl(
 
         val hasAnyPin =
             preferredVariant != null ||
-                preferredTokens.isNotEmpty() ||
-                !preferredGlob.isNullOrBlank()
+                    preferredTokens.isNotEmpty() ||
+                    !preferredGlob.isNullOrBlank()
 
         for (release in candidates) {
             val installableForPlatform =
@@ -284,28 +286,27 @@ class InstalledAppsRepositoryImpl(
                     ?.onFailure { error ->
                         Logger.w {
                             "Invalid asset filter for $packageName " +
-                                "(${app.assetFilterRegex}): ${error.message} — ignoring"
+                                    "(${app.assetFilterRegex}): ${error.message} — ignoring"
                         }
                     }?.getOrNull()
 
-            val resolved =
-                resolveTrackedRelease(
-                    releases = releases,
-                    filter = compiledFilter,
-                    fallbackToOlderReleases = app.fallbackToOlderReleases,
-                    preferredVariant = app.preferredAssetVariant,
-                    preferredTokens = AssetVariant.deserializeTokens(app.preferredAssetTokens),
-                    preferredGlob = app.assetGlobPattern,
-                    pickedIndex = app.pickedAssetIndex,
-                    pickedSiblingCount = app.pickedAssetSiblingCount,
-                    trackedPackageName = app.packageName,
-                    installedAssetName = app.installedAssetName,
-                )
+            val resolved = resolveTrackedRelease(
+                releases = releases,
+                filter = compiledFilter,
+                fallbackToOlderReleases = app.fallbackToOlderReleases,
+                preferredVariant = app.preferredAssetVariant,
+                preferredTokens = AssetVariant.deserializeTokens(app.preferredAssetTokens),
+                preferredGlob = app.assetGlobPattern,
+                pickedIndex = app.pickedAssetIndex,
+                pickedSiblingCount = app.pickedAssetSiblingCount,
+                trackedPackageName = app.packageName,
+                installedAssetName = app.installedAssetName,
+            )
 
             if (resolved == null) {
                 Logger.d {
                     "No matching release found for ${app.appName} in window of ${releases.size}; " +
-                        "filter=${app.assetFilterRegex}, fallback=${app.fallbackToOlderReleases}"
+                            "filter=${app.assetFilterRegex}, fallback=${app.fallbackToOlderReleases}"
                 }
 
                 installedAppsDao.clearUpdateMetadata(packageName, System.currentTimeMillis())
@@ -318,18 +319,18 @@ class InstalledAppsRepositoryImpl(
             val latestCode = app.latestVersionCode
             val codesAlreadyMatch =
                 installedCode > 0L &&
-                    latestCode != null &&
-                    latestCode > 0L &&
-                    installedCode == latestCode
+                        latestCode != null &&
+                        latestCode > 0L &&
+                        installedCode == latestCode
 
             val skippedTag = app.skippedReleaseTag
             val matchesSkipped =
                 skippedTag != null &&
-                    VersionMath.isExactSameVersion(matchedRelease.tagName, skippedTag)
+                        VersionMath.isExactSameVersion(matchedRelease.tagName, skippedTag)
             val skipBecameStale =
                 skippedTag != null &&
-                    !matchesSkipped &&
-                    VersionMath.isVersionNewer(matchedRelease.tagName, skippedTag)
+                        !matchesSkipped &&
+                        VersionMath.isVersionNewer(matchedRelease.tagName, skippedTag)
             if (skipBecameStale) {
                 installedAppsDao.setSkippedReleaseTag(packageName, null)
             }
@@ -347,12 +348,19 @@ class InstalledAppsRepositoryImpl(
 
             Logger.d {
                 "Update check for ${app.appName}: " +
-                    "installedTag=${app.installedVersion}, " +
-                    "matchedTag=${matchedRelease.tagName}, " +
-                    "matchedAsset=${primaryAsset.name}, " +
-                    "codesMatch=$codesAlreadyMatch, " +
-                    "isUpdate=$isUpdateAvailable, variantLost=$variantWasLost"
+                        "installedTag=${app.installedVersion}, " +
+                        "matchedTag=${matchedRelease.tagName}, " +
+                        "matchedAsset=${primaryAsset.name}, " +
+                        "codesMatch=$codesAlreadyMatch, " +
+                        "isUpdate=$isUpdateAvailable, variantLost=$variantWasLost"
             }
+
+            val resolvedLatestVersionCode =
+                when {
+                    !isUpdateAvailable && installedCode > 0L -> installedCode
+                    matchedRelease.tagName == app.latestVersion -> app.latestVersionCode
+                    else -> null
+                }
 
             installedAppsDao.updateVersionInfo(
                 packageName = packageName,
@@ -364,7 +372,7 @@ class InstalledAppsRepositoryImpl(
                 releaseNotes = matchedRelease.description ?: "",
                 timestamp = System.currentTimeMillis(),
                 latestVersionName = matchedRelease.tagName,
-                latestVersionCode = null,
+                latestVersionCode = resolvedLatestVersionCode,
                 latestReleasePublishedAt = matchedRelease.publishedAt,
             )
 
@@ -443,7 +451,7 @@ class InstalledAppsRepositoryImpl(
         val snapshotLatestVersion = app.latestVersion
         val isUpdateStillAvailable =
             !snapshotLatestVersion.isNullOrBlank() &&
-                VersionMath.isVersionNewer(snapshotLatestVersion, newTag)
+                    VersionMath.isVersionNewer(snapshotLatestVersion, newTag)
 
         installedAppsDao.updateApp(
             app.copy(
@@ -453,6 +461,7 @@ class InstalledAppsRepositoryImpl(
                 installedVersionName = newVersionName,
                 installedVersionCode = newVersionCode,
                 isUpdateAvailable = isUpdateStillAvailable,
+                latestVersionCode = if (isUpdateStillAvailable) app.latestVersionCode else newVersionCode,
                 isPendingInstall = isPendingInstall,
                 lastUpdatedAt = System.currentTimeMillis(),
                 lastCheckedAt = System.currentTimeMillis(),
@@ -542,7 +551,7 @@ class InstalledAppsRepositoryImpl(
         } catch (e: Exception) {
             Logger.w {
                 "Saved new asset filter for $packageName but immediate " +
-                    "re-check failed: ${e.message}"
+                        "re-check failed: ${e.message}"
             }
         }
     }
@@ -574,7 +583,7 @@ class InstalledAppsRepositoryImpl(
         } catch (e: Exception) {
             Logger.w {
                 "Saved new variant for $packageName but immediate " +
-                    "re-check failed: ${e.message}"
+                        "re-check failed: ${e.message}"
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -321,7 +321,8 @@ class InstalledAppsRepositoryImpl(
                 installedCode > 0L &&
                         latestCode != null &&
                         latestCode > 0L &&
-                        installedCode == latestCode
+                        installedCode == latestCode &&
+                        matchedRelease.tagName == app.latestVersion
 
             val skippedTag = app.skippedReleaseTag
             val matchesSkipped =
@@ -361,12 +362,12 @@ class InstalledAppsRepositoryImpl(
                         "isUpdate=$isUpdateAvailable, variantLost=$variantWasLost"
             }
 
+            // Keep the latest release's known code only while the tag is unchanged. A new
+            // tag means a new (still-unknown) code, so reset to null — otherwise
+            // codesAlreadyMatch would freeze on a stale code and mask the new release.
+            // The real code is set on install (updateAppVersion); the poll never invents it.
             val resolvedLatestVersionCode =
-                when {
-                    !isUpdateAvailable && installedCode > 0L -> installedCode
-                    matchedRelease.tagName == app.latestVersion -> app.latestVersionCode
-                    else -> null
-                }
+                if (matchedRelease.tagName == app.latestVersion) app.latestVersionCode else null
 
             installedAppsDao.updateVersionInfo(
                 packageName = packageName,

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/repository/InstalledAppsRepositoryImpl.kt
@@ -335,10 +335,16 @@ class InstalledAppsRepositoryImpl(
                 installedAppsDao.setSkippedReleaseTag(packageName, null)
             }
 
+            // If the installed version can't be reconciled with the release tag (e.g. tag
+            // 2.0.9.1 vs APK versionName 2.0.9-<githash>), numeric comparison is misleading.
+            // Pin to the current tag (below) and track by release tag from here on (GH#729).
+            val reconcilable =
+                VersionMath.versionsReconcilable(app.installedVersion, matchedRelease.tagName)
             val isUpdateAvailable =
                 when {
                     codesAlreadyMatch -> false
                     matchesSkipped -> false
+                    !reconcilable -> false
                     else ->
                         VersionMath.isVersionNewer(
                             candidate = matchedRelease.tagName,
@@ -376,7 +382,7 @@ class InstalledAppsRepositoryImpl(
                 latestReleasePublishedAt = matchedRelease.publishedAt,
             )
 
-            if (codesAlreadyMatch &&
+            if ((codesAlreadyMatch || !reconcilable) &&
                 app.installedVersion != matchedRelease.tagName
             ) {
                 installedAppsDao.updateInstalledVersion(

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/VersionMath.kt
@@ -97,6 +97,22 @@ object VersionMath {
         return compareNormalized(normCandidate, normCurrent) > 0
     }
 
+    // Whether two versions can be compared meaningfully by number. False when one is
+    // unparseable, or when exactly one carries a commit-hash-style suffix (e.g. tag
+    // "2.0.9.1" vs APK versionName "2.0.9-1c19925b5") — the hash normalizes to a
+    // pre-release and makes the real build look older. Callers should then track by
+    // release tag instead of nagging on a bogus numeric diff (GH#729).
+    fun versionsReconcilable(installed: String?, latest: String?): Boolean {
+        val a = parseSemanticVersion(normalizeVersion(installed)) ?: return false
+        val b = parseSemanticVersion(normalizeVersion(latest)) ?: return false
+        val aHash = a.preRelease?.let { isCommitHashPreRelease(it) } == true
+        val bHash = b.preRelease?.let { isCommitHashPreRelease(it) } == true
+        return aHash == bHash
+    }
+
+    private fun isCommitHashPreRelease(preRelease: String): Boolean =
+        COMMIT_HASH_PATTERN.matches(preRelease)
+
     fun compareVersions(a: String?, b: String?): Int {
         val normA = normalizeVersion(a)
         val normB = normalizeVersion(b)

--- a/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
+++ b/feature/apps/data/src/commonMain/kotlin/zed/rainxch/apps/data/repository/AppsRepositoryImpl.kt
@@ -279,11 +279,22 @@ class AppsRepositoryImpl(
         val resolvedGlob = assetGlobPattern ?: freshFingerprint?.glob
         val resolvedSiblingCount = pickedAssetSiblingCount.takeIf { it > 0 }
 
+        // Store the release tag (not the APK versionName) when the two can't be reconciled,
+        // so update checks compare tag-vs-tag instead of false-nagging (GH#729).
+        val reconcilable =
+            VersionMath.versionsReconcilable(deviceApp.versionName, repoInfo.latestReleaseTag)
         val initialIsUpdateAvailable =
-            VersionMath.isVersionNewer(
-                candidate = repoInfo.latestReleaseTag,
-                current = deviceApp.versionName,
-            )
+            reconcilable &&
+                VersionMath.isVersionNewer(
+                    candidate = repoInfo.latestReleaseTag,
+                    current = deviceApp.versionName,
+                )
+        val initialInstalledVersion =
+            if (reconcilable) {
+                deviceApp.versionName ?: "unknown"
+            } else {
+                repoInfo.latestReleaseTag ?: deviceApp.versionName ?: "unknown"
+            }
 
         val installedApp =
             InstalledApp(
@@ -295,7 +306,7 @@ class AppsRepositoryImpl(
                 repoDescription = repoInfo.description,
                 primaryLanguage = repoInfo.language,
                 repoUrl = repoInfo.htmlUrl,
-                installedVersion = deviceApp.versionName ?: "unknown",
+                installedVersion = initialInstalledVersion,
                 installedAssetName = null,
                 installedAssetUrl = null,
                 latestVersion = repoInfo.latestReleaseTag,


### PR DESCRIPTION
Three fixes for false "update available" nags (refs #729).

1. **Track irreconcilable versions by release tag (Obtainium's approach).** When the installed version can't be reconciled with the release tag — e.g. PiliPlus tags `2.0.9.1` but builds the APK with versionName `2.0.9-<git-hash>`, so the hash normalizes to a pre-release and the real build looks *older* — numeric comparison is meaningless. `VersionMath.versionsReconcilable` detects this (hash-suffix on one side only / unparseable), and the update check then pins `installedVersion` to the current tag and compares **tag-vs-tag** from then on. A genuinely new release still flags; the same release never false-nags. No APK downloads (matches Obtainium). Also fixes `linkAppToRepo` storing the APK versionName instead of the tag.

2. **Persist latest versionCode.** The poll wrote `latestVersionCode = null` every time, so the `codesAlreadyMatch` guard never fired. Now: up-to-date → seed with the installed code; same tag → keep; newer tag → null; installing the latest records its code. Store-installed apps stop nagging precisely.

3. **Auto-link no longer lists already-tracked apps.** `ExternalImportRepositoryImpl` now has `InstalledAppDao` and excludes tracked packages (and prunes stale candidate rows).

Trade-off (irreconcilable apps only): if a user links an *old* build of such an app, it's assumed current until a newer release appears — unavoidable without the APK's versionCode, same as Obtainium. Download-verify ("precise mode") parked as a possible future opt-in.

Refs #729.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate linking of already-managed apps and removed stale external link entries to avoid DB conflicts.
  * Made update/version metadata persistence more reliable so apps retain accurate latest-version info.
  * Adjusted update-check behavior and related logging to reduce incorrect warnings.

* **New Features**
  * Improved update detection by reconciling installed and repository version formats, producing more accurate "update available" results and initial installed-version values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->