### PR TITLE
feat: Add iOS filtering and search support

### DIFF
--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AdaptiveDetailPaneContent.kt
@@ -29,6 +29,7 @@ private sealed interface DetailPaneRoute {
         val owner: String,
         val repo: String,
         val sourceHost: String?,
+        val translateTo: String? = null,
     ) : DetailPaneRoute
 
     data class WhatsNew(
@@ -82,8 +83,8 @@ fun AdaptiveDetailPaneContent(
                         navController = navController,
                         onCrossNavToRepo = onCrossNavToRepo,
                         onClearPane = onClearPane,
-                        onOpenAbout = { repoId, owner, repo, sourceHost ->
-                            route = DetailPaneRoute.About(repoId, owner, repo, sourceHost)
+                        onOpenAbout = { repoId, owner, repo, sourceHost, translateTo ->
+                            route = DetailPaneRoute.About(repoId, owner, repo, sourceHost, translateTo)
                         },
                         onOpenWhatsNew = { repoId, owner, repo, sourceHost ->
                             route = DetailPaneRoute.WhatsNew(repoId, owner, repo, sourceHost)
@@ -99,6 +100,7 @@ fun AdaptiveDetailPaneContent(
                         owner = current.owner,
                         repo = current.repo,
                         sourceHost = current.sourceHost,
+                        translateTo = current.translateTo,
                         onNavigateBack = { route = DetailPaneRoute.Main },
                         viewModel =
                             koinViewModel(key = aboutKey) {
@@ -143,7 +145,7 @@ private fun MainDetailPane(
     navController: NavHostController,
     onCrossNavToRepo: (AdaptiveDetailArgs) -> Unit,
     onClearPane: () -> Unit,
-    onOpenAbout: (Long, String, String, String?) -> Unit,
+    onOpenAbout: (Long, String, String, String?, String?) -> Unit,
     onOpenWhatsNew: (Long, String, String, String?) -> Unit,
 ) {
     val vmKey =

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/AppNavigation.kt
@@ -427,13 +427,14 @@ fun AppNavigation(
                                             ),
                                         )
                                     },
-                                    onNavigateToAbout = { repoId, owner, repo, sourceHost ->
+                                    onNavigateToAbout = { repoId, owner, repo, sourceHost, translateTo ->
                                         navController.navigate(
                                             GithubStoreGraph.DetailsAboutScreen(
                                                 repositoryId = repoId,
                                                 owner = owner,
                                                 repo = repo,
                                                 sourceHost = sourceHost,
+                                                translateTo = translateTo,
                                             ),
                                         )
                                     },
@@ -525,6 +526,7 @@ fun AppNavigation(
                                 owner = args.owner,
                                 repo = args.repo,
                                 sourceHost = args.sourceHost,
+                                translateTo = args.translateTo,
                                 onNavigateBack = { navController.navigateUp() },
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
+++ b/composeApp/src/commonMain/kotlin/zed/rainxch/githubstore/app/navigation/GithubStoreGraph.kt
@@ -121,6 +121,7 @@ sealed interface GithubStoreGraph {
         val owner: String = "",
         val repo: String = "",
         val sourceHost: String? = null,
+        val translateTo: String? = null,
     ) : GithubStoreGraph
 
     @Serializable

--- a/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
+++ b/composeApp/src/jvmMain/kotlin/zed/rainxch/githubstore/DesktopApp.kt
@@ -80,13 +80,14 @@ fun main(args: Array<String>) {
         val koin = GlobalContext.get()
         val tweaksRepo = koin.get<TweaksRepository>()
         val localization = koin.get<LocalizationManager>()
-        val tag = try {
-            withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds) {
-                tweaksRepo.getAppLanguage().first()
+        val tag =
+            try {
+                withTimeoutOrNull(LANGUAGE_PREF_READ_TIMEOUT_MS.milliseconds) {
+                    tweaksRepo.getAppLanguage().first()
+                }
+            } catch (_: Exception) {
+                null
             }
-        } catch (_: Exception) {
-            null
-        }
         localization.setActiveLanguageTag(tag)
     }
 

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/repository/DiscoveryPlatform.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/model/repository/DiscoveryPlatform.kt
@@ -5,12 +5,13 @@ enum class DiscoveryPlatform {
     Macos,
     Windows,
     Linux,
+    Ios,
     ;
 
     companion object {
         fun fromName(name: String?): DiscoveryPlatform = DiscoveryPlatform.entries.find { it.name == name } ?: All
 
         val selectablePlatforms: List<DiscoveryPlatform> =
-            listOf(Android, Macos, Windows, Linux)
+            listOf(Android, Macos, Windows, Linux, Ios)
     }
 }

--- a/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/AssetPlatform.kt
+++ b/core/domain/src/commonMain/kotlin/zed/rainxch/core/domain/utils/AssetPlatform.kt
@@ -6,6 +6,7 @@ fun assetPlatformOf(assetName: String): DiscoveryPlatform? {
     val lower = assetName.lowercase()
     return when {
         lower.endsWith(".apk") -> DiscoveryPlatform.Android
+        lower.endsWith(".ipa") -> DiscoveryPlatform.Ios
         lower.endsWith(".exe") || lower.endsWith(".msi") -> DiscoveryPlatform.Windows
         lower.endsWith(".dmg") || lower.endsWith(".pkg") -> DiscoveryPlatform.Macos
         lower.endsWith(".deb") ||

--- a/core/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/core/presentation/src/commonMain/composeResources/values/strings.xml
@@ -700,6 +700,7 @@
     <string name="platform_section_windows">Windows</string>
     <string name="platform_section_macos">macOS</string>
     <string name="platform_section_linux">Linux</string>
+    <string name="platform_section_ios">iOS</string>
     <string name="section_chip_your_device">Your device</string>
     <string name="section_chip_for_transfer">For transfer</string>
     <string name="hidden_repositories_title">Hidden repositories</string>

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/components/RepositoryCard.kt
@@ -456,6 +456,7 @@ private fun platformLabel(platform: DiscoveryPlatform): String =
         DiscoveryPlatform.Windows -> "Windows"
         DiscoveryPlatform.Macos -> "macOS"
         DiscoveryPlatform.Linux -> "Linux"
+        DiscoveryPlatform.Ios -> "iOS"
         DiscoveryPlatform.All -> ""
     }
 

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/DiscoveryPlatformUiResources.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/DiscoveryPlatformUiResources.kt
@@ -34,6 +34,10 @@ fun DiscoveryPlatform.toIcons(): List<ImageVector> =
         DiscoveryPlatform.Linux -> {
             listOf(vectorResource(Res.drawable.ic_platform_linux))
         }
+
+        DiscoveryPlatform.Ios -> {
+            listOf(vectorResource(Res.drawable.ic_platform_macos)) // Fallback to apple icon
+        }
     }
 
 @Composable
@@ -57,5 +61,9 @@ fun DiscoveryPlatform.toLabel(): String =
 
         DiscoveryPlatform.Linux -> {
             "Linux"
+        }
+
+        DiscoveryPlatform.Ios -> {
+            "iOS"
         }
     }

--- a/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/DiscoveryPlatformUiResources.kt
+++ b/core/presentation/src/commonMain/kotlin/zed/rainxch/core/presentation/utils/DiscoveryPlatformUiResources.kt
@@ -36,7 +36,7 @@ fun DiscoveryPlatform.toIcons(): List<ImageVector> =
         }
 
         DiscoveryPlatform.Ios -> {
-            listOf(vectorResource(Res.drawable.ic_platform_macos)) // Fallback to apple icon
+            listOf(vectorResource(Res.drawable.ic_platform_macos))
         }
     }
 

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/repository/DetailsRepositoryImpl.kt
@@ -396,6 +396,7 @@ class DetailsRepositoryImpl(
                 preprocessMarkdown(
                     markdown = rawMarkdown,
                     baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/",
+                    linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/",
                 )
             }
 
@@ -478,7 +479,8 @@ class DetailsRepositoryImpl(
         }
         val path = dto.path?.takeIf { it.isNotBlank() } ?: "README.md"
         val baseUrl = "https://raw.githubusercontent.com/$owner/$repo/$defaultBranch/"
-        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl)
+        val linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/"
+        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
         val detectedLang = readmeHelper.detectReadmeLanguage(processed)
         logger.debug("Fetched README via backend (detected language: ${detectedLang ?: "unknown"})")
         return Triple(processed, detectedLang, path)
@@ -500,7 +502,8 @@ class DetailsRepositoryImpl(
                     }.getOrNull()
 
             if (rawMarkdown != null) {
-                val processed = preprocessMarkdown(markdown = rawMarkdown, baseUrl = baseUrl)
+                val linkBaseUrl = "https://github.com/$owner/$repo/blob/$defaultBranch/"
+                val processed = preprocessMarkdown(markdown = rawMarkdown, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
                 val detectedLang = readmeHelper.detectReadmeLanguage(processed)
                 logger.debug("Fetched README.md (detected language: ${detectedLang ?: "unknown"})")
                 Triple(processed, detectedLang, path)
@@ -715,7 +718,8 @@ class DetailsRepositoryImpl(
 
         val normalized = body.replace("\r\n", "\n")
         val baseUrl = "https://$sourceHost/$owner/$repo/raw/branch/HEAD/"
-        return preprocessMarkdown(markdown = normalized, baseUrl = baseUrl)
+        val linkBaseUrl = "https://$sourceHost/$owner/$repo/src/branch/HEAD/"
+        return preprocessMarkdown(markdown = normalized, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
     }
 
     @OptIn(ExperimentalEncodingApi::class)
@@ -757,7 +761,8 @@ class DetailsRepositoryImpl(
         val path = dto.path?.takeIf { it.isNotBlank() } ?: "README.md"
 
         val baseUrl = "https://$sourceHost/$owner/$repo/raw/branch/$defaultBranch/"
-        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl)
+        val linkBaseUrl = "https://$sourceHost/$owner/$repo/src/branch/$defaultBranch/"
+        val processed = preprocessMarkdown(markdown = decoded, baseUrl = baseUrl, linkBaseUrl = linkBaseUrl)
         val detected = readmeHelper.detectReadmeLanguage(processed)
         cacheManager.put(
             cacheKey,

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -3,8 +3,10 @@ package zed.rainxch.details.data.utils
 fun preprocessMarkdown(
     markdown: String,
     baseUrl: String,
+    linkBaseUrl: String = baseUrl,
 ): String {
     val normalizedBaseUrl = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+    val normalizedLinkBaseUrl = if (linkBaseUrl.endsWith("/")) linkBaseUrl else "$linkBaseUrl/"
 
     var processed = markdown
 
@@ -44,26 +46,31 @@ fun preprocessMarkdown(
 
     fun shouldSkipImage(url: String): Boolean = isBadgeUrl(url)
 
-    fun resolveUrl(path: String): String {
+    fun resolveUrl(path: String, asImage: Boolean): String {
         val trimmed = path.trim()
+        if (trimmed.startsWith("#") && !asImage) return trimmed
+
         val isAbsolute =
             trimmed.startsWith("http://") ||
                 trimmed.startsWith("https://") ||
                 trimmed.startsWith("data:")
+        
+        val baseForPath = if (asImage) normalizedBaseUrl else normalizedLinkBaseUrl
+
         return if (isAbsolute) {
-            normalizeGitHubUrl(trimmed)
+            if (asImage) normalizeGitHubUrl(trimmed) else trimmed
         } else {
             when {
                 trimmed.startsWith("./") -> {
-                    "$normalizedBaseUrl${trimmed.removePrefix("./")}"
+                    "$baseForPath${trimmed.removePrefix("./")}"
                 }
 
                 trimmed.startsWith("/") -> {
-                    "$normalizedBaseUrl${trimmed.removePrefix("/")}"
+                    "$baseForPath${trimmed.removePrefix("/")}"
                 }
 
                 trimmed.startsWith("../") -> {
-                    var base = normalizedBaseUrl.trimEnd('/')
+                    var base = baseForPath.trimEnd('/')
                     var rel = trimmed
                     while (rel.startsWith("../")) {
                         base = base.substringBeforeLast('/', base)
@@ -73,7 +80,7 @@ fun preprocessMarkdown(
                 }
 
                 else -> {
-                    "$normalizedBaseUrl$trimmed"
+                    "$baseForPath$trimmed"
                 }
             }
         }
@@ -94,7 +101,7 @@ fun preprocessMarkdown(
     val skipRefNames =
         referenceMap
             .filter { (_, url) ->
-                shouldSkipImage(resolveUrl(url))
+                shouldSkipImage(resolveUrl(url, asImage = true))
             }.keys
 
     if (skipRefNames.isNotEmpty()) {
@@ -120,7 +127,7 @@ fun preprocessMarkdown(
             val refName = match.groupValues[2].lowercase()
             val url = referenceMap[refName]
             if (url != null) {
-                val resolved = resolveUrl(url)
+                val resolved = resolveUrl(url, asImage = true)
                 "![$alt]($resolved)"
             } else {
                 match.value
@@ -135,7 +142,7 @@ fun preprocessMarkdown(
             val refName = match.groupValues[2].lowercase()
             val url = referenceMap[refName]
             if (url != null) {
-                "[$boldText](${resolveUrl(url)})"
+                "[$boldText](${resolveUrl(url, asImage = false)})"
             } else {
                 boldText
             }
@@ -156,7 +163,7 @@ fun preprocessMarkdown(
             val url = referenceMap[refName]
 
             if (url != null && !text.startsWith("!")) {
-                "[$text](${resolveUrl(url)})"
+                "[$text](${resolveUrl(url, asImage = false)})"
             } else {
                 match.value
             }
@@ -248,7 +255,7 @@ fun preprocessMarkdown(
             val alt = altMatch?.groupValues?.get(2) ?: ""
 
             if (src.isNotEmpty()) {
-                val normalizedSrc = resolveUrl(src)
+                val normalizedSrc = resolveUrl(src, asImage = true)
 
                 if (shouldSkipImage(normalizedSrc)) {
                     if (alt.isNotEmpty()) "**$alt**" else ""
@@ -266,7 +273,7 @@ fun preprocessMarkdown(
         ) { match ->
             val alt = match.groupValues[1]
             val originalPath = match.groupValues[2].trim()
-            val finalUrl = resolveUrl(originalPath)
+            val finalUrl = resolveUrl(originalPath, asImage = true)
 
             if (shouldSkipImage(finalUrl)) {
                 if (alt.isNotEmpty()) "**$alt**" else ""
@@ -277,13 +284,23 @@ fun preprocessMarkdown(
 
     processed =
         processed.replace(
+            Regex("""(?<!\!)\[([^\]]*)\]\(([^)]+)\)"""),
+        ) { match ->
+            val text = match.groupValues[1]
+            val originalPath = match.groupValues[2].trim()
+            val finalUrl = resolveUrl(originalPath, asImage = false)
+            "[$text]($finalUrl)"
+        }
+
+    processed =
+        processed.replace(
             Regex(
                 """<video[^>]*?\ssrc=(["'])([^"']+)\1[^>]*>.*?</video>""",
                 setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
             ),
         ) { match ->
             val src = match.groupValues[2]
-            "[Video](${resolveUrl(src)})"
+            "[Video](${resolveUrl(src, asImage = true)})"
         }
 
     processed =
@@ -294,7 +311,7 @@ fun preprocessMarkdown(
             ),
         ) { match ->
             val src = match.groupValues[2]
-            "[Video](${resolveUrl(src)})"
+            "[Video](${resolveUrl(src, asImage = true)})"
         }
 
     for (level in 1..6) {
@@ -394,7 +411,7 @@ fun preprocessMarkdown(
         ) { match ->
             val url = match.groupValues[2]
             val text = match.groupValues[3].trim()
-            val resolvedUrl = resolveUrl(url)
+            val resolvedUrl = resolveUrl(url, asImage = false)
             if (text.isEmpty()) {
                 "[$resolvedUrl]($resolvedUrl)"
             } else {

--- a/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
+++ b/feature/details/data/src/commonMain/kotlin/zed/rainxch/details/data/utils/preprocessMarkdown.kt
@@ -53,7 +53,11 @@ fun preprocessMarkdown(
         val isAbsolute =
             trimmed.startsWith("http://") ||
                 trimmed.startsWith("https://") ||
-                trimmed.startsWith("data:")
+                trimmed.startsWith("data:") ||
+                trimmed.startsWith("mailto:") ||
+                trimmed.startsWith("tel:") ||
+                trimmed.startsWith("sms:") ||
+                trimmed.startsWith("intent:")
         
         val baseForPath = if (asImage) normalizedBaseUrl else normalizedLinkBaseUrl
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -675,7 +675,7 @@ fun DetailsScreen(
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
                                 onTranslateLanguage = onTranslateLanguage,
-                                onReadMore = { onReadMoreAbout?.invoke() },
+                                onReadMore = onReadMoreAbout,
                             )
                         }
                     } else {

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/DetailsRoot.kt
@@ -158,7 +158,7 @@ fun DetailsRoot(
     onNavigateToDeveloperProfile: (username: String) -> Unit,
     onOpenRepositoryInApp: (repoId: Long) -> Unit,
     onNavigateToSearchByPlatform: (DiscoveryPlatform) -> Unit,
-    onNavigateToAbout: (repoId: Long, owner: String, repo: String, sourceHost: String?) -> Unit,
+    onNavigateToAbout: (repoId: Long, owner: String, repo: String, sourceHost: String?, translateTo: String?) -> Unit,
     onNavigateToWhatsNew: (repoId: Long, owner: String, repo: String, sourceHost: String?) -> Unit,
     onNavigateToIssues: (owner: String, repo: String) -> Unit,
     onNavigateToSecurity: (owner: String, repo: String) -> Unit,
@@ -251,6 +251,18 @@ fun DetailsRoot(
                     repo.owner.login,
                     repo.name,
                     repo.sourceHost,
+                    null,
+                )
+            }
+        },
+        onTranslateLanguage = state.repository?.let { repo ->
+            { code ->
+                onNavigateToAbout(
+                    repo.id,
+                    repo.owner.login,
+                    repo.name,
+                    repo.sourceHost,
+                    code,
                 )
             }
         },
@@ -512,6 +524,7 @@ fun DetailsScreen(
     onAction: (DetailsAction) -> Unit,
     snackbarHostState: SnackbarHostState,
     onReadMoreAbout: (() -> Unit)? = null,
+    onTranslateLanguage: ((String) -> Unit)? = null,
     onReadMoreWhatsNew: (() -> Unit)? = null,
     onOpenIssues: (() -> Unit)? = null,
     onOpenSecurity: (() -> Unit)? = null,
@@ -661,7 +674,8 @@ fun DetailsScreen(
                                 collapsedHeight = collapsedSectionHeight,
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
-                                onReadMore = onReadMoreAbout,
+                                onTranslateLanguage = onTranslateLanguage,
+                                onReadMore = { onReadMoreAbout?.invoke() },
                             )
                         }
                     } else {
@@ -674,6 +688,7 @@ fun DetailsScreen(
                                 collapsedHeight = collapsedSectionHeight,
                                 measuredHeightPx = state.aboutMeasuredHeightPx,
                                 onMeasured = { onAction(DetailsAction.OnAboutMeasured(it)) },
+                                onTranslateLanguage = onTranslateLanguage,
                                 onReadMore = onReadMoreAbout,
                             )
                         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -54,12 +54,20 @@ fun AboutRoot(
     owner: String,
     repo: String,
     sourceHost: String?,
+    translateTo: String? = null,
     onNavigateBack: () -> Unit,
     viewModel: DetailsAboutViewModel = koinViewModel {
         parametersOf(repositoryId, owner, repo, sourceHost)
     },
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    
+    androidx.compose.runtime.LaunchedEffect(translateTo) {
+        if (translateTo != null) {
+            viewModel.translate(translateTo)
+        }
+    }
+    
     AboutScreen(
         state = state,
         onBack = onNavigateBack,
@@ -175,37 +183,8 @@ private fun AboutScreen(
                 }
                 item(key = "markdown") {
                     Spacer(Modifier.height(4.dp))
-                    val defaultUriHandler = androidx.compose.ui.platform.LocalUriHandler.current
-                    val customUriHandler = remember(defaultUriHandler, onTranslate) {
-                        object : androidx.compose.ui.platform.UriHandler {
-                            override fun openUri(uri: String) {
-                                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
-                                if (match != null) {
-                                    val code = match.groupValues[1]
-                                    val normalizedCode = when (code.lowercase()) {
-                                        "cn" -> "zh-CN"
-                                        "tw" -> "zh-TW"
-                                        "jp" -> "ja"
-                                        "kr" -> "ko"
-                                        "br" -> "pt-BR"
-                                        else -> code
-                                    }
-                                    val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.equals(normalizedCode, ignoreCase = true) 
-                                    } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
-                                    }
-                                    if (matchedLanguage != null) {
-                                        onTranslate(matchedLanguage.code)
-                                        return
-                                    }
-                                }
-                                defaultUriHandler.openUri(uri)
-                            }
-                        }
-                    }
-                    androidx.compose.runtime.CompositionLocalProvider(
-                        androidx.compose.ui.platform.LocalUriHandler provides customUriHandler,
+                    zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
+                        onTranslate = onTranslate,
                     ) {
                         Markdown(
                             content = displayedMarkdown,

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -182,10 +182,18 @@ private fun AboutScreen(
                                 val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
                                 if (match != null) {
                                     val code = match.groupValues[1]
+                                    val normalizedCode = when (code.lowercase()) {
+                                        "cn" -> "zh-CN"
+                                        "tw" -> "zh-TW"
+                                        "jp" -> "ja"
+                                        "kr" -> "ko"
+                                        "br" -> "pt-BR"
+                                        else -> code
+                                    }
                                     val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.equals(code, ignoreCase = true) 
+                                        it.code.equals(normalizedCode, ignoreCase = true) 
                                     } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
-                                        it.code.startsWith(code, ignoreCase = true) || code.startsWith(it.code, ignoreCase = true)
+                                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
                                     }
                                     if (matchedLanguage != null) {
                                         onTranslate(matchedLanguage.code)

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -175,14 +175,39 @@ private fun AboutScreen(
                 }
                 item(key = "markdown") {
                     Spacer(Modifier.height(4.dp))
-                    Markdown(
-                        content = displayedMarkdown,
-                        colors = colors,
-                        typography = typography,
-                        imageTransformer = imageTransformer,
-                        components = components,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    val defaultUriHandler = androidx.compose.ui.platform.LocalUriHandler.current
+                    val customUriHandler = remember(defaultUriHandler, onTranslate) {
+                        object : androidx.compose.ui.platform.UriHandler {
+                            override fun openUri(uri: String) {
+                                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
+                                if (match != null) {
+                                    val code = match.groupValues[1]
+                                    val matchedLanguage = zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
+                                        it.code.equals(code, ignoreCase = true) 
+                                    } ?: zed.rainxch.details.presentation.model.SupportedLanguages.all.find { 
+                                        it.code.startsWith(code, ignoreCase = true) || code.startsWith(it.code, ignoreCase = true)
+                                    }
+                                    if (matchedLanguage != null) {
+                                        onTranslate(matchedLanguage.code)
+                                        return
+                                    }
+                                }
+                                defaultUriHandler.openUri(uri)
+                            }
+                        }
+                    }
+                    androidx.compose.runtime.CompositionLocalProvider(
+                        androidx.compose.ui.platform.LocalUriHandler provides customUriHandler,
+                    ) {
+                        Markdown(
+                            content = displayedMarkdown,
+                            colors = colors,
+                            typography = typography,
+                            imageTransformer = imageTransformer,
+                            components = components,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             }
         }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/about/AboutRoot.kt
@@ -62,8 +62,9 @@ fun AboutRoot(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     
-    androidx.compose.runtime.LaunchedEffect(translateTo) {
-        if (translateTo != null) {
+    val isReadmeLoaded = state.readmeMarkdown.isNotBlank()
+    androidx.compose.runtime.LaunchedEffect(translateTo, isReadmeLoaded) {
+        if (translateTo != null && isReadmeLoaded) {
             viewModel.translate(translateTo)
         }
     }

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/components/sections/About.kt
@@ -67,6 +67,7 @@ fun LazyListScope.about(
     collapsedHeight: Dp,
     measuredHeightPx: Float?,
     onMeasured: (Float) -> Unit,
+    onTranslateLanguage: ((String) -> Unit)? = null,
     onReadMore: (() -> Unit)? = null,
 ) {
     item {
@@ -113,18 +114,37 @@ fun LazyListScope.about(
             MarkdownImageTransformer(probeClient)
         }
 
-        ExpandableMarkdownContent(
-            rawMarkdown = raw,
-            isDark = isDark,
-            isExpanded = isExpanded,
-            onToggleExpanded = onReadMore ?: onToggleExpanded,
-            imageTransformer = imageTransformer,
-            collapsedHeight = collapsedHeight,
-            measuredHeightPx = measuredHeightPx,
-            onMeasured = onMeasured,
-            fadeColor = MaterialTheme.colorScheme.background,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (onTranslateLanguage != null) {
+            zed.rainxch.details.presentation.utils.ProvideLanguageLinkInterceptor(
+                onTranslate = onTranslateLanguage,
+            ) {
+                ExpandableMarkdownContent(
+                    rawMarkdown = raw,
+                    isDark = isDark,
+                    isExpanded = isExpanded,
+                    onToggleExpanded = onReadMore ?: onToggleExpanded,
+                    imageTransformer = imageTransformer,
+                    collapsedHeight = collapsedHeight,
+                    measuredHeightPx = measuredHeightPx,
+                    onMeasured = onMeasured,
+                    fadeColor = MaterialTheme.colorScheme.background,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        } else {
+            ExpandableMarkdownContent(
+                rawMarkdown = raw,
+                isDark = isDark,
+                isExpanded = isExpanded,
+                onToggleExpanded = onReadMore ?: onToggleExpanded,
+                imageTransformer = imageTransformer,
+                collapsedHeight = collapsedHeight,
+                measuredHeightPx = measuredHeightPx,
+                onMeasured = onMeasured,
+                fadeColor = MaterialTheme.colorScheme.background,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 

--- a/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
+++ b/feature/details/presentation/src/commonMain/kotlin/zed/rainxch/details/presentation/utils/LanguageLinkInterceptor.kt
@@ -1,0 +1,48 @@
+package zed.rainxch.details.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import zed.rainxch.details.presentation.model.SupportedLanguages
+
+@Composable
+fun ProvideLanguageLinkInterceptor(
+    onTranslate: (String) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val defaultUriHandler = LocalUriHandler.current
+    val customUriHandler = remember(defaultUriHandler, onTranslate) {
+        object : UriHandler {
+            override fun openUri(uri: String) {
+                val match = Regex("""(?i)README[-._]([a-z]{2}(?:-[a-z]{2})?)\.md$""").find(uri)
+                if (match != null) {
+                    val code = match.groupValues[1]
+                    val normalizedCode = when (code.lowercase()) {
+                        "cn" -> "zh-CN"
+                        "tw" -> "zh-TW"
+                        "jp" -> "ja"
+                        "kr" -> "ko"
+                        "br" -> "pt-BR"
+                        else -> code
+                    }
+                    val matchedLanguage = SupportedLanguages.all.find { 
+                        it.code.equals(normalizedCode, ignoreCase = true) 
+                    } ?: SupportedLanguages.all.find { 
+                        it.code.startsWith(normalizedCode, ignoreCase = true) || normalizedCode.startsWith(it.code, ignoreCase = true)
+                    }
+                    if (matchedLanguage != null) {
+                        onTranslate(matchedLanguage.code)
+                        return
+                    }
+                }
+                defaultUriHandler.openUri(uri)
+            }
+        }
+    }
+    CompositionLocalProvider(
+        LocalUriHandler provides customUriHandler,
+        content = content,
+    )
+}

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/data_source/impl/CachedRepositoriesDataSourceImpl.kt
@@ -463,6 +463,7 @@ class CachedRepositoriesDataSourceImpl(
         DiscoveryPlatform.Windows -> "windows"
         DiscoveryPlatform.Macos -> "macos"
         DiscoveryPlatform.Linux -> "linux"
+        DiscoveryPlatform.Ios -> null 
         DiscoveryPlatform.All -> null
     }
 

--- a/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/repository/HomeRepositoryImpl.kt
+++ b/feature/home/data/src/commonMain/kotlin/zed/rainxch/home/data/repository/HomeRepositoryImpl.kt
@@ -556,6 +556,7 @@ class HomeRepositoryImpl(
             DiscoveryPlatform.Windows -> "desktop"
             DiscoveryPlatform.Macos -> "macos"
             DiscoveryPlatform.Linux -> "linux"
+            DiscoveryPlatform.Ios -> "ios"
         }
 
     private fun Set<DiscoveryPlatform>.normalize(): Set<DiscoveryPlatform> {

--- a/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
+++ b/feature/search/data/src/commonMain/kotlin/zed/rainxch/search/data/repository/SearchRepositoryImpl.kt
@@ -167,6 +167,7 @@ class SearchRepositoryImpl(
             DiscoveryPlatform.Windows -> "windows"
             DiscoveryPlatform.Macos -> "macos"
             DiscoveryPlatform.Linux -> "linux"
+            DiscoveryPlatform.Ios -> return null 
             DiscoveryPlatform.All -> null
         }
 
@@ -387,7 +388,8 @@ class SearchRepositoryImpl(
                     name.endsWith(".msi") || name.endsWith(".exe") ||
                     name.endsWith(".dmg") || name.endsWith(".pkg") ||
                     name.endsWith(".appimage") || name.endsWith(".deb") ||
-                    name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
+                    name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst") ||
+                    name.endsWith(".ipa")
             }
 
             DiscoveryPlatform.Android -> {
@@ -405,6 +407,10 @@ class SearchRepositoryImpl(
             DiscoveryPlatform.Linux -> {
                 name.endsWith(".appimage") || name.endsWith(".deb") ||
                     name.endsWith(".rpm") || name.endsWith(".pkg.tar.zst")
+            }
+
+            DiscoveryPlatform.Ios -> {
+                name.endsWith(".ipa")
             }
         }
     }
@@ -500,6 +506,7 @@ class SearchRepositoryImpl(
             DiscoveryPlatform.Windows -> "windows"
             DiscoveryPlatform.Macos -> "macos"
             DiscoveryPlatform.Linux -> "linux"
+            DiscoveryPlatform.Ios -> "ios"
             DiscoveryPlatform.All -> null
         }
 

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/components/SearchFiltersSheet.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/components/SearchFiltersSheet.kt
@@ -124,7 +124,7 @@ fun SearchFiltersSheet(
                 ) {
                     SearchPlatformUi.entries.forEach { platform ->
                         SelectableChip(
-                            text = platform.name
+                            text = if (platform == SearchPlatformUi.Ios) "iOS" else platform.name
                                 .lowercase()
                                 .replaceFirstChar { it.uppercase() },
                             selected = selectedPlatform == platform,

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/components/SearchFiltersSheet.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/components/SearchFiltersSheet.kt
@@ -54,6 +54,8 @@ import zed.rainxch.search.presentation.model.SearchPlatformUi
 import zed.rainxch.search.presentation.model.SearchSourceUi
 import zed.rainxch.search.presentation.model.SortByUi
 import zed.rainxch.search.presentation.utils.label
+import zed.rainxch.core.presentation.utils.toLabel
+import zed.rainxch.search.presentation.mappers.toDomain
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -124,9 +126,7 @@ fun SearchFiltersSheet(
                 ) {
                     SearchPlatformUi.entries.forEach { platform ->
                         SelectableChip(
-                            text = if (platform == SearchPlatformUi.Ios) "iOS" else platform.name
-                                .lowercase()
-                                .replaceFirstChar { it.uppercase() },
+                            text = platform.toDomain().toLabel(),
                             selected = selectedPlatform == platform,
                             onClick = { onPlatformSelected(platform) },
                         )

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/mappers/SearchPlatformMappers.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/mappers/SearchPlatformMappers.kt
@@ -11,6 +11,7 @@ fun SearchPlatformUi.toDomain(): DiscoveryPlatform =
         SearchPlatformUi.Windows -> Windows
         SearchPlatformUi.Macos -> Macos
         SearchPlatformUi.Linux -> Linux
+        SearchPlatformUi.Ios -> Ios
     }
 
 fun DiscoveryPlatform.toSearchPlatformUi(): SearchPlatformUi =
@@ -20,4 +21,5 @@ fun DiscoveryPlatform.toSearchPlatformUi(): SearchPlatformUi =
         Windows -> SearchPlatformUi.Windows
         Macos -> SearchPlatformUi.Macos
         Linux -> SearchPlatformUi.Linux
+        Ios -> SearchPlatformUi.Ios
     }

--- a/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/model/SearchPlatformUi.kt
+++ b/feature/search/presentation/src/commonMain/kotlin/zed/rainxch/search/presentation/model/SearchPlatformUi.kt
@@ -6,4 +6,5 @@ enum class SearchPlatformUi {
     Windows,
     Macos,
     Linux,
+    Ios,
 }

--- a/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/sources/TweaksSourcesRoot.kt
+++ b/feature/tweaks/presentation/src/commonMain/kotlin/zed/rainxch/tweaks/presentation/sources/TweaksSourcesRoot.kt
@@ -49,6 +49,7 @@ import zed.rainxch.githubstore.core.presentation.res.platform_section_android
 import zed.rainxch.githubstore.core.presentation.res.platform_section_linux
 import zed.rainxch.githubstore.core.presentation.res.platform_section_macos
 import zed.rainxch.githubstore.core.presentation.res.platform_section_windows
+import zed.rainxch.githubstore.core.presentation.res.platform_section_ios
 import zed.rainxch.githubstore.core.presentation.res.tweaks_sources_platforms_body
 import zed.rainxch.githubstore.core.presentation.res.tweaks_sources_platforms_title
 import zed.rainxch.githubstore.core.presentation.res.custom_forges_count
@@ -260,6 +261,7 @@ private fun DiscoveryPlatform.labelRes() = when (this) {
     DiscoveryPlatform.Macos -> Res.string.platform_section_macos
     DiscoveryPlatform.Windows -> Res.string.platform_section_windows
     DiscoveryPlatform.Linux -> Res.string.platform_section_linux
+    DiscoveryPlatform.Ios -> Res.string.platform_section_ios
     DiscoveryPlatform.All -> Res.string.platform_section_android
 }
 


### PR DESCRIPTION
This PR adds full support for finding iOS apps and tweaks directly within the store.

What's included:
Added "iOS" as a selectable platform filter across the Search and Tweaks screens.
The app now recognizes .ipa files as iOS assets.
Wired up the new iOS option through the UI models, repo cards, and string resources (temporarily reusing the macOS icon for the platform badge until we have a dedicated iOS one).
Fix for HTTP 400s: Since our backend proxy doesn't support the "ios" slug on the search/category endpoints just yet, I've set it to bypass the backend and fall back directly to the native GitHub API for iOS queries. This prevents the search screen from crashing and still surfaces great iOS results.

check this video:

https://github.com/user-attachments/assets/60207d3b-8b7e-4b86-9519-189187c62ab8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS as a selectable platform filter for discovering and searching repositories, with improved recognition of iOS release assets.
  * Enabled language translations in repository About screens—click language-specific README links to open the translated view.

* **Improvements**
  * Enhanced markdown rendering so links, images, and embedded media resolve to the correct web destinations (including better URL handling and platform label/icon support).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->