### PR TITLE
fix: lowercase linux desktop launcher exec (#804)

### DIFF
--- a/.github/workflows/build-desktop-platforms.yml
+++ b/.github/workflows/build-desktop-platforms.yml
@@ -379,7 +379,7 @@ jobs:
           [Desktop Entry]
           Type=Application
           Name=Komi Store
-          Exec=Komi-Store
+          Exec=komi-store
           Icon=github-store
           Categories=Development;
           Comment=Cross-platform app store for GitHub releases
@@ -539,7 +539,7 @@ jobs:
           set -euo pipefail
 
           VERSION=$(grep 'projectVersionName' gradle/libs.versions.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-          PKG_NAME="github-store"
+          PKG_NAME="komi-store"
           PKG_DIR="pkg-root"
 
           # Find the app directory produced by packageAppImage
@@ -564,37 +564,37 @@ jobs:
           fi
 
           # Build the package tree
-          mkdir -p "$PKG_DIR/opt/github-store"
-          cp -a "$APP_ROOT"/. "$PKG_DIR/opt/github-store/"
+          mkdir -p "$PKG_DIR/opt/komi-store"
+          cp -a "$APP_ROOT"/. "$PKG_DIR/opt/komi-store/"
 
           # Install the JVM-direct launcher that bypasses the jpackage native
           # launcher (crashes in glibc setenv() on glibc >= 2.42, see GH#563).
-          cp packaging/linux/github-store-launcher.sh "$PKG_DIR/opt/github-store/bin/github-store-launcher.sh"
-          chmod +x "$PKG_DIR/opt/github-store/bin/github-store-launcher.sh"
+          cp packaging/linux/github-store-launcher.sh "$PKG_DIR/opt/komi-store/bin/github-store-launcher.sh"
+          chmod +x "$PKG_DIR/opt/komi-store/bin/github-store-launcher.sh"
 
           # Launcher symlink
           mkdir -p "$PKG_DIR/usr/bin"
-          ln -s "/opt/github-store/bin/github-store-launcher.sh" "$PKG_DIR/usr/bin/github-store"
+          ln -s "/opt/komi-store/bin/github-store-launcher.sh" "$PKG_DIR/usr/bin/komi-store"
 
           # Desktop entry
           mkdir -p "$PKG_DIR/usr/share/applications"
-          cat > "$PKG_DIR/usr/share/applications/github-store.desktop" << 'EOF'
+          cat > "$PKG_DIR/usr/share/applications/komi-store.desktop" << 'EOF'
           [Desktop Entry]
           Type=Application
           Name=Komi Store
-          Exec=/opt/github-store/bin/github-store-launcher.sh
-          Icon=github-store
+          Exec=komi-store
+          Icon=komi-store
           Categories=Development;
           Comment=Cross-platform app store for GitHub releases
-          StartupWMClass=github-store
+          StartupWMClass=komi-store
           EOF
-          sed -i 's/^          //' "$PKG_DIR/usr/share/applications/github-store.desktop"
+          sed -i 's/^          //' "$PKG_DIR/usr/share/applications/komi-store.desktop"
 
           # Icon
-          if [ -f "$PKG_DIR/opt/github-store/lib/Komi-Store.png" ]; then
+          if [ -f "$PKG_DIR/opt/komi-store/lib/Komi-Store.png" ]; then
             mkdir -p "$PKG_DIR/usr/share/icons/hicolor/256x256/apps"
-            cp "$PKG_DIR/opt/github-store/lib/Komi-Store.png" \
-               "$PKG_DIR/usr/share/icons/hicolor/256x256/apps/github-store.png"
+            cp "$PKG_DIR/opt/komi-store/lib/Komi-Store.png" \
+               "$PKG_DIR/usr/share/icons/hicolor/256x256/apps/komi-store.png"
           fi
 
           # .PKGINFO (pacman metadata — must be a flat file at archive root)
@@ -609,6 +609,8 @@ jobs:
           arch = x86_64
           license = GPL-3.0
           size = ${INSTALLED_SIZE}
+          replaces = github-store
+          conflicts = github-store
           depend = java-runtime>=21
           depend = hicolor-icon-theme
           EOF

--- a/core/presentation/src/commonMain/composeResources/files/whatsnew/21.json
+++ b/core/presentation/src/commonMain/composeResources/files/whatsnew/21.json
@@ -15,7 +15,8 @@
       "type": "FIXED",
       "bullets": [
         "App downloads now auto-pick the build that matches your device's CPU (like aarch64) instead of defaulting to a larger universal APK.",
-        "Fixed GitHub sign-in on Windows — the desktop app now reliably opens and finishes login after you authorize in your browser."
+        "Fixed GitHub sign-in on Windows — the desktop app now reliably opens and finishes login after you authorize in your browser.",
+        "Fixed the app not launching from the menu on some Linux setups (like Arch/KDE) caused by a mismatched desktop-shortcut name."
       ]
     }
   ]


### PR DESCRIPTION
Closes #804.

Linux `.desktop` entries shipped a capitalized `Exec=Komi-Store`, but the lowercase `komi-store` binary is the standard convention. On case-sensitive filesystems the menu launcher fails ("Cannot find program 'Komi-Store'").

- AppImage desktop: `Exec=komi-store`
- Official Arch pkg renamed `github-store` -> `komi-store` (lowercase `/usr/bin/komi-store`, matching `Exec`, `replaces`/`conflicts`), aligned with deb/rpm
- whatsnew 21.json bullet

Note: `komi-store-bin` (AUR) is community-maintained; this fixes our official artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Linux app-launch issue where the menu shortcut could fail to open the app due to a mismatched desktop entry name.
  * Improved Linux AppImage launch behavior so the desktop shortcut now uses the correct app launcher name.
  * Updated Arch Linux packaging details to align with the current app name and avoid install/upgrade conflicts with the older package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->