### PR TITLE
Publish only the MSI to WinGet

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -14,13 +14,3 @@ jobs:
           identifier: zed.rainxch.githubstore
           installers-regex: '\.msi$'
           token: ${{ secrets.WINGET_TOKEN }}
-
-  publish-exe:
-    name: Publish EXE to WinGet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: vedantmgoyal9/winget-releaser@main
-        with:
-          identifier: zed.rainxch.githubstore
-          installers-regex: '\.exe$'
-          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
The WinGet workflow ran two `winget-releaser` jobs (MSI + EXE) against the same identifier `zed.rainxch.githubstore`. They collide into one manifest, producing duplicate installer entries that fail winget validation (see [microsoft/winget-pkgs#393498](https://github.com/microsoft/winget-pkgs/pull/393498)).

MSI is the correct winget installer (ProductCode/UpgradeCode → clean upgrades, native silent install), so drop the `publish-exe` job and ship the MSI only. The `.exe` remains available as a direct download for non-winget users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * WinGet publishing now targets MSI installers only.
  * EXE installer publishing was removed from the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->