### PR TITLE
Fix Homebrew tap workflow for komi-store rename

### DIFF
--- a/.github/workflows/homebrew-tap-publish.yml
+++ b/.github/workflows/homebrew-tap-publish.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           set -euo pipefail
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
-          curl -fSL -o arm64.dmg "${BASE}/GitHub-Store-${VERSION}-arm64.dmg"
-          curl -fSL -o x64.dmg   "${BASE}/GitHub-Store-${VERSION}-x64.dmg"
+          curl -fSL -o arm64.dmg "${BASE}/Komi-Store-${VERSION}-arm64.dmg"
+          curl -fSL -o x64.dmg   "${BASE}/Komi-Store-${VERSION}-x64.dmg"
           ls -la *.dmg
 
       - name: Compute SHA256
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout tap repo
         uses: actions/checkout@v4
         with:
-          repository: OpenHub-Store/homebrew-tap
+          repository: kurikomi-labs/homebrew-komi-store
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
@@ -74,7 +74,7 @@ jobs:
         run: |
           python3 - <<'EOF'
           import os, re, sys
-          path = "Casks/github-store.rb"
+          path = "Casks/komi-store.rb"
           version = os.environ["NEW_VERSION"]
           sha_arm = os.environ["NEW_SHA_ARM"]
           sha_intel = os.environ["NEW_SHA_INTEL"]
@@ -110,10 +110,10 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Casks/github-store.rb
+          git add Casks/komi-store.rb
           if git diff --cached --quiet; then
             echo "Cask already up to date"
             exit 0
           fi
-          git commit -m "Bump github-store to ${VERSION}"
+          git commit -m "Bump komi-store to ${VERSION}"
           git push

--- a/dist/homebrew/Casks/komi-store.rb
+++ b/dist/homebrew/Casks/komi-store.rb
@@ -1,12 +1,12 @@
-cask "github-store" do
+cask "komi-store" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.8.2"
-  sha256 arm:   "ad0c532873c0400736b7ea706a33604f7ef93b2479a4a6f32673a789b18ccd8e",
-         intel: "faf002283c301db2a97f7a32193778f678d42ed71551a623711cd170d6fde16a"
+  version "1.9.2"
+  sha256 arm:   "df371a7c4c821125810dacaab04a7fb0bcd40162bc996b798caf21c586fd0f0f",
+         intel: "2d95aa11a273528978cb2dad427e592d0705bb8e67c099a91a3216677abc4315"
 
-  url "https://github.com/kurikomi-labs/komi-store/releases/download/v#{version}/GitHub-Store-#{version}-#{arch}.dmg"
-  name "GitHub Store"
+  url "https://github.com/kurikomi-labs/komi-store/releases/download/v#{version}/Komi-Store-#{version}-#{arch}.dmg"
+  name "Komi Store"
   desc "Cross-platform app store for GitHub releases"
   homepage "https://github.com/kurikomi-labs/komi-store"
 
@@ -18,26 +18,26 @@ cask "github-store" do
   auto_updates false
   depends_on macos: :big_sur
 
-  app "GitHub-Store.app"
+  app "Komi-Store.app"
 
   uninstall quit: "zed.rainxch.githubstore"
 
   zap trash: [
-    "~/Library/Application Support/GitHub-Store",
-    "~/Library/Caches/GitHub-Store",
-    "~/Library/Logs/GitHub-Store",
+    "~/Library/Application Support/Komi-Store",
+    "~/Library/Caches/Komi-Store",
+    "~/Library/Logs/Komi-Store",
     "~/Library/Preferences/zed.rainxch.githubstore.plist",
     "~/Library/Saved Application State/zed.rainxch.githubstore.savedState",
   ]
 
   caveats <<~EOS
-    GitHub Store is not yet signed with an Apple Developer ID.
+    Komi Store is not yet signed with an Apple Developer ID.
     macOS Gatekeeper will block it from launching with a "damaged" or
     "cannot be opened" error.
 
     To allow the app to launch, run:
 
-      xattr -dr com.apple.quarantine "#{appdir}/GitHub-Store.app"
+      xattr -dr com.apple.quarantine "#{appdir}/Komi-Store.app"
 
     This step is required after each install or upgrade until the app is
     signed and notarized.

--- a/dist/homebrew/README.md
+++ b/dist/homebrew/README.md
@@ -1,16 +1,16 @@
 # Homebrew Cask (reference copy)
 
 The Cask in this directory is a **reference/seed copy**. The live, user-facing
-Cask lives in [`OpenHub-Store/homebrew-tap`](https://github.com/OpenHub-Store/homebrew-tap)
+Cask lives in [`kurikomi-labs/homebrew-komi-store`](https://github.com/kurikomi-labs/homebrew-komi-store)
 and is auto-updated on each release by
 [`.github/workflows/homebrew-tap-publish.yml`](../../.github/workflows/homebrew-tap-publish.yml).
 
 Users install with:
 
 ```bash
-brew tap OpenHub-Store/tap
-brew install --cask github-store
-xattr -dr com.apple.quarantine /Applications/GitHub-Store.app
+brew tap kurikomi-labs/komi-store
+brew install --cask komi-store
+xattr -dr com.apple.quarantine /Applications/Komi-Store.app
 ```
 
 The final `xattr` is required until the app is signed and notarized.
@@ -19,9 +19,9 @@ The final `xattr` is required until the app is signed and notarized.
 
 No manual step needed. On each `release: types: [released]` event, the workflow:
 
-1. Downloads `GitHub-Store-<version>-arm64.dmg` + `GitHub-Store-<version>-x64.dmg`.
+1. Downloads `Komi-Store-<version>-arm64.dmg` + `Komi-Store-<version>-x64.dmg`.
 2. Computes SHA256 of both.
-3. Patches `version` + `sha256` in the tap repo's `Casks/github-store.rb`.
+3. Patches `version` + `sha256` in the tap repo's `Casks/komi-store.rb`.
 4. Commits + pushes to the tap repo.
 
 Requires the `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with


### PR DESCRIPTION
Homebrew publish workflow still referenced the pre-rename identity, so the `released` job for v1.9.2 failed at the DMG download step (404).

Fixes:
- Download `Komi-Store-${VERSION}-{arm64,x64}.dmg` (was `GitHub-Store-*`, the actual 404)
- Checkout tap `kurikomi-labs/homebrew-komi-store` (was `OpenHub-Store/homebrew-tap`)
- Patch/add/commit `Casks/komi-store.rb` (was `github-store.rb`)

Tap repo updated separately: cask renamed to `komi-store`, retargeted to `kurikomi-labs/komi-store`, bumped to 1.9.2 with real SHAs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew release process to publish the app under the new Komi-Store packaging and tap.
  * Release downloads now use the Komi-Store DMG naming and installer artifacts.
  * Homebrew tap updates now target the renamed cask and repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->