### PR TITLE
feat: support downloads from private GitHub repos for signed-in users

### DIFF
--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/di/PlatformModule.android.kt
@@ -57,6 +57,7 @@ actual val corePlatformModule =
         single<Downloader> {
             AndroidDownloader(
                 files = get(),
+                tokenStore = get(),
             )
         }
 

--- a/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
+++ b/core/data/src/androidMain/kotlin/zed/rainxch/core/data/services/AndroidDownloader.kt
@@ -10,6 +10,8 @@ import okhttp3.Call
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import zed.rainxch.core.data.data_source.TokenStore
+import zed.rainxch.core.data.network.GithubAssetAuth
 import zed.rainxch.core.data.network.ProxyManager
 import zed.rainxch.core.data.network.resolveAndroidSystemProxy
 import zed.rainxch.core.domain.model.installation.DownloadProgress
@@ -30,6 +32,7 @@ import java.util.concurrent.TimeUnit
 
 class AndroidDownloader(
     private val files: FileLocationsProvider,
+    private val tokenStore: TokenStore,
 ) : Downloader {
     private val activeDownloads = ConcurrentHashMap<String, Call>()
     private val idsByName = ConcurrentHashMap<String, MutableSet<String>>()
@@ -119,7 +122,19 @@ class AndroidDownloader(
 
             Logger.d { "Starting download: $url (id=$downloadId)" }
 
-            val request = Request.Builder().url(url).build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .apply {
+                        val token = githubToken()
+                        if (token != null && GithubAssetAuth.isGithubHost(url)) {
+                            header("Authorization", "Bearer $token")
+                            if (GithubAssetAuth.isGithubApiHost(url)) {
+                                header("Accept", "application/octet-stream")
+                            }
+                        }
+                    }.build()
             val call = client.newCall(request)
 
             activeDownloads[downloadId] = call
@@ -180,6 +195,15 @@ class AndroidDownloader(
                 }
             }
         }.flowOn(Dispatchers.IO)
