### PR TITLE
Instant Scoop updates on release

### DIFF
--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -1,0 +1,19 @@
+name: Publish to Scoop
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+jobs:
+  trigger-bucket:
+    name: Trigger Scoop bucket update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Excavator
+        env:
+          GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+        run: |
+          gh api --method POST \
+            repos/kurikomi-labs/komi-store-scoop-bucket/dispatches \
+            -f event_type=komi-store-release


### PR DESCRIPTION
Scoop's bucket auto-updates via Excavator, but only on a 4h cron poll. This fires a `repository_dispatch` (`komi-store-release`) to [komi-store-scoop-bucket](https://github.com/kurikomi-labs/komi-store-scoop-bucket) on each release so Excavator runs immediately — matching the instant behavior of the Homebrew and WinGet publishers.

Bucket side already updated to listen for the dispatch (keeps the 4h cron as fallback).

**Requires** a new repo secret `SCOOP_BUCKET_TOKEN`: a fine-grained PAT with **Contents: read & write** on `kurikomi-labs/komi-store-scoop-bucket` (same pattern as `HOMEBREW_TAP_TOKEN`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing support for Scoop when a release is published, with an option to trigger it manually as well.
  * Release updates can now be forwarded to the Scoop bucket repository automatically, helping Scoop users get the latest version faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->