### PR TITLE
Persist desktop settings under the application data directory

### DIFF
--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/di/PlatformModule.jvm.kt
@@ -96,15 +96,24 @@ actual val corePlatformModule = module {
     }
 
     single<eu.anifantakis.lib.ksafe.KSafe>(qualifier = org.koin.core.qualifier.named("tokens")) {
-        eu.anifantakis.lib.ksafe.KSafe(fileName = "ghs_tokens")
+        eu.anifantakis.lib.ksafe.KSafe(
+            fileName = "ghs_tokens",
+            baseDir = zed.rainxch.core.data.local.DesktopAppDataPaths.ksafeBaseDir(),
+        )
     }
 
     single<eu.anifantakis.lib.ksafe.KSafe>(qualifier = org.koin.core.qualifier.named("prefs")) {
-        eu.anifantakis.lib.ksafe.KSafe(fileName = "ghs_prefs")
+        eu.anifantakis.lib.ksafe.KSafe(
+            fileName = "ghs_prefs",
+            baseDir = zed.rainxch.core.data.local.DesktopAppDataPaths.ksafeBaseDir(),
+        )
     }
 
     single<eu.anifantakis.lib.ksafe.KSafe>(qualifier = org.koin.core.qualifier.named("announcements_cache")) {
-        eu.anifantakis.lib.ksafe.KSafe(fileName = "ghs_announcements")
+        eu.anifantakis.lib.ksafe.KSafe(
+            fileName = "ghs_announcements",
+            baseDir = zed.rainxch.core.data.local.DesktopAppDataPaths.ksafeBaseDir(),
+        )
     }
 
     single<BrowserHelper> {

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
@@ -46,10 +46,6 @@ object DesktopAppDataPaths {
                 marker.createNewFile()
             }
         }
-        println(
-            "[KSAFE-DIAG] baseDir=${target.absolutePath} exists=${target.exists()} " +
-                "writable=${target.canWrite()} contents=${target.list()?.sorted()}",
-        )
         return target
     }
 

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
@@ -46,6 +46,10 @@ object DesktopAppDataPaths {
                 marker.createNewFile()
             }
         }
+        println(
+            "[KSAFE-DIAG] baseDir=${target.absolutePath} exists=${target.exists()} " +
+                "writable=${target.canWrite()} contents=${target.list()?.sorted()}",
+        )
         return target
     }
 

--- a/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
+++ b/core/data/src/jvmMain/kotlin/zed/rainxch/core/data/local/DesktopAppDataPaths.kt
@@ -29,6 +29,26 @@ object DesktopAppDataPaths {
         return dir
     }
 
+    // KSafe's JVM default baseDir is ~/.eu_anifantakis_ksafe, which is not reliably
+    // persistent inside the Flatpak sandbox (writes land off the per-app tree and are
+    // silently swallowed). Pin it to the same persistent dir Room uses. One-time,
+    // best-effort copy of any legacy store so existing desktop users keep their settings.
+    @Synchronized
+    fun ksafeBaseDir(): File {
+        val target = appDataDir()
+        runCatching {
+            val marker = File(target, ".ksafe_migrated")
+            if (!marker.exists()) {
+                val legacy = File(System.getProperty("user.home"), ".eu_anifantakis_ksafe")
+                if (legacy.isDirectory) {
+                    legacy.copyRecursively(target, overwrite = false)
+                }
+                marker.createNewFile()
+            }
+        }
+        return target
+    }
+
     fun migrateFromTmpIfNeeded(filename: String): Boolean {
         val newFile = File(appDataDir(), filename)
         if (newFile.exists()) return false


### PR DESCRIPTION
Desktop settings, the what's-new flag, and onboarding state reset on every launch because the JVM KSafe stores fell back to the library's default base directory (`~/.eu_anifantakis_ksafe`), which is not persisted inside the Flatpak sandbox. Writes appeared to succeed but never landed on durable storage, so each session started from defaults while the Room database (which uses an absolute path) survived.

This pins all three KSafe instances to the same application data directory Room already uses, and performs a one-time best-effort copy of any existing store so current desktop users keep their settings after updating.

Verified on a Flatpak build: the encrypted preference files now persist across runs and survive a full restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local data storage handling so saved app data stays in the app’s persistent directory on desktop.
  * Added a one-time migration for existing saved data, helping preserve previously stored items after updates.
  * Reduced the chance of missing or reset local settings, tokens, and cached announcements by keeping storage paths consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->