+
+    private suspend fun githubToken(): String? =
+        try {
+            tokenStore.currentToken()?.accessToken?.trim()?.takeIf { it.isNotEmpty() }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
     private fun moveAtomic(source: File, target: File) {
         try {

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/di/SharedModule.kt
@@ -301,6 +301,7 @@ val coreModule =
                 slowDownloadDetector = get(),
                 appScope = get(),
                 systemInstallSerializer = get(),
+                tokenStore = get(),
             )
         }
 

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubRepoNetworkModel.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/dto/GithubRepoNetworkModel.kt
@@ -19,6 +19,7 @@ data class GithubRepoNetworkModel(
     @SerialName("releases_url") val releasesUrl: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("fork") val fork: Boolean = false,
+    @SerialName("private") val private: Boolean = false,
     @SerialName("archived") val archived: Boolean = false,
     @SerialName("open_issues_count") val openIssuesCount: Int = 0,
     @SerialName("has_downloads") val hasDownloads: Boolean = false,

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendFallbackPolicy.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/BackendFallbackPolicy.kt
@@ -13,6 +13,16 @@ fun shouldFallbackToGithubOrRethrow(cause: Throwable): Boolean =
         else -> true
     }
 
+fun shouldFallbackToGithubOrRethrow(cause: Throwable, isSignedIn: Boolean): Boolean =
+    when (cause) {
+        is CancellationException -> throw cause
+        is RateLimitedException -> throw cause.toDomainRateLimitException()
+        is BackendException ->
+            cause.statusCode in 500..599 ||
+                (isSignedIn && cause.statusCode in setOf(401, 403, 404))
+        else -> true
+    }
+
 private fun RateLimitedException.toDomainRateLimitException(): RateLimitException {
     val nowSec = Clock.System.now().epochSeconds
     val reset = resetEpochSeconds

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/GithubAssetAuth.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/network/GithubAssetAuth.kt
@@ -1,0 +1,29 @@
+package zed.rainxch.core.data.network
+
+object GithubAssetAuth {
+    fun hostOf(url: String): String? {
+        val afterScheme = url.substringAfter("://", "")
+        if (afterScheme.isEmpty()) return null
+        return afterScheme
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringBefore('#')
+            .substringBefore(':')
+            .lowercase()
+            .ifEmpty { null }
+    }
+
+    fun isGithubHost(url: String): Boolean {
+        if (!url.startsWith("https://", ignoreCase = true)) return false
+        val host = hostOf(url) ?: return false
+        return host == "github.com" ||
+            host == "api.github.com" ||
+            host == "codeload.github.com" ||
+            host.endsWith(".githubusercontent.com")
+    }
+
+    fun isGithubApiHost(url: String): Boolean = hostOf(url) == "api.github.com"
+
+    fun assetApiUrl(owner: String, repo: String, assetId: Long): String =
+        "https://api.github.com/repos/$owner/$repo/releases/assets/$assetId"
+}

--- a/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
+++ b/core/data/src/commonMain/kotlin/zed/rainxch/core/data/services/DefaultDownloadOrchestrator.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import zed.rainxch.core.data.data_source.TokenStore
+import zed.rainxch.core.data.network.GithubAssetAuth
+import zed.rainxch.core.domain.model.installation.DownloadProgress
 import zed.rainxch.core.domain.network.DigestVerifier
 import zed.rainxch.core.domain.network.Downloader
 import zed.rainxch.core.domain.network.SlowDownloadDetector
@@ -41,6 +44,7 @@ class DefaultDownloadOrchestrator(
     private val slowDownloadDetector: SlowDownloadDetector,
     private val appScope: CoroutineScope,
     private val systemInstallSerializer: SystemInstallSerializer,
+    private val tokenStore: TokenStore,
 ) : DownloadOrchestrator {
     private companion object {
         private const val DEFAULT_MAX_CONCURRENT = 3
@@ -147,18 +151,38 @@ class DefaultDownloadOrchestrator(
             )
         }
 
-        multiSourceDownloader.download(spec.asset.downloadUrl, scopedName).collect { progress ->
-            if (progress.restart) {
-                slowDownloadDetector.reset()
+        suspend fun streamProgress(flow: Flow<DownloadProgress>) {
+            flow.collect { progress ->
+                if (progress.restart) {
+                    slowDownloadDetector.reset()
+                }
+                slowDownloadDetector.onProgress(progress)
+                updateEntry(spec.packageName) {
+                    it.copy(
+                        progressPercent = progress.percent,
+                        bytesDownloaded = progress.bytesDownloaded,
+                        totalBytes = progress.totalBytes ?: it.totalBytes,
+                    )
+                }
             }
-            slowDownloadDetector.onProgress(progress)
+        }
+
+        try {
+            streamProgress(multiSourceDownloader.download(spec.asset.downloadUrl, scopedName))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            val apiUrl = authenticatedGithubAssetUrl(spec)
+                ?: throw e
+            Logger.w(e) {
+                "Orchestrator: primary download failed for ${spec.asset.name}, " +
+                    "retrying via authenticated GitHub asset API"
+            }
             updateEntry(spec.packageName) {
-                it.copy(
-                    progressPercent = progress.percent,
-                    bytesDownloaded = progress.bytesDownloaded,
-                    totalBytes = progress.totalBytes ?: it.totalBytes,
-                )
+                it.copy(bytesDownloaded = 0L, progressPercent = 0)
             }
+            slowDownloadDetector.reset()
+            streamProgress(downloader.download(apiUrl, scopedName, bypassMirror = true))
         }
 
         val filePath =
@@ -197,6 +221,21 @@ class DefaultDownloadOrchestrator(
 
             InstallPolicy.DeferUntilUserAction -> parkForUser(spec, filePath, notify = true)
         }
+    }
+
+    private suspend fun authenticatedGithubAssetUrl(spec: DownloadSpec): String? {
+        if (spec.asset.id <= 0L) return null
+        if (!GithubAssetAuth.isGithubHost(spec.asset.downloadUrl)) return null
+        val signedIn =
+            try {
+                tokenStore.currentToken()?.accessToken?.trim().isNullOrEmpty().not()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                false
+            }
+        if (!signedIn) return null
+        return GithubAssetAuth.assetApiUrl(spec.repoOwner, spec.repoName, spec.asset.id)
     }
 
     private suspend fun runInstall(spec: DownloadSpec, filePath: String) {

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
@@ -46,6 +46,7 @@ actual val corePlatformModule = module {
     single<Downloader> {
         DesktopDownloader(
             files = get(),
+            tokenStore = get(),
         )
     }
 

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopDownloader.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/services/DesktopDownloader.kt
@@ -10,6 +10,8 @@ import okhttp3.Call
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import zed.rainxch.core.data.data_source.TokenStore
+import zed.rainxch.core.data.network.GithubAssetAuth
 import zed.rainxch.core.data.network.ProxyManager
 import zed.rainxch.core.domain.model.installation.DownloadProgress
 import zed.rainxch.core.domain.model.settings.ProxyConfig
@@ -28,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 class DesktopDownloader(
     private val files: FileLocationsProvider,
+    private val tokenStore: TokenStore,
 ) : Downloader {
     private val activeDownloads = ConcurrentHashMap<String, Call>()
     private val idsByName = ConcurrentHashMap<String, MutableSet<String>>()
@@ -110,7 +113,19 @@ class DesktopDownloader(
 
             Logger.d { "Starting download: $url" }
 
-            val request = Request.Builder().url(url).build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .apply {
+                        val token = githubToken()
+                        if (token != null && GithubAssetAuth.isGithubHost(url)) {
+                            header("Authorization", "Bearer $token")
+                            if (GithubAssetAuth.isGithubApiHost(url)) {
+                                header("Accept", "application/octet-stream")
+                            }
+                        }
+                    }.build()
             val call = client.newCall(request)
             activeDownloads[downloadId] = call
             idsByName.computeIfAbsent(safeName) { ConcurrentHashMap.newKeySet() }.add(downloadId)
@@ -166,6 +181,15 @@ class DesktopDownloader(
                 }
             }
         }.flowOn(Dispatchers.IO)
+
+    private suspend fun githubToken(): String? =
+        try {
+            tokenStore.currentToken()?.accessToken?.trim()?.takeIf { it.isNotEmpty() }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
     private fun moveAtomic(source: File, target: File) {
         try {

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/account/ForgeKind.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/account/ForgeKind.kt
@@ -11,7 +11,7 @@ enum class ForgeKind(
         displayName = "GitHub",
         tokenCreationUrl =
             "https://github.com/settings/tokens/new" +
-                "?scopes=public_repo,read:user&description=GitHub%20Store",
+                "?scopes=repo,read:user&description=GitHub%20Store",
         tokenTermNoun = "Personal access token",
     ),
     CODEBERG(

--- a/feature/auth/data/src/commonMain/kotlin/zed/rainxch/auth/data/network/GitHubAuthApi.kt
+++ b/feature/auth/data/src/commonMain/kotlin/zed/rainxch/auth/data/network/GitHubAuthApi.kt
@@ -74,6 +74,7 @@ object GitHubAuthApi {
                         FormDataContent(
                             Parameters.build {
                                 append("client_id", clientId)
+                                append("scope", "repo")
                             },
                         ),
                     )

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/di/SharedModule.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/di/SharedModule.kt
@@ -20,6 +20,7 @@ val detailsModule =
                 localizationManager = get(),
                 cacheManager = get(),
                 forgejoClientRegistry = get(),
+                tokenStore = get(),
             )
         }
 

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -24,6 +24,7 @@ import zed.rainxch.details.data.dto.AttestationsResponse
 import zed.rainxch.core.data.dto.BackendRepoResponse
 import zed.rainxch.core.data.mappers.toDomain
 import zed.rainxch.core.data.mappers.toSummary
+import zed.rainxch.core.data.data_source.TokenStore
 import zed.rainxch.core.data.network.BackendApiClient
 import zed.rainxch.core.data.network.BackendException
 import zed.rainxch.core.data.network.RateLimitedException
@@ -56,8 +57,18 @@ class DetailsRepositoryImpl(
     private val logger: GitHubStoreLogger,
     private val cacheManager: CacheManager,
     private val forgejoClientRegistry: zed.rainxch.core.data.network.ForgejoClientRegistry,
+    private val tokenStore: TokenStore,
 ) : DetailsRepository {
     private val httpClient: HttpClient get() = clientProvider.client
+
+    private suspend fun isSignedIn(): Boolean =
+        try {
+            tokenStore.currentToken()?.accessToken?.trim()?.isNotEmpty() == true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
 
     private fun zed.rainxch.core.data.dto.ForgejoRepoNetworkModel.toForgejoSummary(
         sourceHost: String,
@@ -92,8 +103,8 @@ class DetailsRepositoryImpl(
 
     private val readmeHelper = ReadmeLocalizationHelper(localizationManager)
 
-    private fun shouldFallbackToGithubOrRethrow(cause: Throwable): Boolean =
-        sharedShouldFallback(cause)
+    private fun shouldFallbackToGithubOrRethrow(cause: Throwable, isSignedIn: Boolean): Boolean =
+        sharedShouldFallback(cause, isSignedIn)
 
     private fun BackendRepoResponse.toBackendSummary(): GithubRepoSummary = toSummary()
 
@@ -172,7 +183,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, isSignedIn())) {
 
                     cacheManager.getStale<GithubRepoSummary>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for $owner/$name, serving stale cache")
@@ -328,7 +339,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, isSignedIn())) {
                     cacheManager.getStale<List<GithubRelease>>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for releases $owner/$repo, serving stale cache")
                         return stale
@@ -434,7 +445,7 @@ class DetailsRepositoryImpl(
                 logger.debug("Backend readme decode failed for $owner/$repo, falling back to raw URL")
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, isSignedIn())) {
                     cacheManager.getStale<CachedReadme>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for readme $owner/$repo, serving stale cache")
                         return Triple(stale.content, stale.languageCode, stale.path)
@@ -545,7 +556,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, isSignedIn())) {
                     cacheManager.getStale<RepoStats>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for stats $owner/$repo, serving stale cache")
                         return stale
@@ -604,7 +615,7 @@ class DetailsRepositoryImpl(
                 return result
             },
             onFailure = { e ->
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, isSignedIn())) {
                     cacheManager.getStale<GithubUserProfile>(cacheKey)?.let { stale ->
                         logger.debug("Backend 4xx for profile $username, serving stale cache")
                         return stale

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/di/SharedModule.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/di/SharedModule.kt
@@ -14,6 +14,7 @@ val searchModule =
                 backendApiClient = get(),
                 cacheManager = get(),
                 forgejoClientRegistry = get(),
+                tokenStore = get(),
             )
         }
 

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -45,6 +45,7 @@ class SearchRepositoryImpl(
     private val backendApiClient: BackendApiClient,
     private val cacheManager: CacheManager,
     private val forgejoClientRegistry: zed.rainxch.core.data.network.ForgejoClientRegistry,
+    private val tokenStore: zed.rainxch.core.data.data_source.TokenStore,
 ) : SearchRepository {
     private val httpClient: HttpClient get() = clientProvider.client
     private val releaseCheckCache = LruCache<String, GithubRepoSummary>(maxSize = 500)
@@ -93,21 +94,76 @@ class SearchRepositoryImpl(
 
             val cacheKey = searchCacheKey(query, platform, language, sortBy, sortOrder, page)
 
+            val privateMatches =
+                if (page == 1 && query.isNotBlank()) {
+                    searchPrivateRepos(query, language)
+                } else {
+                    emptyList()
+                }
+
             val cached = cacheManager.get<PaginatedDiscoveryRepositories>(cacheKey)
             if (cached != null) {
-                send(cached)
+                send(cached.prepend(privateMatches))
                 return@channelFlow
             }
 
             val backendResult = tryBackendSearch(query, platform, sortBy, page)
             if (backendResult != null) {
                 cacheManager.put(cacheKey, backendResult, SEARCH_RESULTS)
-                send(backendResult)
+                send(backendResult.prepend(privateMatches))
                 return@channelFlow
             }
 
-            fallbackGithubSearch(query, platform, language, sortBy, sortOrder, page, cacheKey)
+            fallbackGithubSearch(query, platform, language, sortBy, sortOrder, page, cacheKey, privateMatches)
         }.flowOn(Dispatchers.IO)
+
+    private suspend fun searchPrivateRepos(
+        query: String,
+        language: ProgrammingLanguage,
+    ): List<GithubRepoSummary> {
+        if (tokenStore.currentToken()?.accessToken?.isNotBlank() != true) return emptyList()
+
+        val safeQuery = query.trim().replace("\"", "")
+        val q =
+            buildString {
+                append("\"$safeQuery\" in:name,description fork:true is:private")
+                if (language != ProgrammingLanguage.All && language.queryValue != null) {
+                    append(" language:${language.queryValue}")
+                }
+            }
+
+        return try {
+            val response =
+                httpClient
+                    .executeRequest<GithubRepoSearchResponse> {
+                        get("/search/repositories") {
+                            parameter("q", q)
+                            parameter("per_page", 20)
+                        }
+                    }.getOrNull() ?: return emptyList()
+
+            response.items
+                .filter { it.private }
+                .map { it.toSummary() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun PaginatedDiscoveryRepositories.prepend(
+        extra: List<GithubRepoSummary>,
+    ): PaginatedDiscoveryRepositories {
+        if (extra.isEmpty()) return this
+        val existingIds = repos.mapTo(mutableSetOf()) { it.id }
+        val deduped = extra.filter { it.id !in existingIds }
+        if (deduped.isEmpty()) return this
+        return copy(
+            repos = deduped + repos,
+            totalCount = totalCount?.plus(deduped.size),
+        )
+    }
 
     private suspend fun kotlinx.coroutines.channels.ProducerScope<PaginatedDiscoveryRepositories>.forgejoSearch(
         host: String,
@@ -217,6 +273,7 @@ class SearchRepositoryImpl(
         sortOrder: SortOrder,
         page: Int,
         cacheKey: String,
+        privateMatches: List<GithubRepoSummary>,
     ) {
         val searchQuery = buildSearchQuery(query, language)
         val sort = sortBy.toGithubSortParam()
@@ -254,7 +311,7 @@ class SearchRepositoryImpl(
                             hasMore = false,
                             nextPageIndex = currentPage + 1,
                             totalCount = total,
-                        ),
+                        ).prepend(privateMatches),
                     )
                     return
                 }
@@ -270,7 +327,7 @@ class SearchRepositoryImpl(
                             totalCount = total,
                         )
                     cacheManager.put(cacheKey, result, SEARCH_RESULTS)
-                    send(result)
+                    send(result.prepend(privateMatches))
                     return
                 }
 
@@ -281,7 +338,7 @@ class SearchRepositoryImpl(
                             hasMore = false,
                             nextPageIndex = currentPage + 1,
                             totalCount = total,
-                        ),
+                        ).prepend(privateMatches),
                     )
                     return
                 }
@@ -296,7 +353,7 @@ class SearchRepositoryImpl(
                     hasMore = true,
                     nextPageIndex = currentPage + 1,
                     totalCount = null,
-                ),
+                ).prepend(privateMatches),
             )
         } catch (e: RateLimitException) {
             throw e
@@ -308,7 +365,7 @@ class SearchRepositoryImpl(
                     repos = emptyList(),
                     hasMore = false,
                     nextPageIndex = page,
-                ),
+                ).prepend(privateMatches),
             )
         }
     }

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -96,7 +96,7 @@ class SearchRepositoryImpl(
 
             val privateMatches =
                 if (page == 1 && query.isNotBlank()) {
-                    searchPrivateRepos(query, language)
+                    searchPrivateRepos(query, platform, language)
                 } else {
                     emptyList()
                 }
@@ -117,11 +117,21 @@ class SearchRepositoryImpl(
             fallbackGithubSearch(query, platform, language, sortBy, sortOrder, page, cacheKey, privateMatches)
         }.flowOn(Dispatchers.IO)
 
+    private suspend fun isSignedIn(): Boolean =
+        try {
+            tokenStore.currentToken()?.accessToken?.isNotBlank() == true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
+
     private suspend fun searchPrivateRepos(
         query: String,
+        platform: DiscoveryPlatform,
         language: ProgrammingLanguage,
     ): List<GithubRepoSummary> {
-        if (tokenStore.currentToken()?.accessToken?.isNotBlank() != true) return emptyList()
+        if (!isSignedIn()) return emptyList()
 
         val safeQuery = query.trim().replace("\"", "")
         val q =
@@ -142,9 +152,12 @@ class SearchRepositoryImpl(
                         }
                     }.getOrNull() ?: return emptyList()
 
-            response.items
-                .filter { it.private }
-                .map { it.toSummary() }
+            val privateItems = response.items.filter { it.private }
+            if (platform == DiscoveryPlatform.All) {
+                privateItems.map { it.toSummary() }
+            } else {
+                verifyBatch(privateItems, platform)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
@@ -234,6 +247,7 @@ class SearchRepositoryImpl(
             SortBy.MostForks -> null
         }
 
+        val signedIn = isSignedIn()
         val offset = (page - 1) * BACKEND_PAGE_SIZE
         val result = backendApiClient.search(
             query = query,
@@ -257,7 +271,7 @@ class SearchRepositoryImpl(
             },
             onFailure = { e ->
 
-                if (!shouldFallbackToGithubOrRethrow(e)) {
+                if (!shouldFallbackToGithubOrRethrow(e, signedIn)) {
                     throw e
                 }
                 null


### PR DESCRIPTION
Closes #768.

Authenticated users can now discover and download releases from private GitHub repositories they have access to.

- Attach the user's GitHub token (Authorization: Bearer) to download requests, restricted to https GitHub-owned hosts via GithubAssetAuth. Token is sent in a header (never the URL) and OkHttp strips it on cross-host redirects to S3, so it only reaches GitHub.
- Add an authenticated GitHub asset-API fallback in the download orchestrator: when the primary (mirror/public) download fails and the user is signed in, retry via /repos/{owner}/{repo}/releases/assets/{id}.
- Surface private repos in search results for signed-in users via a dedicated is:private query, prepended to public results and never cached.
- When signed in, fall back from backend to direct GitHub on 401/403/404 so private repos resolve through the user's token.
- Broaden OAuth/PAT scope from public_repo to repo (classic OAuth has no read-only private scope) for both web and device flows.
- Add the private flag to GithubRepoNetworkModel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated users can now search private GitHub repositories.
  * Downloading GitHub release assets can use authenticated requests when available.
* **Improvements**
  * Fallback behavior now accounts for whether the user is signed in, expanding when GitHub retries are attempted.
  * GitHub OAuth/device-flow scope and asset handling were updated for better access.
* **Bug Fixes / Behavior Changes**
  * GitHub asset downloads and orchestrated streaming can retry via the GitHub Releases asset API for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->