### PR TITLE
Fix relative markdown links and intercept README language links (#785)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -14,6 +14,10 @@ android {
 }
 
 kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     sourceSets {
         androidMain.dependencies {
             implementation(libs.androidx.compose.ui.tooling.preview)

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/di/ViewModelsModule.kt
@@ -92,6 +92,13 @@ val viewModelsModule =
                 translationRepository = get(),
             )
         }
+        viewModel { params ->
+            zed.rainxch.details.presentation.markdownviewer.MarkdownViewerViewModel(
+                url = params[0],
+                detailsRepository = get(),
+                translationRepository = get(),
+            )
+        }
         viewModelOf(::DeveloperProfileViewModel)
         viewModel { params ->
             IssuesViewModel(

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
@@ -29,6 +29,7 @@ private sealed interface DetailPaneRoute {
         val owner: String,
         val repo: String,
         val sourceHost: String?,
+        val translateTo: String? = null,
     ) : DetailPaneRoute
 
     data class WhatsNew(
@@ -82,8 +83,8 @@ fun AdaptiveDetailPaneContent(
                         navController = navController,
                         onCrossNavToRepo = onCrossNavToRepo,
                         onClearPane = onClearPane,
-                        onOpenAbout = { repoId, owner, repo, sourceHost ->
-                            route = DetailPaneRoute.About(repoId, owner, repo, sourceHost)
+                        onOpenAbout = { repoId, owner, repo, sourceHost, translateTo ->
+                            route = DetailPaneRoute.About(repoId, owner, repo, sourceHost, translateTo)
                         },
                         onOpenWhatsNew = { repoId, owner, repo, sourceHost ->
                             route = DetailPaneRoute.WhatsNew(repoId, owner, repo, sourceHost)
@@ -99,6 +100,7 @@ fun AdaptiveDetailPaneContent(
                         owner = current.owner,
                         repo = current.repo,
                         sourceHost = current.sourceHost,
+                        translateTo = current.translateTo,
                         onNavigateBack = { route = DetailPaneRoute.Main },
                         viewModel =
                             koinViewModel(key = aboutKey) {
@@ -143,7 +145,7 @@ private fun MainDetailPane(
     navController: NavHostController,
     onCrossNavToRepo: (AdaptiveDetailArgs) -> Unit,
     onClearPane: () -> Unit,
-    onOpenAbout: (Long, String, String, String?) -> Unit,
+    onOpenAbout: (Long, String, String, String?, String?) -> Unit,
     onOpenWhatsNew: (Long, String, String, String?) -> Unit,
 ) {
     val vmKey =

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
@@ -102,6 +102,9 @@ fun AdaptiveDetailPaneContent(
                         sourceHost = current.sourceHost,
                         translateTo = current.translateTo,
                         onNavigateBack = { route = DetailPaneRoute.Main },
+                        onNavigateToMarkdownViewer = { url ->
+                            navController.navigate(GithubStoreGraph.MarkdownViewerScreen(url))
+                        },
                         viewModel =
                             koinViewModel(key = aboutKey) {
                                 parametersOf(
@@ -195,6 +198,9 @@ private fun MainDetailPane(
         },
         onNavigateToPulls = { owner, repo ->
             navController.navigate(GithubStoreGraph.RepoPullsScreen(owner = owner, repo = repo))
+        },
+        onNavigateToMarkdownViewer = { url ->
+            navController.navigate(GithubStoreGraph.MarkdownViewerScreen(url))
         },
         viewModel = viewModel,
     )

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -472,6 +472,9 @@ fun AppNavigation(
                                             ),
                                         )
                                     },
+                                    onNavigateToMarkdownViewer = { url ->
+                                        navController.navigate(GithubStoreGraph.MarkdownViewerScreen(url))
+                                    },
                                     viewModel =
                                         koinViewModel {
                                             parametersOf(
@@ -528,6 +531,9 @@ fun AppNavigation(
                                 sourceHost = args.sourceHost,
                                 translateTo = args.translateTo,
                                 onNavigateBack = { navController.navigateUp() },
+                                onNavigateToMarkdownViewer = { url ->
+                                    navController.navigate(GithubStoreGraph.MarkdownViewerScreen(url))
+                                },
                             )
                         }
 
@@ -631,6 +637,17 @@ fun AppNavigation(
                                     )
                                 },
                                 viewModel = koinViewModel { parametersOf(args.owner, args.repo) },
+                            )
+                        }
+
+                        composable<GithubStoreGraph.MarkdownViewerScreen> { backStackEntry ->
+                            val args = backStackEntry.toRoute<GithubStoreGraph.MarkdownViewerScreen>()
+                            zed.rainxch.details.presentation.markdownviewer.MarkdownViewerRoot(
+                                url = args.url,
+                                onNavigateBack = { navController.navigateUp() },
+                                onNavigateToMarkdownViewer = { url ->
+                                    navController.navigate(GithubStoreGraph.MarkdownViewerScreen(url))
+                                },
                             )
                         }
 

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -427,13 +427,14 @@ fun AppNavigation(
                                             ),
                                         )
                                     },
-                                    onNavigateToAbout = { repoId, owner, repo, sourceHost ->
+                                    onNavigateToAbout = { repoId, owner, repo, sourceHost, translateTo ->
                                         navController.navigate(
                                             GithubStoreGraph.DetailsAboutScreen(
                                                 repositoryId = repoId,
                                                 owner = owner,
                                                 repo = repo,
                                                 sourceHost = sourceHost,
+                                                translateTo = translateTo,
                                             ),
                                         )
                                     },
@@ -525,6 +526,7 @@ fun AppNavigation(
                                 owner = args.owner,
                                 repo = args.repo,
                                 sourceHost = args.sourceHost,
+                                translateTo = args.translateTo,
                                 onNavigateBack = { navController.navigateUp() },
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -156,4 +156,9 @@ sealed interface GithubStoreGraph {
         val owner: String,
         val repo: String,
     ) : GithubStoreGraph
+
+    @Serializable
+    data class MarkdownViewerScreen(
+        val url: String,
+    ) : GithubStoreGraph
 }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -121,6 +121,7 @@ sealed interface GithubStoreGraph {
         val owner: String = "",
         val repo: String = "",
         val sourceHost: String? = null,
+        val translateTo: String? = null,
     ) : GithubStoreGraph
 
     @Serializable

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -396,6 +396,7 @@ class DetailsRepositoryImpl(
                 preprocessMarkdown(
                     markdown = rawMarkdown,
                     baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/",
+                    linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/",
                 )
             }
 
@@ -478,7 +479,8 @@ class DetailsRepositoryImpl(
         }
         val path = dto.path?.takeIf { it.isNotBlank() } ?: "README.md"
         val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/"
-        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl)
+        val linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/"
+        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
         val detectedLang = readmeHelper.detectReadmeLanguage(processed)
         logger.debug("Fetched README via backend (detected language: ${detectedLang ?: "unknown"})")
         return Triple(processed, detectedLang, path)
@@ -500,7 +502,8 @@ class DetailsRepositoryImpl(
                     }.getOrNull()
 
             if (rawMarkdown != null) {
-                val processed = preprocessMarkdown(markdown = rawMarkdown, baseUrl = baseUrl)
+                val linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/"
+                val processed = preprocessMarkdown(markdown = rawMarkdown, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
                 val detectedLang = readmeHelper.detectReadmeLanguage(processed)
                 logger.debug("Fetched README.md (detected language: ${detectedLang ?: "unknown"})")
                 Triple(processed, detectedLang, path)
@@ -715,7 +718,8 @@ class DetailsRepositoryImpl(
 
         val normalized = body.replace("\r\n", "\n")
         val baseUrl = "https://$sourceHost/$owner/$repo/raw/branch/HEAD/"
-        return preprocessMarkdown(markdown = normalized, baseUrl = baseUrl)
+        val linkBaseUrl = "https://$sourceHost/$owner/$repo/src/branch/HEAD/"
+        return preprocessMarkdown(markdown = normalized, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
     }
 
     @OptIn(ExperimentalEncodingApi::class)
@@ -757,7 +761,8 @@ class DetailsRepositoryImpl(
         val path = dto.path?.takeIf { it.isNotBlank() } ?: "README.md"
 
         val baseUrl = "https://$sourceHost/$owner/$repo/raw/branch/$defaultBranch/"
-        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl)
+        val linkBaseUrl = "https://$sourceHost/$owner/$repo/src/branch/$defaultBranch/"
+        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
         val detected = readmeHelper.detectReadmeLanguage(processed)
         cacheManager.put(
             cacheKey,

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -894,4 +894,43 @@ class DetailsRepositoryImpl(
             false
         }
 
+    override suspend fun fetchRawMarkdown(url: String): String? {
+        val fetchUrl = if (url.startsWith("https://github.com/") && url.contains("/blob/")) {
+            url.replaceFirst("https://github.com/", "https://raw.githubusercontent.com/")
+               .replaceFirst("/blob/", "/")
+        } else {
+            url
+        }
+
+        return try {
+            val rawMarkdown = httpClient.executeRequest<String> {
+                get(fetchUrl)
+            }.getOrNull()
+
+            if (rawMarkdown != null) {
+                val match = Regex("""https://(?:raw\.githubusercontent\.com|github\.com)/([^/]+)/([^/]+)/(?:blob/)?([^/]+)/(.*)""").find(url)
+                if (match != null) {
+                    val owner = match.groupValues[1]
+                    val repo = match.groupValues[2]
+                    val branch = match.groupValues[3]
+                    val path = match.groupValues[4]
+
+                    val basePath = path.substringBeforeLast("/", "")
+                    val pathPrefix = if (basePath.isNotEmpty()) "$basePath/" else ""
+
+                    val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$branch/$pathPrefix"
+                    val linkBaseUrl = "https://github.com/$owner/$repo/blob/$branch/$pathPrefix"
+
+                    preprocessMarkdown(markdown = rawMarkdown, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
+                } else {
+                    rawMarkdown
+                }
+            } else null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to fetch raw markdown from $url: ${e.message}")
+            null
+        }
+    }
 }

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -3,8 +3,10 @@ package zed.rainxch.details.data.utils
 fun preprocessMarkdown(
     markdown: String,
     baseUrl: String,
+    linkBaseUrl: String = baseUrl,
 ): String {
     val normalizedBaseUrl = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+    val normalizedLinkBaseUrl = if (linkBaseUrl.endsWith("/")) linkBaseUrl else "$linkBaseUrl/"
 
     var processed = markdown
 
@@ -44,26 +46,31 @@ fun preprocessMarkdown(
 
     fun shouldSkipImage(url: String): Boolean = isBadgeUrl(url)
 
-    fun resolveUrl(path: String): String {
+    fun resolveUrl(path: String, asImage: Boolean): String {
         val trimmed = path.trim()
+        if (trimmed.startsWith("#") && !asImage) return trimmed
+
         val isAbsolute =
             trimmed.startsWith("http://") ||
                 trimmed.startsWith("https://") ||
                 trimmed.startsWith("data:")
+        
+        val baseForPath = if (asImage) normalizedBaseUrl else normalizedLinkBaseUrl
+
         return if (isAbsolute) {
-            normalizeGitHubUrl(trimmed)
+            if (asImage) normalizeGitHubUrl(trimmed) else trimmed
         } else {
             when {
                 trimmed.startsWith("./") -> {
-                    "$normalizedBaseUrl${trimmed.removePrefix("./")}"
+                    "$baseForPath${trimmed.removePrefix("./")}"
                 }
 
                 trimmed.startsWith("/") -> {
-                    "$normalizedBaseUrl${trimmed.removePrefix("/")}"
+                    "$baseForPath${trimmed.removePrefix("/")}"
                 }
 
                 trimmed.startsWith("../") -> {
-                    var base = normalizedBaseUrl.trimEnd('/')
+                    var base = baseForPath.trimEnd('/')
                     var rel = trimmed
                     while (rel.startsWith("../")) {
                         base = base.substringBeforeLast('/', base)
@@ -73,7 +80,7 @@ fun preprocessMarkdown(
                 }
 
                 else -> {
-                    "$normalizedBaseUrl$trimmed"
+                    "$baseForPath$trimmed"
                 }
             }
         }
@@ -94,7 +101,7 @@ fun preprocessMarkdown(
     val skipRefNames =
         referenceMap
             .filter { (_, url) ->
-                shouldSkipImage(resolveUrl(url))
+                shouldSkipImage(resolveUrl(url, asImage = true))
             }.keys
 
     if (skipRefNames.isNotEmpty()) {
@@ -120,7 +127,7 @@ fun preprocessMarkdown(
             val refName = match.groupValues[2].lowercase()
             val url = referenceMap[refName]
             if (url != null) {
-                val resolved = resolveUrl(url)
+                val resolved = resolveUrl(url, asImage = true)
                 "![$alt]($resolved)"
             } else {
                 match.value
@@ -135,7 +142,7 @@ fun preprocessMarkdown(
             val refName = match.groupValues[2].lowercase()
             val url = referenceMap[refName]
             if (url != null) {
-                "[$boldText](${resolveUrl(url)})"
+                "[$boldText](${resolveUrl(url, asImage = false)})"
             } else {
                 boldText
             }
@@ -156,7 +163,7 @@ fun preprocessMarkdown(
             val url = referenceMap[refName]
 
             if (url != null && !text.startsWith("!")) {
-                "[$text](${resolveUrl(url)})"
+                "[$text](${resolveUrl(url, asImage = false)})"
             } else {
                 match.value
             }
@@ -248,7 +255,7 @@ fun preprocessMarkdown(
             val alt = altMatch?.groupValues?.get(2) ?: ""
 
             if (src.isNotEmpty()) {
-                val normalizedSrc = resolveUrl(src)
+                val normalizedSrc = resolveUrl(src, asImage = true)
 
                 if (shouldSkipImage(normalizedSrc)) {
                     if (alt.isNotEmpty()) "**$alt**" else ""
@@ -266,7 +273,7 @@ fun preprocessMarkdown(
         ) { match ->
             val alt = match.groupValues[1]
             val originalPath = match.groupValues[2].trim()
-            val finalUrl = resolveUrl(originalPath)
+            val finalUrl = resolveUrl(originalPath, asImage = true)
 
             if (shouldSkipImage(finalUrl)) {
                 if (alt.isNotEmpty()) "**$alt**" else ""
@@ -277,13 +284,23 @@ fun preprocessMarkdown(
 
     processed =
         processed.replace(
+            Regex("""(?<!\!)\[([^\]]*)\]\(([^)]+)\)"""),
+        ) { match ->
+            val text = match.groupValues[1]
+            val originalPath = match.groupValues[2].trim()
+            val finalUrl = resolveUrl(originalPath, asImage = false)
+            "[$text]($finalUrl)"
+        }
+
+    processed =
+        processed.replace(
             Regex(
                 """<video[^>]*?\ssrc=(["'])([^"']+)\1[^>]*>.*?</video>""",
                 setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
             ),
         ) { match ->
             val src = match.groupValues[2]
-            "[Video](${resolveUrl(src)})"
+            "[Video](${resolveUrl(src, asImage = true)})"
         }
 
     processed =
@@ -294,7 +311,7 @@ fun preprocessMarkdown(
             ),
         ) { match ->
             val src = match.groupValues[2]
-            "[Video](${resolveUrl(src)})"
+            "[Video](${resolveUrl(src, asImage = true)})"
         }
 
     for (level in 1..6) {
@@ -394,7 +411,7 @@ fun preprocessMarkdown(
         ) { match ->
             val url = match.groupValues[2]
             val text = match.groupValues[3].trim()
-            val resolvedUrl = resolveUrl(url)
+            val resolvedUrl = resolveUrl(url, asImage = false)
             if (text.isEmpty()) {
                 "[$resolvedUrl]($resolvedUrl)"
             } else {

--- a/feature/details/domain/src/commonMain/kotlin/zed/rainxch/details/domain/repository/DetailsRepository.kt
+++ b/feature/details/domain/src/commonMain/kotlin/zed/rainxch/details/domain/repository/DetailsRepository.kt
@@ -57,4 +57,6 @@ interface DetailsRepository {
         repo: String,
         sha256Digest: String,
     ): Boolean
+
+    suspend fun fetchRawMarkdown(url: String): String?
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -163,6 +163,7 @@ fun DetailsRoot(
     onNavigateToIssues: (owner: String, repo: String) -> Unit,
     onNavigateToSecurity: (owner: String, repo: String) -> Unit,
     onNavigateToPulls: (owner: String, repo: String) -> Unit,
+    onNavigateToMarkdownViewer: (url: String) -> Unit,
     viewModel: DetailsViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -675,7 +675,7 @@ fun DetailsScreen(
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
                                 onTranslateLanguage = onTranslateLanguage,
-                                onReadMore = { onReadMoreAbout?.invoke() },
+                                onReadMore = onReadMoreAbout,
                             )
                         }
                     } else {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -158,7 +158,7 @@ fun DetailsRoot(
     onNavigateToDeveloperProfile: (username: String) -> Unit,
     onOpenRepositoryInApp: (repoId: Long) -> Unit,
     onNavigateToSearchByPlatform: (DiscoveryPlatform) -> Unit,
-    onNavigateToAbout: (repoId: Long, owner: String, repo: String, sourceHost: String?) -> Unit,
+    onNavigateToAbout: (repoId: Long, owner: String, repo: String, sourceHost: String?, translateTo: String?) -> Unit,
     onNavigateToWhatsNew: (repoId: Long, owner: String, repo: String, sourceHost: String?) -> Unit,
     onNavigateToIssues: (owner: String, repo: String) -> Unit,
     onNavigateToSecurity: (owner: String, repo: String) -> Unit,
@@ -251,6 +251,18 @@ fun DetailsRoot(
                     repo.owner.login,
                     repo.name,
                     repo.sourceHost,
+                    null,
+                )
+            }
+        },
+        onTranslateLanguage = state.repository?.let { repo ->
+            { code ->
+                onNavigateToAbout(
+                    repo.id,
+                    repo.owner.login,
+                    repo.name,
+                    repo.sourceHost,
+                    code,
                 )
             }
         },
@@ -512,6 +524,7 @@ fun DetailsScreen(
     onAction: (DetailsAction) -> Unit,
     snackbarHostState: SnackbarHostState,
     onReadMoreAbout: (() -> Unit)? = null,
+    onTranslateLanguage: ((String) -> Unit)? = null,
     onReadMoreWhatsNew: (() -> Unit)? = null,
     onOpenIssues: (() -> Unit)? = null,
     onOpenSecurity: (() -> Unit)? = null,
@@ -661,7 +674,8 @@ fun DetailsScreen(
                                 collapsedHeight = collapsedSectionHeight,
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
-                                onReadMore = onReadMoreAbout,
+                                onTranslateLanguage = onTranslateLanguage,
+                                onReadMore = { onReadMoreAbout?.invoke() },
                             )
                         }
                     } else {
@@ -674,6 +688,7 @@ fun DetailsScreen(
                                 collapsedHeight = collapsedSectionHeight,
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
+                                onTranslateLanguage = onTranslateLanguage,
                                 onReadMore = onReadMoreAbout,
                             )
                         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -54,12 +54,20 @@ fun AboutRoot(
     owner: String,
     repo: String,
     sourceHost: String?,
+    translateTo: String? = null,
     onNavigateBack: () -> Unit,
     viewModel: DetailsAboutViewModel = koinViewModel {
         parametersOf(repositoryId, owner, repo, sourceHost)
     },
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    
+    androidx.compose.runtime.LaunchedEffect(translateTo) {
+        if (translateTo != null) {
+            viewModel.translate(translateTo)
+        }
+    }
+    
     AboutScreen(
         state = state,
         onBack = onNavigateBack,
@@ -175,37 +183,8 @@ private fun AboutScreen(
                 }
                 item(key = "markdown") {
                     Spacer(Modifier.height(4.dp))
-                    val defaultUriHandler = androidx.compose.ui.platform.LocalUriHandler.current
-                    val customUriHandler = remember(defaultUriHandler, onTranslate) {
-                        object : androidx.compose.ui.platform.UriHandler {
-                            override fun openUri(uri: String) {
-                                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
-                                if (match != null) {
-                                    val code = match.groupValues[1]
-                                    val normalizedCode = when (code.lowercase()) {
-                                        "cn" -> "zh-CN"
-                                        "tw" -> "zh-TW"
-                                        "jp" -> "ja"
-                                        "kr" -> "ko"
-                                        "br" -> "pt-BR"
-                                        else -> code
-                                    }
-                                    val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.equals(normalizedCode, ignoreCase = true) 
-                                    } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
-                                    }
-                                    if (matchedLanguage != null) {
-                                        onTranslate(matchedLanguage.code)
-                                        return
-                                    }
-                                }
-                                defaultUriHandler.openUri(uri)
-                            }
-                        }
-                    }
-                    androidx.compose.runtime.CompositionLocalProvider(
-                        androidx.compose.ui.platform.LocalUriHandler provides customUriHandler,
+                    zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
+                        onTranslate = onTranslate,
                     ) {
                         Markdown(
                             content = displayedMarkdown,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -182,10 +182,18 @@ private fun AboutScreen(
                                 val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
                                 if (match != null) {
                                     val code = match.groupValues[1]
+                                    val normalizedCode = when (code.lowercase()) {
+                                        "cn" -> "zh-CN"
+                                        "tw" -> "zh-TW"
+                                        "jp" -> "ja"
+                                        "kr" -> "ko"
+                                        "br" -> "pt-BR"
+                                        else -> code
+                                    }
                                     val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.equals(code, ignoreCase = true) 
+                                        it.code.equals(normalizedCode, ignoreCase = true) 
                                     } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.startsWith(code, ignoreCase = true) || code.startsWith(it.code, ignoreCase = true)
+                                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
                                     }
                                     if (matchedLanguage != null) {
                                         onTranslate(matchedLanguage.code)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -175,14 +175,39 @@ private fun AboutScreen(
                 }
                 item(key = "markdown") {
                     Spacer(Modifier.height(4.dp))
-                    Markdown(
-                        content = displayedMarkdown,
-                        colors = colors,
-                        typography = typography,
-                        imageTransformer = imageTransformer,
-                        components = components,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    val defaultUriHandler = androidx.compose.ui.platform.LocalUriHandler.current
+                    val customUriHandler = remember(defaultUriHandler, onTranslate) {
+                        object : androidx.compose.ui.platform.UriHandler {
+                            override fun openUri(uri: String) {
+                                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
+                                if (match != null) {
+                                    val code = match.groupValues[1]
+                                    val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
+                                        it.code.equals(code, ignoreCase = true) 
+                                    } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
+                                        it.code.startsWith(code, ignoreCase = true) || code.startsWith(it.code, ignoreCase = true)
+                                    }
+                                    if (matchedLanguage != null) {
+                                        onTranslate(matchedLanguage.code)
+                                        return
+                                    }
+                                }
+                                defaultUriHandler.openUri(uri)
+                            }
+                        }
+                    }
+                    androidx.compose.runtime.CompositionLocalProvider(
+                        androidx.compose.ui.platform.LocalUriHandler provides customUriHandler,
+                    ) {
+                        Markdown(
+                            content = displayedMarkdown,
+                            colors = colors,
+                            typography = typography,
+                            imageTransformer = imageTransformer,
+                            components = components,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             }
         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -186,6 +186,7 @@ private fun AboutScreen(
                     Spacer(Modifier.height(4.dp))
                     zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
                         onTranslate = onTranslate,
+                        onClearTranslation = onClearTranslation,
                     ) {
                         Markdown(
                             content = displayedMarkdown,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -67,6 +67,7 @@ fun LazyListScope.about(
     collapsedHeight: Dp,
     measuredHeightPx: Float?,
     onMeasured: (Float) -> Unit,
+    onTranslateLanguage: ((String) -> Unit)? = null,
     onReadMore: (() -> Unit)? = null,
 ) {
     item {
@@ -113,18 +114,37 @@ fun LazyListScope.about(
             MarkdownImageTransformer(probeClient)
         }
 
-        ExpandableMarkdownContent(
-            rawMarkdown = raw,
-            isDark = isDark,
-            isExpanded = isExpanded,
-            onToggleExpanded = onReadMore ?: onToggleExpanded,
-            imageTransformer = imageTransformer,
-            collapsedHeight = collapsedHeight,
-            measuredHeightPx = measuredHeightPx,
-            onMeasured = onMeasured,
-            fadeColor = MaterialTheme.colorScheme.background,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (onTranslateLanguage != null) {
+            zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
+                onTranslate = onTranslateLanguage,
+            ) {
+                ExpandableMarkdownContent(
+                    rawMarkdown = raw,
+                    isDark = isDark,
+                    isExpanded = isExpanded,
+                    onToggleExpanded = onReadMore ?: onToggleExpanded,
+                    imageTransformer = imageTransformer,
+                    collapsedHeight = collapsedHeight,
+                    measuredHeightPx = measuredHeightPx,
+                    onMeasured = onMeasured,
+                    fadeColor = MaterialTheme.colorScheme.background,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        } else {
+            ExpandableMarkdownContent(
+                rawMarkdown = raw,
+                isDark = isDark,
+                isExpanded = isExpanded,
+                onToggleExpanded = onReadMore ?: onToggleExpanded,
+                imageTransformer = imageTransformer,
+                collapsedHeight = collapsedHeight,
+                measuredHeightPx = measuredHeightPx,
+                onMeasured = onMeasured,
+                fadeColor = MaterialTheme.colorScheme.background,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -68,6 +68,7 @@ fun LazyListScope.about(
     measuredHeightPx: Float?,
     onMeasured: (Float) -> Unit,
     onTranslateLanguage: ((String) -> Unit)? = null,
+    onOpenInternalMarkdown: ((String) -> Unit)? = null,
     onReadMore: (() -> Unit)? = null,
 ) {
     item {
@@ -105,8 +106,9 @@ fun LazyListScope.about(
     }
 
     item(key = "about_markdown") {
-        val raw = readmeMarkdown
         val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val raw = applyThemeAwareImages(readmeMarkdown, isDark = isDark)
+        
         val probeClient = org.koin.compose.koinInject<io.ktor.client.HttpClient>(
             qualifier = org.koin.core.qualifier.named("test"),
         )
@@ -117,6 +119,7 @@ fun LazyListScope.about(
         if (onTranslateLanguage != null) {
             zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
                 onTranslate = onTranslateLanguage,
+                onOpenInternalMarkdown = onOpenInternalMarkdown,
             ) {
                 ExpandableMarkdownContent(
                     rawMarkdown = raw,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerScreen.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerScreen.kt
@@ -1,6 +1,7 @@
-package zed.rainxch.details.presentation.about
+package zed.rainxch.details.presentation.markdownviewer
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -20,8 +22,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -30,6 +35,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mikepenz.markdown.compose.Markdown
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.delay
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -45,32 +53,20 @@ import zed.rainxch.details.presentation.components.LanguagePicker
 import zed.rainxch.details.presentation.components.TranslationCard
 import zed.rainxch.githubstore.core.presentation.res.Res
 import zed.rainxch.githubstore.core.presentation.res.cd_back
-import zed.rainxch.githubstore.core.presentation.res.details_about_screen_title
 import zed.rainxch.githubstore.core.presentation.res.retry
 
 @Composable
-fun AboutRoot(
-    repositoryId: Long,
-    owner: String,
-    repo: String,
-    sourceHost: String?,
-    translateTo: String? = null,
+fun MarkdownViewerRoot(
+    url: String,
     onNavigateBack: () -> Unit,
     onNavigateToMarkdownViewer: (String) -> Unit,
-    viewModel: DetailsAboutViewModel = koinViewModel {
-        parametersOf(repositoryId, owner, repo, sourceHost)
+    viewModel: MarkdownViewerViewModel = koinViewModel {
+        parametersOf(url)
     },
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    
-    val isReadmeLoaded = state.readmeMarkdown.isNotBlank()
-    androidx.compose.runtime.LaunchedEffect(translateTo, isReadmeLoaded) {
-        if (translateTo != null && isReadmeLoaded) {
-            viewModel.translate(translateTo)
-        }
-    }
-    
-    AboutScreen(
+
+    MarkdownViewerScreen(
         state = state,
         onBack = onNavigateBack,
         onRetry = viewModel::retry,
@@ -84,8 +80,8 @@ fun AboutRoot(
 }
 
 @Composable
-private fun AboutScreen(
-    state: DetailsAboutState,
+private fun MarkdownViewerScreen(
+    state: MarkdownViewerState,
     onBack: () -> Unit,
     onRetry: () -> Unit,
     onTranslate: (String) -> Unit,
@@ -109,7 +105,30 @@ private fun AboutScreen(
     ) {
         state.translation.translatedText
     } else {
-        state.readmeMarkdown
+        state.markdown
+    }
+
+    var isReadyToRender by remember { mutableStateOf(false) }
+    LaunchedEffect(displayedMarkdown) {
+        if (displayedMarkdown.isNotEmpty()) {
+            delay(350) // Let the slide-in animation finish smoothly
+            isReadyToRender = true
+        } else {
+            isReadyToRender = false
+        }
+    }
+
+    val markdownChunks = remember(displayedMarkdown) {
+        if (displayedMarkdown.isEmpty()) return@remember emptyList<String>()
+        val flavour = GFMFlavourDescriptor()
+        val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(displayedMarkdown)
+        parsedTree.children.map { node ->
+            displayedMarkdown.substring(node.startOffset, node.endOffset)
+        }.filter { it.isNotBlank() }
+    }
+
+    val filename = remember(state.url) {
+        state.url.substringAfterLast("/", "Document").substringBefore("?")
     }
 
     Column(
@@ -118,7 +137,7 @@ private fun AboutScreen(
             .background(MaterialTheme.colorScheme.background)
             .systemBarsPadding(),
     ) {
-        AboutTopBar(title = state.repoName, onBack = onBack)
+        MarkdownViewerTopBar(title = filename, onBack = onBack)
         when {
             state.isLoading -> Box(
                 modifier = Modifier.fillMaxSize(),
@@ -143,7 +162,8 @@ private fun AboutScreen(
                         modifier = Modifier
                             .padding(8.dp)
                             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                            .padding(horizontal = 12.dp, vertical = 6.dp)
+                            .clickable { onRetry() },
                     )
                 }
             }
@@ -153,27 +173,6 @@ private fun AboutScreen(
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                item(key = "header") {
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text(
-                            text = stringResource(Res.string.details_about_screen_title),
-                            style = MaterialTheme.typography.headlineMedium.copy(
-                                fontWeight = FontWeight.SemiBold,
-                                fontSize = 26.sp,
-                            ),
-                            color = MaterialTheme.colorScheme.onBackground,
-                        )
-                        Squiggle()
-                        state.readmeLanguage?.let { lang ->
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                text = lang,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
                 item(key = "translation_card") {
                     Spacer(Modifier.height(4.dp))
                     TranslationCard(
@@ -185,21 +184,33 @@ private fun AboutScreen(
                         onCancel = onClearTranslation,
                     )
                 }
-                item(key = "markdown") {
-                    Spacer(Modifier.height(4.dp))
-                    zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
-                        onTranslate = onTranslate,
-                        onClearTranslation = onClearTranslation,
-                        onOpenInternalMarkdown = onNavigateToMarkdownViewer,
-                    ) {
-                        Markdown(
-                            content = displayedMarkdown,
-                            colors = colors,
-                            typography = typography,
-                            imageTransformer = imageTransformer,
-                            components = components,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
+                if (isReadyToRender) {
+                    items(
+                        items = markdownChunks,
+                    ) { chunk ->
+                        zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
+                            onTranslate = onTranslate,
+                            onClearTranslation = onClearTranslation,
+                            onOpenInternalMarkdown = onNavigateToMarkdownViewer,
+                        ) {
+                            Markdown(
+                                content = chunk,
+                                colors = colors,
+                                typography = typography,
+                                imageTransformer = imageTransformer,
+                                components = components,
+                                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                            )
+                        }
+                    }
+                } else {
+                    item(key = "loading") {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(top = 32.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                        }
                     }
                 }
             }
@@ -219,7 +230,7 @@ private fun AboutScreen(
 }
 
 @Composable
-private fun AboutTopBar(title: String, onBack: () -> Unit) {
+private fun MarkdownViewerTopBar(title: String, onBack: () -> Unit) {
     androidx.compose.foundation.layout.Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -242,6 +253,8 @@ private fun AboutTopBar(title: String, onBack: () -> Unit) {
             ),
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(start = 4.dp),
+            maxLines = 1,
+            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
         )
     }
 }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerState.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerState.kt
@@ -1,0 +1,13 @@
+package zed.rainxch.details.presentation.markdownviewer
+
+import zed.rainxch.details.presentation.model.TranslationState
+
+data class MarkdownViewerState(
+    val url: String = "",
+    val isLoading: Boolean = false,
+    val markdown: String = "",
+    val errorMessage: String? = null,
+    val translation: TranslationState = TranslationState(),
+    val isLanguagePickerVisible: Boolean = false,
+    val deviceLanguageCode: String = "en",
+)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerViewModel.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/markdownviewer/MarkdownViewerViewModel.kt
@@ -1,0 +1,127 @@
+package zed.rainxch.details.presentation.markdownviewer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
+import zed.rainxch.details.domain.repository.DetailsRepository
+import zed.rainxch.details.domain.repository.TranslationRepository
+import zed.rainxch.details.presentation.model.SupportedLanguages
+import zed.rainxch.details.presentation.model.TranslationState
+import zed.rainxch.githubstore.core.presentation.res.Res
+import zed.rainxch.githubstore.core.presentation.res.failed_to_load
+import zed.rainxch.githubstore.core.presentation.res.translation_failed
+
+class MarkdownViewerViewModel(
+    private val url: String,
+    private val detailsRepository: DetailsRepository,
+    private val translationRepository: TranslationRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        MarkdownViewerState(
+            url = url,
+            deviceLanguageCode = translationRepository.getDeviceLanguageCode(),
+        ),
+    )
+    val state = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() {
+        load()
+    }
+
+    fun translate(targetLanguageCode: String) {
+        val markdown = _state.value.markdown
+        if (markdown.isBlank()) return
+        val displayName = SupportedLanguages.all.firstOrNull { it.code == targetLanguageCode }?.displayName
+        _state.update {
+            it.copy(
+                translation = it.translation.copy(
+                    isTranslating = true,
+                    targetLanguageCode = targetLanguageCode,
+                    targetLanguageDisplayName = displayName,
+                    error = null,
+                ),
+            )
+        }
+        viewModelScope.launch {
+            runCatching {
+                translationRepository.translate(markdown, targetLanguageCode)
+            }.onSuccess { result ->
+                _state.update {
+                    it.copy(
+                        translation = it.translation.copy(
+                            isTranslating = false,
+                            translatedText = result.translatedText,
+                            isShowingTranslation = true,
+                            detectedSourceLanguage = result.detectedSourceLanguage,
+                            error = null,
+                        ),
+                    )
+                }
+            }.onFailure { e ->
+                _state.update {
+                    it.copy(
+                        translation = it.translation.copy(
+                            isTranslating = false,
+                            error = e.message ?: getString(Res.string.translation_failed),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    fun toggleTranslation() {
+        _state.update {
+            it.copy(
+                translation = it.translation.copy(
+                    isShowingTranslation = !it.translation.isShowingTranslation,
+                ),
+            )
+        }
+    }
+
+    fun clearTranslation() {
+        _state.update {
+            it.copy(translation = TranslationState())
+        }
+    }
+
+    fun showLanguagePicker() {
+        _state.update { it.copy(isLanguagePickerVisible = true) }
+    }
+
+    fun dismissLanguagePicker() {
+        _state.update { it.copy(isLanguagePickerVisible = false) }
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            runCatching {
+                detailsRepository.fetchRawMarkdown(url)
+            }.onSuccess { rawMarkdown ->
+                if (rawMarkdown != null) {
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            markdown = rawMarkdown,
+                        )
+                    }
+                } else {
+                    _state.update { it.copy(isLoading = false, errorMessage = getString(Res.string.failed_to_load)) }
+                }
+            }.onFailure { e ->
+                _state.update { it.copy(isLoading = false, errorMessage = e.message ?: getString(Res.string.failed_to_load)) }
+            }
+        }
+    }
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
@@ -10,13 +10,21 @@ import zed.rainxch.details.presentation.model.SupportedLanguages
 @Composable
 fun ProvideLanguageLinkInterceptor(
     onTranslate: (String) -> Unit,
+    onClearTranslation: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     val defaultUriHandler = LocalUriHandler.current
-    val customUriHandler = remember(defaultUriHandler, onTranslate) {
+    val customUriHandler = remember(defaultUriHandler, onTranslate, onClearTranslation) {
         object : UriHandler {
             override fun openUri(uri: String) {
-                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
+                if (Regex("""(?i)README\.md(?:[#?].*)?$""").find(uri) != null) {
+                    if (onClearTranslation != null) {
+                        onClearTranslation.invoke()
+                        return
+                    }
+                }
+
+                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md(?:[#?].*)?$""").find(uri)
                 if (match != null) {
                     val code = match.groupValues[1]
                     val normalizedCode = when (code.lowercase()) {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
@@ -1,0 +1,48 @@
+package zed.rainxch.details.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import zed.rainxch.details.presentation.model.SupportedLanguages
+
+@Composable
+fun ProvideLanguageLinkInterceptor(
+    onTranslate: (String) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val defaultUriHandler = LocalUriHandler.current
+    val customUriHandler = remember(defaultUriHandler, onTranslate) {
+        object : UriHandler {
+            override fun openUri(uri: String) {
+                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
+                if (match != null) {
+                    val code = match.groupValues[1]
+                    val normalizedCode = when (code.lowercase()) {
+                        "cn" -> "zh-CN"
+                        "tw" -> "zh-TW"
+                        "jp" -> "ja"
+                        "kr" -> "ko"
+                        "br" -> "pt-BR"
+                        else -> code
+                    }
+                    val matchedLanguage = SupportedLanguages.all.find { 
+                        it.code.equals(normalizedCode, ignoreCase = true) 
+                    } ?: SupportedLanguages.all.find { 
+                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
+                    }
+                    if (matchedLanguage != null) {
+                        onTranslate(matchedLanguage.code)
+                        return
+                    }
+                }
+                defaultUriHandler.openUri(uri)
+            }
+        }
+    }
+    CompositionLocalProvider(
+        LocalUriHandler provides customUriHandler,
+        content = content,
+    )
+}

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
@@ -11,10 +11,11 @@ import zed.rainxch.details.presentation.model.SupportedLanguages
 fun ProvideLanguageLinkInterceptor(
     onTranslate: (String) -> Unit,
     onClearTranslation: (() -> Unit)? = null,
+    onOpenInternalMarkdown: ((String) -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     val defaultUriHandler = LocalUriHandler.current
-    val customUriHandler = remember(defaultUriHandler, onTranslate, onClearTranslation) {
+    val customUriHandler = remember(defaultUriHandler, onTranslate, onClearTranslation, onOpenInternalMarkdown) {
         object : UriHandler {
             override fun openUri(uri: String) {
                 if (Regex("""(?i)README\.md(?:[#?].*)?$""").find(uri) != null) {
@@ -45,6 +46,15 @@ fun ProvideLanguageLinkInterceptor(
                         return
                     }
                 }
+                
+                if (onOpenInternalMarkdown != null) {
+                    val isInternalMarkdown = Regex("""(?i)^https://(?:raw\.githubusercontent\.com|github\.com)/[^/]+/[^/]+/(?:blob/)?[^/]+/.+\.md(?:[#?].*)?$""").find(uri) != null
+                    if (isInternalMarkdown) {
+                        onOpenInternalMarkdown.invoke(uri)
+                        return
+                    }
+                }
+
                 defaultUriHandler.openUri(uri)
             }
         }


### PR DESCRIPTION
Fixes #785

### Description
This PR resolves an issue where clicking relative links (like "简体中文") in a repository's README would open the raw markdown source code (`raw.githubusercontent.com`) in the browser instead of the rendered webpage or the app's native translation feature.

### Changes Made
- **Differentiated Image vs Hyperlink URLs**: Updated `preprocessMarkdown` to accept a separate `linkBaseUrl` parameter alongside `baseUrl`. `resolveUrl` now correctly applies the raw data URL to images, and the standard web URL to hyperlinks.
- **Fixed Standard Markdown Links**: Added a regex pass to properly resolve standard Markdown links (`[text](url)`) using the new `linkBaseUrl`.
- **Ignored Anchor Links**: Ensured that local table of contents links (e.g., `#features`) are untouched so they don't break.
- **Intercept Language Links**: Wrapped the `Markdown` component in `AboutRoot.kt` with a custom `LocalUriHandler`. When a user clicks a link pointing to a localized README (e.g., `README.zh-CN.md`), the app intercepts it, extracts the language code, and seamlessly triggers the app's native Translation Card instead of opening the browser. Unrecognized links fall back safely to opening in the browser.


<img width="1080" height="2408" alt="image" src="https://github.com/user-attachments/assets/84a61c5b-867b-4fdc-bd03-06b76b9c42b2" />
<img width="1080" height="2408" alt="image" src="https://github.com/user-attachments/assets/064ea5bb-42ee-497c-bf64-5a927912edd9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS as a selectable platform across repository discovery, searching, and related UI labels/filters.
  * Added in-app language switching from README language links via an “About” screen translation action, with optional preselected target language.
* **Bug Fixes**
  * Improved markdown link handling so rendered links resolve correctly for both GitHub and Forgejo web UIs.
  * Refined relative URL processing by distinguishing image vs. non-image contexts for more consistent rendering.
  * Fixed URL resolution for video embeds and HTML anchor links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->