### PR TITLE
Stop re-asking for root permission every launch

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -81,6 +81,7 @@ actual val corePlatformModule =
 
         single {
             RootServiceManager(
+                context = androidContext(),
                 scope = get<CoroutineScope>(),
             ).also { it.initialize() }
         }

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/root/RootServiceManager.kt
@@ -1,5 +1,6 @@
 package zed.rainxch.core.data.services.root
 
+import android.content.Context
 import co.touchlab.kermit.Logger
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.CoroutineScope
@@ -13,8 +14,21 @@ import zed.rainxch.core.data.services.root.model.RootStatus
 import java.io.File
 
 class RootServiceManager(
+    private val context: Context,
     private val scope: CoroutineScope,
 ) {
+    private val prefs by lazy {
+        context.getSharedPreferences(ROOT_PREFS, Context.MODE_PRIVATE)
+    }
+
+    private fun wasGrantedBefore(): Boolean = prefs.getBoolean(KEY_GRANTED_BEFORE, false)
+
+    private fun rememberGranted(granted: Boolean) {
+        if (prefs.getBoolean(KEY_GRANTED_BEFORE, false) != granted) {
+            prefs.edit().putBoolean(KEY_GRANTED_BEFORE, granted).apply()
+        }
+    }
+
     private val _status = MutableStateFlow(RootStatus.NOT_AVAILABLE)
     val status: StateFlow<RootStatus> = _status.asStateFlow()
 
@@ -125,15 +139,34 @@ class RootServiceManager(
 
     private fun computeStatus(): RootStatus {
         Shell.getCachedShell()?.let { shell ->
+            rememberGranted(shell.isRoot)
             return if (shell.isRoot) RootStatus.READY else RootStatus.NOT_AVAILABLE
         }
         return when (Shell.isAppGrantedRoot()) {
-            true -> RootStatus.READY
-            false, null -> RootStatus.PERMISSION_NEEDED
+            true -> {
+                rememberGranted(true)
+                RootStatus.READY
+            }
+            // false/null on a fresh process (no shell created yet) is unreliable. If root
+            // was granted before, trust the su manager's persistent grant instead of
+            // re-prompting on every launch (GH#705). A real revoke is caught lazily when
+            // an install actually spawns the shell (isRootGranted below).
+            else -> if (wasGrantedBefore()) RootStatus.READY else RootStatus.PERMISSION_NEEDED
         }
     }
 
-    private fun isRootGranted(): Boolean = Shell.isAppGrantedRoot() == true
+    // Establishes the root shell and reports whether root is actually granted. With a
+    // persistent su grant this is silent (no prompt); if the grant was revoked the shell
+    // comes back non-root and we forget the remembered grant so the status corrects.
+    private fun isRootGranted(): Boolean =
+        try {
+            val granted = Shell.getShell().isRoot
+            rememberGranted(granted)
+            granted
+        } catch (e: Exception) {
+            Logger.w(TAG) { "isRootGranted() — getShell failed: ${e.message}" }
+            false
+        }
 
     private fun configureDefaultShell() {
         if (configured) return
@@ -155,6 +188,8 @@ class RootServiceManager(
 
     companion object {
         private const val TAG = "RootServiceManager"
+        private const val ROOT_PREFS = "ghs_root_prefs"
+        private const val KEY_GRANTED_BEFORE = "root_granted_before"
         private const val STATUS_SUCCESS = 0
         private const val STATUS_FAILURE = -1
         private const val SHELL_TIMEOUT_SECONDS = 10L


### PR DESCRIPTION
Root users get re-prompted to "allow root" on (almost) every launch even though the su manager (KernelSU/Magisk) already granted it persistently (#705).

Cause: after process death there's no cached libsu shell, and `Shell.isAppGrantedRoot()` returns null on a fresh process. `computeStatus()` mapped null → `PERMISSION_NEEDED`, so the app re-asked.

Fix: persist a "root was granted" flag (`RootServiceManager` now has a `Context`). When libsu can't determine the state on a fresh process (null/false), trust the persistent grant → `READY`, no re-prompt. A real revoke is caught lazily: `isRootGranted()` now establishes the shell (silent under a persistent grant) and forgets the flag if it comes back non-root, so the status self-corrects.

Net: grant once → stays granted until you revoke in the su manager or an install genuinely fails — exactly what the reporter asked for.

Fixes #705.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Root access permissions are now reliably remembered and restored across app sessions on Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->